### PR TITLE
Use the virtual environment's flake8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,7 @@ eslint: ui/node_modules
 .PHONY: flake8
 flake8: env
 	@ printf "\nRunning Flake8 Tests\n\n"
-	@ flake8 --tee --output-file=build/flake8.txt
+	@ env/bin/flake8 --tee --output-file=build/flake8.txt
 
 .PHONY: jest
 jest: ui/node_modules


### PR DESCRIPTION
`make python-tests` will fail if flake8 is not installed outside of the virtual environment

```
$ make python-tests

Running Bandit

[main]  INFO    profile include tests: None
[main]  INFO    profile exclude tests: None
[main]  INFO    cli include tests: None
[main]  INFO    cli exclude tests: None
[main]  INFO    running on Python 3.9.2
Run started:2021-03-24 18:35:03.329265

Test results:
        No issues identified.

Code scanned:
        Total lines of code: 2720
        Total lines skipped (#nosec): 0

Run metrics:
        Total issues (by severity):
                Undefined: 0.0
                Low: 0.0
                Medium: 0.0
                High: 0.0
        Total issues (by confidence):
                Undefined: 0.0
                Low: 0.0
                Medium: 0.0
                High: 0.0
Files skipped (0):

Running Flake8 Tests

make: flake8: No such file or directory
make: *** [flake8] Error 1
```