### PR TITLE
Handle API keys with an invalid format

### DIFF
--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -179,6 +179,11 @@ class InternalTestCase(base.TestCase):
         self.assertFalse(await obj.authenticate())
 
     @testing.gen_test
+    async def test_garbage_token_fails(self):
+        obj = user.User(self._app, 'foo', None, 'ohno')
+        self.assertFalse(await obj.authenticate())
+
+    @testing.gen_test
     async def test_should_refresh_false(self):
         user_value = await self.setup_user()
         obj = user.User(


### PR DESCRIPTION
Handle the psycopg2 `InvalidTextRepresentation` exception when a non-UUID API key is given by denying authentication.