### PR TITLE
Use ipv4 in Docker environment

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -9,7 +9,7 @@ set -e
 # Common constants
 COLOR_RESET='\033[0m'
 COLOR_GREEN='\033[0;32m'
-TEST_HOST="${TEST_HOST:-localhost}"
+TEST_HOST="${TEST_HOST:-127.0.0.1}"
 
 echo "Integration test host: ${TEST_HOST}"
 


### PR DESCRIPTION
Fixes the development environment where localhost resolves to an ipv6 address.

Relevant https://docs.docker.com/config/daemon/ipv6/

Resolves https://github.com/aweber/imbi/issues/35