### PR TITLE
Add project name filter

### DIFF
--- a/imbi/endpoints/projects.py
+++ b/imbi/endpoints/projects.py
@@ -97,7 +97,7 @@ class CollectionRequestHandler(_RequestHandlerMixin,
 
     async def get(self, *args, **kwargs):
         kwargs['limit'] = int(self.get_query_argument('limit', '10'))
-        kwargs['offset'] = int(self.get_query_argument('offset', '20'))
+        kwargs['offset'] = int(self.get_query_argument('offset', '0'))
         where_chunks = []
         if self.get_query_argument('include_archived', 'false') == 'false':
             where_chunks.append('a.archived IS FALSE')
@@ -106,8 +106,6 @@ class CollectionRequestHandler(_RequestHandlerMixin,
             if value is not None:
                 kwargs[kwarg] = value
                 where_chunks.append(self.FILTER_CHUNKS[kwarg])
-        if 'name' in kwargs:
-            kwargs['name'] = f'{kwargs["name"]}%'
         where_sql = ''
         if where_chunks:
             where_sql = ' WHERE {}'.format(' AND '.join(where_chunks))

--- a/ui/.eslintrc
+++ b/ui/.eslintrc
@@ -22,5 +22,13 @@
             "pragma": "React",
             "version": "16.6"
         }
-    }
+    },
+    "overrides": [
+        {
+            "files": "tailwind.config.js",
+            "env": {
+                "node": true
+            }
+        }
+    ]
 }

--- a/ui/public/locales/en.js
+++ b/ui/public/locales/en.js
@@ -73,7 +73,7 @@ export default {
         administration: 'Administration',
         dashboard: 'Dashboard',
         newOperationsLogEntry: 'Add Ops Log Entry',
-        newProject: 'Create a New Project',
+        newProject: 'New Project',
         openNewMenu: 'Open New Menu',
         openUserMenu: 'Open User Menu',
         profile: 'Profile',
@@ -246,7 +246,7 @@ export default {
       },
       projects: {
         newProject: 'New Project',
-        includeArchived: 'Include archived projects',
+        includeArchived: 'Include archived',
         project: 'project',
         projects: 'projects',
         paginationState:

--- a/ui/src/js/views/Projects/Filter.jsx
+++ b/ui/src/js/views/Projects/Filter.jsx
@@ -69,10 +69,10 @@ function Filter({
     }
   }
 
-  function onChange(key, option) {
+  function onChange(key, value) {
     const newValues = {
       ...values,
-      [key]: option === null ? null : option.value.toString()
+      [key]: value
     }
     if (values !== newValues) setFilterValues(newValues)
   }
@@ -90,26 +90,42 @@ function Filter({
         isSearchable={false}
         name="namespace_id"
         options={namespaces}
-        onChange={(values) => {
-          onChange('namespace_id', values)
+        onChange={(option) => {
+          onChange('namespace_id', option && option.value.toString())
         }}
         placeholder={t('terms.namespace')}
         styles={styles}
         value={namespace}
       />
       <Select
-        className="border-gray-200 flex-auto shadow text-gray-600"
+        className="border-gray-200 flex-auto sm:mr-2 shadow text-gray-600"
         isClearable
         isDisabled={disabled}
         isSearchable={false}
         name="project_type_id"
         options={projectTypes}
-        onChange={(values) => {
-          onChange('project_type_id', values)
+        onChange={(option) => {
+          onChange('project_type_id', option && option.value.toString())
         }}
         placeholder={t('terms.projectType')}
         styles={styles}
         value={projectType}
+      />
+      <input
+        className="text-sm border-gray-200 flex-1 shadow text-gray-600
+                   rounded-md pt-2.5 placeholder-gray-500 disabled:bg-gray-100
+                   focus:border-gray-200 focus:outline-none focus:ring-0"
+        type="text"
+        autoComplete="off"
+        disabled={disabled}
+        name="project_name"
+        placeholder={t('common.name')}
+        onBlur={(event) => {
+          onChange('name', event.target.value)
+        }}
+        onKeyDown={(event) => {
+          if (event.key === 'Enter') onChange('name', event.target.value)
+        }}
       />
       <Link
         to="/ui/reports/project-type-definitions"

--- a/ui/src/js/views/Projects/Projects.jsx
+++ b/ui/src/js/views/Projects/Projects.jsx
@@ -40,7 +40,8 @@ function Projects() {
     filter: {
       include_archived: query.get('include_archived') === 'true',
       namespace_id: query.get('namespace_id'),
-      project_type_id: query.get('project_type_id')
+      project_type_id: query.get('project_type_id'),
+      project_name: query.get('project_name')
     },
     lastRequest: null,
     offset: parseInt(query.get('offset') || '0'),
@@ -136,7 +137,8 @@ function Projects() {
   function buildURL(path = '/projects') {
     const url = new URL(path, globalState.baseURL)
     Object.entries(state.filter).forEach(([key, value]) => {
-      if (value !== null) url.searchParams.append(key, value)
+      if (value !== null && value.length > 0)
+        url.searchParams.append(key, value)
     })
     const sortValues = []
     sortOrder.map((key) => {
@@ -187,8 +189,10 @@ function Projects() {
         />
         <Link to="/ui/projects/create" className="flex-auto text-right text-sm">
           <button className="btn-green whitespace-nowrap">
-            <Icon className="mr-2" icon="fas plus-circle" />
-            {t('headerNavItems.newProject')}
+            <Icon className="lg:mr-2" icon="fas plus-circle" />
+            <span className="hidden lg:inline-block">
+              {t('headerNavItems.newProject')}
+            </span>
           </button>
         </Link>
       </div>

--- a/ui/tailwind.config.js
+++ b/ui/tailwind.config.js
@@ -11,7 +11,9 @@ module.exports = {
     }
   },
   variants: {
-    extend: {}
+    extend: {
+      backgroundColor: ['disabled']
+    }
   },
   plugins: [require('@tailwindcss/forms')]
 }


### PR DESCRIPTION
Adds a text input filter to the project list that leverages the existing name filter on the projects endpoint.

Some notes:
* I shortened a couple english UI strings to improve available space without changing UI semantics
* I added a collapsed state to the create project button that excludes the text to allow for more room for filters in narrow widths.
* A couple minor tweaks were required to fix the name filter on the projects collection endpoint, which now has a super basic test which highlighted those issues