### PR TITLE
Gitlab connection

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,3 +80,38 @@ Please ensure your code-style passes the lint tests for the code you are modifyi
 Python code is expected to be strict PEP-8 and the `make flake8` command will check the formatting along with other code style preferences.
 
 You should always run prettier for the JavaScript/JSX code. It will reformat the code to the preferred style.
+
+## Local Development Notes
+
+### Adding a new user
+
+The easiest way to add a new user is to create a LDIF file and run it using `docker-compose ldap ldapmodify`:
+
+    $ docker-compose exec ldap ldapadd -D cn=admin,dc=example,dc=org -W
+    Enter LDAP Password: admin
+    dn: cn=dave-shawley,ou=users,dc=example,dc=org
+    objectclass: person
+    objectclass: organizationalPerson
+    objectclass: inetOrgPerson
+    objectClass: posixAccount
+    objectClass: shadowAccount
+    cn: dave-shawley
+    givenName: Dave Shawley
+    sn: Dave
+    uid: dave-shawley
+    mail: daveshawley@gmail.com
+    uidNumber: 502
+    gidNumber: 501
+    homeDirectory: /home/dave-shawley
+    loginShell: /bin/ksh
+    title: Software Engineer
+    initials: DS
+    displayName: Dave
+    gecos: dave-shawley
+    userPassword: {SHA}5en6G6MezRroT3XKqkdPOmY/BfQ=
+    ^D
+    $
+
+You can also use `docker-compose exec` to spawn a shell and use the ldap utilities directly on the container.  The admin user is `cn=admin,dc=example,dc=org` with a password of `admin`.  The `userPassword` in the document is the Base-64 encoded SHA1 checksum of the plaintext password.
+
+Once you have the new user in LDAP, you can log into imbi using the `cn` of the user and the password.

--- a/bootstrap
+++ b/bootstrap
@@ -103,25 +103,19 @@ logging:
   loggers:
     imbi:
       level: DEBUG
-      propagate: true
-      handlers: [console]
     imbi.ldap:
       level: WARNING
-      handlers: [console]
     imbi.session:
       level: WARNING
-      handlers: [console]
     imbi.user:
       level: WARNING
-      handlers: [console]
     sprockets_postgres:
       level: DEBUG
-      propagate: true
-      handlers: [console]
     tornado:
       level: DEBUG
-      propagate: true
-      handlers: [console]
+  root:
+    level: INFO
+    handlers: [console]
   disable_existing_loggers: false
   incremental: false
 EOF
@@ -155,7 +149,6 @@ logging:
   loggers: {}
   root:
     level: CRITICAL
-    propagate: true
     handlers: [console]
   disable_existing_loggers: true
   incremental: false

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -16,7 +16,6 @@ tar c -C /source -f - \
     setup.py \
     tests \
   | tar xf -
-ln -s /usr/local /tmp/test/env
 
 cat > .env <<EOF
 export DEBUG=1
@@ -58,5 +57,4 @@ logging:
   incremental: false
 EOF
 ls -al
-pip3 install -e '.[testing]'
 make python-tests

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -1,16 +1,21 @@
 #!/bin/sh -e
 echo "Setting up tests"
 apk --update add curl-dev gcc git libffi-dev libpq libressl-dev make musl-dev postgresql-dev linux-headers tzdata
-cp -R /source/ddl /tmp/test/
-cp -R /source/imbi /tmp/test/
-cp -R /source/scaffolding /tmp/test/
-cp -R /source/tests /tmp/test/
-cp /source/setup.* /tmp/test/
-cp /source/LICENSE /tmp/test/
-cp /source/MANIFEST.in /tmp/test/
-cp /source/VERSION /tmp/test/
-cp /source/Makefile /tmp/test/
 cd /tmp/test
+tar c -C /source -f - \
+    LICENSE \
+    MANIFEST.in \
+    Makefile \
+    VERSION \
+    bootstrap \
+    docker-compose.yml \
+    ddl \
+    imbi \
+    scaffolding \
+    setup.cfg \
+    setup.py \
+    tests \
+  | tar xf -
 ln -s /usr/local /tmp/test/env
 
 cat > .env <<EOF

--- a/ddl/MANIFEST
+++ b/ddl/MANIFEST
@@ -22,6 +22,7 @@ types/v1/fact_type.sql
 tables/v1/environments.sql
 tables/v1/namespaces.sql
 tables/v1/namespace_kpi_history.sql
+tables/v1/oauth_integrations.sql
 tables/v1/project_types.sql
 tables/v1/cookie_cutters.sql
 tables/v1/projects.sql
@@ -40,6 +41,7 @@ tables/v1/users.sql
 tables/v1/authentication_tokens.sql
 tables/v1/groups.sql
 tables/v1/group_members.sql
+tables/v1/user_oauth2_tokens.sql
 
 -- Functions
 functions/v1/group_name_from_ldap_dn.sql

--- a/ddl/tables/v1/oauth_integrations.sql
+++ b/ddl/tables/v1/oauth_integrations.sql
@@ -1,0 +1,27 @@
+SET SEARCH_PATH TO v1;
+
+CREATE TABLE IF NOT EXISTS oauth_integrations (
+    name                   TEXT    NOT NULL PRIMARY KEY,
+    api_endpoint           TEXT    NOT NULL,
+    callback_url           TEXT,
+    authorization_endpoint TEXT    NOT NULL,
+    token_endpoint         TEXT    NOT NULL,
+    revoke_endpoint        TEXT,
+    client_id              TEXT    NOT NULL,
+    client_secret          TEXT,
+    public_client          BOOLEAN NOT NULL
+);
+
+COMMENT ON TABLE oauth_integrations IS 'Table of OAuth connection details for integrations.';
+COMMENT ON COLUMN oauth_integrations.name IS 'Unique display name for the integrated application.';
+COMMENT ON COLUMN oauth_integrations.api_endpoint IS 'Root URL for the application HTTP API.';
+COMMENT ON COLUMN oauth_integrations.callback_url IS 'URL to include as the redirect_uri in the OAuth 2 authorization flow.';
+COMMENT ON COLUMN oauth_integrations.authorization_endpoint IS 'URL used to initiate the OAuth 2 authorization flow.';
+COMMENT ON COLUMN oauth_integrations.token_endpoint IS 'URL used to redeem an OAuth 2 authorization code.';
+COMMENT ON COLUMN oauth_integrations.revoke_endpoint IS 'URL used to revoke an OAuth 2 token if supported.';
+COMMENT ON COLUMN oauth_integrations.client_id IS 'Public OAuth 2 client ID used to for OAuth 2 authorization.';
+COMMENT ON COLUMN oauth_integrations.client_secret IS 'OAuth 2 client secret used for Oauth 2 authorization.';
+COMMENT ON COLUMN oauth_integrations.public_client IS 'If TRUE, then the OAuth 2 authorization flow requires PKCE.';
+
+GRANT SELECT ON oauth_integrations TO reader;
+GRANT SELECT, INSERT, UPDATE, DELETE ON oauth_integrations TO admin;

--- a/ddl/tables/v1/projects.sql
+++ b/ddl/tables/v1/projects.sql
@@ -13,6 +13,10 @@ CREATE TABLE IF NOT EXISTS projects (
   description            TEXT,
   environments           TEXT[],
   archived               BOOLEAN                   NOT NULL  DEFAULT FALSE,
+  gitlab_project_id      INT4,
+  sentry_project_slug    TEXT,
+  sonarqube_project_key  TEXT,
+  pagerduty_service_id   TEXT,
   UNIQUE (namespace_id, project_type_id, name),
   FOREIGN KEY (namespace_id) REFERENCES namespaces (id) ON UPDATE CASCADE ON DELETE RESTRICT,
   FOREIGN KEY (project_type_id) REFERENCES project_types (id) ON UPDATE CASCADE ON DELETE RESTRICT
@@ -33,6 +37,10 @@ COMMENT ON COLUMN projects.slug IS 'The project slug used in paths';
 COMMENT ON COLUMN projects.description IS 'Description of the high-level purpose and context for the project';
 COMMENT ON COLUMN projects.environments IS 'The operational environments the project is available in';
 COMMENT ON COLUMN projects.archived IS 'Indicates that the project is archived and should not appear in normal search results';
+COMMENT ON COLUMN projects.gitlab_project_id IS 'If set, specifies the GitLab project ID for the GitLab integration';
+COMMENT ON COLUMN projects.sentry_project_slug IS 'If set, specifies the project slug for the Sentry integration';
+COMMENT ON COLUMN projects.sonarqube_project_key IS 'If set, specifies the project slug for the SonarQube integration';
+COMMENT ON COLUMN projects.pagerduty_service_id IS 'If set, specifies the service id for the PagerDuty integration';
 
 GRANT SELECT ON projects TO reader;
 GRANT SELECT, INSERT, UPDATE, DELETE ON projects TO writer;

--- a/ddl/tables/v1/user_oauth2_tokens.sql
+++ b/ddl/tables/v1/user_oauth2_tokens.sql
@@ -1,0 +1,9 @@
+CREATE TABLE v1.user_oauth2_tokens (
+    username TEXT NOT NULL REFERENCES v1.users(username) ON DELETE RESTRICT ON UPDATE CASCADE,
+    integration TEXT NOT NULL REFERENCES v1.oauth_integrations(name) ON DELETE RESTRICT ON UPDATE CASCADE,
+    external_id TEXT NOT NULL,
+    access_token TEXT NOT NULL,
+    refresh_token TEXT NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (integration, external_id)
+);

--- a/ddl/tests/test_v1_tables.sql
+++ b/ddl/tests/test_v1_tables.sql
@@ -1,5 +1,5 @@
 BEGIN;
-SELECT plan(21);
+SELECT plan(23);
 
 SELECT has_table('v1'::NAME, 'authentication_tokens'::NAME);
 SELECT has_table('v1'::NAME, 'cookie_cutters'::NAME);
@@ -8,6 +8,7 @@ SELECT has_table('v1'::NAME, 'group_members'::NAME);
 SELECT has_table('v1'::NAME, 'groups'::NAME);
 SELECT has_table('v1'::NAME, 'namespaces'::NAME);
 SELECT has_table('v1'::NAME, 'namespace_kpi_history'::NAME);
+SELECT has_table('v1'::NAME, 'oauth_integrations'::NAME);
 SELECT has_table('v1'::NAME, 'operations_log'::NAME);
 SELECT has_table('v1'::NAME, 'project_dependencies'::NAME);
 SELECT has_table('v1'::NAME, 'project_fact_history'::NAME);
@@ -21,6 +22,7 @@ SELECT has_table('v1'::NAME, 'project_types'::NAME);
 SELECT has_table('v1'::NAME, 'project_score_history'::NAME);
 SELECT has_table('v1'::NAME, 'project_urls'::NAME);
 SELECT has_table('v1'::NAME, 'projects'::NAME);
+SELECT has_table('v1'::NAME, 'user_oauth2_tokens'::NAME);
 SELECT has_table('v1'::NAME, 'users'::NAME);
 
 SELECT * FROM finish();

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-%YAML 1.2
----
 version: "3.7"
 services:
   ldap:
@@ -13,8 +11,6 @@ services:
       - type: bind
         source: ./scaffolding/ldap
         target: /container/service/slapd/assets/config/bootstrap/ldif/custom/
-        volume:
-          nocopy: true
     healthcheck:
       test: /usr/bin/ldapsearch -x -h localhost -b dc=example,dc=org cn=test,ou=users,dc=example,dc=org
     command: --loglevel debug --copy-service

--- a/imbi/app.py
+++ b/imbi/app.py
@@ -57,6 +57,7 @@ class Application(sprockets_postgres.ApplicationMixin, app.Application):
         self.stats: typing.Optional[stats.Stats] = None
 
         content.set_default_content_type(self, 'application/json')
+        content.add_transcoder(self, transcoders.FormTranscoder())
         content.add_transcoder(self, transcoders.JSONTranscoder())
         content.add_transcoder(self, transcoders.MsgPackTranscoder())
         content.add_text_content_type(

--- a/imbi/endpoints/__init__.py
+++ b/imbi/endpoints/__init__.py
@@ -3,7 +3,7 @@ from tornado import web
 from imbi import constants
 from . import (activity_feed, authentication_tokens, cookie_cutters, dashboard,
                environments, fact_type_enums, fact_type_ranges, fact_types,
-               groups, metrics, namespaces, openapi, permissions,
+               groups, integrations, metrics, namespaces, openapi, permissions,
                project_activity_feed, project_dependencies, project_fact_types,
                project_facts, project_link_types, project_links,
                project_score_history, project_types, project_urls, projects,
@@ -31,6 +31,9 @@ URLS = [
     web.url(r'^/groups/(?P<name>[\w_\-%\+]+)$',
             groups.RecordRequestHandler,
             name='group'),
+    web.url(r'^/integrations$', integrations.CollectionRequestHandler),
+    web.url(r'^/integrations/(?P<name>[\w_\-%\+]+)$',
+            integrations.RecordRequestHandler),
     web.url(r'^/metrics$', metrics.RequestHandler),
     web.url(r'^/namespaces$', namespaces.CollectionRequestHandler),
     web.url(r'^/namespaces/(?P<id>\d+)$',

--- a/imbi/endpoints/__init__.py
+++ b/imbi/endpoints/__init__.py
@@ -3,11 +3,11 @@ from tornado import web
 from imbi import constants
 from . import (activity_feed, authentication_tokens, cookie_cutters, dashboard,
                environments, fact_type_enums, fact_type_ranges, fact_types,
-               groups, integrations, metrics, namespaces, openapi, permissions,
-               project_activity_feed, project_dependencies, project_fact_types,
-               project_facts, project_link_types, project_links,
-               project_score_history, project_types, project_urls, projects,
-               reports, status, ui)
+               gitlab, groups, integrations, metrics, namespaces, openapi,
+               permissions, project_activity_feed, project_dependencies,
+               project_fact_types, project_facts, project_link_types,
+               project_links, project_score_history, project_types,
+               project_urls, projects, reports, status, ui)
 
 URLS = [
     web.url(r'^/$', ui.IndexRequestHandler),
@@ -27,6 +27,9 @@ URLS = [
     web.url(r'^/environments/(?P<name>[\w_\-%\+]+)$',
             environments.RecordRequestHandler,
             name='environment'),
+    web.url(r'^/gitlab/auth', gitlab.RedirectHandler),
+    web.url(r'^/gitlab/namespaces', gitlab.UserNamespacesHandler),
+    web.url(r'^/gitlab/projects', gitlab.ProjectsHandler),
     web.url(r'^/groups$', groups.CollectionRequestHandler),
     web.url(r'^/groups/(?P<name>[\w_\-%\+]+)$',
             groups.RecordRequestHandler,

--- a/imbi/endpoints/__init__.py
+++ b/imbi/endpoints/__init__.py
@@ -36,7 +36,7 @@ URLS = [
             name='group'),
     web.url(r'^/integrations$', integrations.CollectionRequestHandler),
     web.url(r'^/integrations/(?P<name>[\w_\-%\+]+)$',
-            integrations.RecordRequestHandler),
+            integrations.RecordRequestHandler, name='integration'),
     web.url(r'^/metrics$', metrics.RequestHandler),
     web.url(r'^/namespaces$', namespaces.CollectionRequestHandler),
     web.url(r'^/namespaces/(?P<id>\d+)$',

--- a/imbi/endpoints/gitlab.py
+++ b/imbi/endpoints/gitlab.py
@@ -205,6 +205,7 @@ class ProjectsHandler(sprockets.mixins.http.HTTPClientMixin,
             entries = await self.fetch_all_pages(url, token)
             projects.extend([
                 {
+                    'description': entry['description'],
                     'name': entry['name'],
                     'id': entry['id'],
                     'web_url': entry['web_url'],

--- a/imbi/endpoints/gitlab.py
+++ b/imbi/endpoints/gitlab.py
@@ -1,0 +1,243 @@
+import dataclasses
+import typing
+import urllib.parse
+
+import problemdetails
+import sprockets.mixins.http
+import yarl
+
+from . import base
+from .. import integrations, user
+
+
+@dataclasses.dataclass
+class GitlabToken:
+    access_token: str
+    refresh_token: str
+
+
+class RedirectHandler(sprockets.mixins.http.HTTPClientMixin,
+                      base.RequestHandler):
+    integration: integrations.OAuth2Integration
+
+    async def prepare(self) -> None:
+        await super().prepare()
+        if not self._finished:
+            self.integration = await integrations.OAuth2Integration.by_name(
+                self.application, 'gitlab')
+            if not self.integration:
+                raise problemdetails.Problem(
+                    500, 'application lookup failed for %s', 'gitlab',
+                    type='https://imbi.aweber.com/errors/#server-error',
+                    title='Internal server error')
+
+    async def get(self):
+        auth_code = self.get_query_argument('code')
+        state = self.get_query_argument('state')
+        token = await self.exchange_code_for_token(auth_code)
+        try:
+            user_id, user_name, email = await self.fetch_gitlab_user(token)
+            imbi_user = user.User(self.application, username=state)
+            await imbi_user.refresh()
+            if imbi_user.email_address != email:
+                raise problemdetails.Problem(
+                    403, 'mismatched user email: expected %r received %r',
+                    imbi_user.email_address, email,
+                    type='https://imbi.aweber.com/errors/#gitlab-auth-failure',
+                    title='Gitlab authorization failure',
+                    detail='unexpected email address {} for user {}'.format(
+                        email, imbi_user.username),
+                )
+            await self.integration.add_user_token(
+                imbi_user, str(user_id), token.access_token,
+                token.refresh_token)
+        except Exception:
+            await self.revoke_gitlab_token(token)
+            raise
+
+        target = yarl.URL(self.request.full_url())
+        target = target.with_path('/ui/user/profile')
+        self.redirect(str(target))
+
+    async def exchange_code_for_token(self, code) -> GitlabToken:
+        body = urllib.parse.urlencode({
+            'client_id': self.integration.client_id,
+            'client_secret': self.integration.client_secret,
+            'grant_type': 'authorization_code',
+            'redirect_uri': str(self.integration.callback_url),
+            'code': code,
+        })
+        response = await self.http_fetch(
+            str(self.integration.token_endpoint), method='POST', body=body,
+            content_type='application/x-www-form-urlencoded')
+        if not response.ok:
+            self.logger.error('failed to exchange auth code for token: %s %s',
+                              response.body['error'],
+                              response.body['error_description'])
+            raise problemdetails.Problem(
+                500, 'failed exchange auth code for token: %s', response.code,
+                type='https://imbi.aweber.com/errors/#gitlab-auth-failure',
+                title='Gitlab authorization failure',
+                instance={
+                    'error': response.body['error'],
+                    'error_description': response.body['error_description'],
+                })
+        self.logger.debug('response_body %r', response.body)
+        return GitlabToken(access_token=response.body['access_token'],
+                           refresh_token=response.body['refresh_token'])
+
+    async def fetch_gitlab_user(self, token: GitlabToken) -> typing.Tuple[
+            int, str, str]:
+        response = await self.http_fetch(
+            str(self.integration.api_endpoint / 'user'),
+            request_headers={'Accept': 'application/json',
+                             'Authorization': f'Bearer {token.access_token}'})
+        if response.ok:
+            return (response.body['id'], response.body['username'],
+                    response.body['email'])
+        raise problemdetails.Problem(
+            500, 'failed to retrieve gitlab user from access token',
+            type='https://imbi.aweber.com/errors/#gitlab-auth-failure',
+            title='Gitlab user lookup failure')
+
+    async def revoke_gitlab_token(self, token: GitlabToken):
+        ...
+
+
+class UserNamespacesHandler(sprockets.mixins.http.HTTPClientMixin,
+                            base.AuthenticatedRequestHandler):
+    integration: integrations.OAuth2Integration
+
+    async def prepare(self) -> None:
+        await super().prepare()
+        if not self._finished:
+            self.integration = await integrations.OAuth2Integration.by_name(
+                self.application, 'gitlab')
+            if not self.integration:
+                raise problemdetails.Problem(
+                    500, 'application lookup failed for %s', 'gitlab',
+                    type='https://imbi.aweber.com/errors/#server-error',
+                    title='Internal server error')
+
+    async def get(self):
+        namespaces = []
+        imbi_user = await self.get_current_user()  # shouldn't be None
+        url = self.integration.api_endpoint / 'groups'
+        url = url.with_query({'min_access_level': 30})
+        for token in await self.integration.get_user_tokens(imbi_user):
+            entries = await self.fetch_all_pages(url, token)
+            namespaces.extend([
+                {
+                    'name': entry['full_name'],
+                    'id': entry['id'],
+                }
+                for entry in entries
+            ])
+
+        namespaces.sort(key=lambda elm: elm['name'])
+        self.send_response(namespaces)
+
+    async def fetch_all_pages(
+            self, url: yarl.URL, token: integrations.IntegrationToken
+    ) -> typing.Sequence[dict]:
+        entries = []
+        while url is not None:
+            response = await self.http_fetch(
+                str(url),
+                request_headers={
+                    'Accept': 'application/json',
+                    'Authorization': f'Bearer {token.access_token}',
+                }
+            )
+            if response.ok:
+                entries.extend(response.body)
+            else:  # TODO -- handle token expiration
+                raise problemdetails.Problem(
+                    500, 'failed to retrieve groups: %s', response.code,
+                    type='https://imbi.aweber.com/errors/#server-error',
+                    title='Internal server error')
+
+            url = None
+            for link in response.links:
+                if link['rel'] == 'next':
+                    url = yarl.URL(link['target'])
+                    break
+
+        return entries
+
+
+class ProjectsHandler(sprockets.mixins.http.HTTPClientMixin,
+                      base.AuthenticatedRequestHandler):
+    integration: integrations.OAuth2Integration
+
+    async def prepare(self) -> None:
+        await super().prepare()
+        if not self._finished:
+            self.integration = await integrations.OAuth2Integration.by_name(
+                self.application, 'gitlab')
+            if not self.integration:
+                raise problemdetails.Problem(
+                    500, 'application lookup failed for %s', 'gitlab',
+                    type='https://imbi.aweber.com/errors/#server-error',
+                    title='Internal server error')
+
+    async def get(self):
+        group_arg = self.get_query_argument('group_id')
+        try:
+            group_id = int(group_arg)
+        except ValueError:
+            raise problemdetails.Problem(
+                400, 'invalid group ID: %r', group_arg,
+                type='https://imbi.aweber.com/errors/#invalid-parameter',
+                title='Invalid Query Parameter')
+
+        imbi_user = await self.get_current_user()
+        url = (self.integration.api_endpoint / 'groups' / str(group_id)
+               / 'projects')
+        url = url.with_query({
+            'include_subgroups': 'false',
+            'simple': 'true',
+            'with_shared': 'false',
+        })
+
+        projects = []
+        for token in await self.integration.get_user_tokens(imbi_user):
+            entries = await self.fetch_all_pages(url, token)
+            projects.extend([
+                {
+                    'name': entry['name'],
+                    'id': entry['id'],
+                    'web_url': entry['web_url'],
+                }
+                for entry in entries
+            ])
+
+        self.send_response(projects)
+
+    async def fetch_all_pages(
+            self, url: yarl.URL, token: integrations.IntegrationToken
+    ) -> typing.Sequence[dict]:
+        entries = []
+        while url is not None:
+            response = await self.http_fetch(
+                str(url),
+                request_headers={
+                    'Accept': 'application/json',
+                    'Authorization': f'Bearer {token.access_token}',
+                }
+            )
+            if response.ok:
+                entries.extend(response.body)
+            else:  # TODO -- handle token expiration
+                raise problemdetails.Problem(
+                    500, 'failed to retrieve groups: %s', response.code,
+                    type='https://imbi.aweber.com/errors/#server-error',
+                    title='Internal server error')
+
+            url = None
+            for link in response.links:
+                if link['rel'] == 'next':
+                    url = yarl.URL(link['target'])
+                    break
+
+        return entries

--- a/imbi/endpoints/integrations.py
+++ b/imbi/endpoints/integrations.py
@@ -4,12 +4,33 @@ from imbi.endpoints import base
 class CollectionRequestHandler(base.CollectionRequestHandler):
     NAME = 'integrations'
     ITEM_NAME = 'integration'
+    ID_KEY = 'name'
+    FIELDS = ['name', 'api_endpoint', 'callback_url', 'authirization_endpoint',
+              'token_endpoint', 'revoke_endpoint', 'client_id',
+              'client_secret', 'public_client']
 
     COLLECTION_SQL = """\
         SELECT name, api_endpoint, callback_url, authorization_endpoint,
                token_endpoint, revoke_endpoint, client_id
           FROM v1.oauth_integrations
          ORDER BY "name" ASC"""
+
+    POST_SQL = """\
+        INSERT INTO v1.oauth_integrations
+                    (name, api_endpoint, callback_url, authorization_endpoint,
+                     token_endpoint, revoke_endpoint, client_id, client_secret,
+                     public_client)
+             VALUES (%(name)s, %(api_endpoint)s, %(callback_url)s,
+                     %(authorization_endpoint)s, %(token_endpoint)s,
+                     %(revoke_endpoint)s, %(client_id)s, %(client_secret)s,
+                     %(public_client)s)
+          RETURNING name"""
+
+    GET_SQL = """\
+        SELECT name, api_endpoint, callback_url, authorization_endpoint,
+               token_endpoint, revoke_endpoint, client_id
+          FROM v1.oauth_integrations
+         WHERE name = %(name)s"""
 
 
 class RecordRequestHandler(base.CRUDRequestHandler):

--- a/imbi/endpoints/integrations.py
+++ b/imbi/endpoints/integrations.py
@@ -1,0 +1,23 @@
+from imbi.endpoints import base
+
+
+class CollectionRequestHandler(base.CollectionRequestHandler):
+    NAME = 'integrations'
+    ITEM_NAME = 'integration'
+
+    COLLECTION_SQL = """\
+        SELECT name, api_endpoint, callback_url, authorization_endpoint,
+               token_endpoint, revoke_endpoint, client_id
+          FROM v1.oauth_integrations
+         ORDER BY "name" ASC"""
+
+
+class RecordRequestHandler(base.CRUDRequestHandler):
+    NAME = 'integration'
+    ID_KEY = 'name'
+
+    GET_SQL = """\
+        SELECT name, api_endpoint, callback_url, authorization_endpoint,
+               token_endpoint, revoke_endpoint, client_id
+          FROM v1.oauth_integrations
+         WHERE name = %(name)s"""

--- a/imbi/endpoints/integrations.py
+++ b/imbi/endpoints/integrations.py
@@ -42,3 +42,5 @@ class RecordRequestHandler(base.CRUDRequestHandler):
                token_endpoint, revoke_endpoint, client_id
           FROM v1.oauth_integrations
          WHERE name = %(name)s"""
+
+    DELETE_SQL = "DELETE FROM v1.oauth_integrations WHERE name = %(name)s"

--- a/imbi/endpoints/integrations.py
+++ b/imbi/endpoints/integrations.py
@@ -43,4 +43,5 @@ class RecordRequestHandler(base.CRUDRequestHandler):
           FROM v1.oauth_integrations
          WHERE name = %(name)s"""
 
-    DELETE_SQL = "DELETE FROM v1.oauth_integrations WHERE name = %(name)s"
+    DELETE_SQL = """\
+        DELETE FROM v1.oauth_integrations WHERE name = %(name)s"""

--- a/imbi/endpoints/projects.py
+++ b/imbi/endpoints/projects.py
@@ -11,7 +11,9 @@ class _RequestHandlerMixin:
     ITEM_NAME = 'project'
     ID_KEY = ['id']
     FIELDS = ['id', 'namespace_id', 'project_type_id', 'name', 'slug',
-              'description', 'environments', 'archived']
+              'description', 'environments', 'archived', 'gitlab_project_id',
+              'sentry_project_slug', 'sonarqube_project_key',
+              'pagerduty_service_id']
     TTL = 300
 
     GET_SQL = re.sub(r'\s+', ' ', """\
@@ -28,7 +30,11 @@ class _RequestHandlerMixin:
                a.slug,
                a.description,
                a.environments,
-               a.archived
+               a.archived,
+               a.gitlab_project_id,
+               a.sentry_project_slug,
+               a.sonarqube_project_key,
+               a.pagerduty_service_id
           FROM v1.projects AS a
           JOIN v1.namespaces AS b ON b.id = a.namespace_id
           JOIN v1.project_types AS c ON c.id = a.project_type_id
@@ -57,6 +63,10 @@ class CollectionRequestHandler(_RequestHandlerMixin,
                a.description,
                a.environments,
                a.archived,
+               a.gitlab_project_id,
+               a.sentry_project_slug,
+               a.sonarqube_project_key,
+               a.pagerduty_service_id,
                v1.project_score(a.id) AS project_score
           FROM v1.projects AS a
           JOIN v1.namespaces AS b ON b.id = a.namespace_id
@@ -156,6 +166,10 @@ class RecordRequestHandler(_RequestHandlerMixin, base.CRUDRequestHandler):
                a.description,
                a.environments,
                a.archived,
+               a.gitlab_project_id,
+               a.sentry_project_slug,
+               a.sonarqube_project_key,
+               a.pagerduty_service_id,
                v1.project_score(a.id)
           FROM v1.projects AS a
           JOIN v1.namespaces AS b ON b.id = a.namespace_id
@@ -229,7 +243,11 @@ class RecordRequestHandler(_RequestHandlerMixin, base.CRUDRequestHandler):
                slug=%(slug)s,
                description=%(description)s,
                environments=%(environments)s,
-               archived=%(archived)s
+               archived=%(archived)s,
+               gitlab_project_id=%(gitlab_project_id)s,
+               sentry_project_slug=%(sentry_project_slug)s,
+               sonarqube_project_key=%(sonarqube_project_key)s,
+               pagerduty_service_id=%(pagerduty_service_id)s
          WHERE id=%(id)s""")
 
     async def get(self, *args, **kwargs):

--- a/imbi/integrations.py
+++ b/imbi/integrations.py
@@ -1,0 +1,139 @@
+import dataclasses
+import logging
+import typing
+
+import problemdetails
+import yarl
+
+from imbi import app, user
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+UNSET_URL = yarl.URL()
+
+
+@dataclasses.dataclass
+class IntegrationToken:
+    integration: 'OAuth2Integration'
+    access_token: str
+    refresh_token: str
+    external_id: str
+
+
+class OAuth2Integration:
+    SQL_REFRESH = """\
+    SELECT api_endpoint, authorization_endpoint, token_endpoint,
+           revoke_endpoint, client_id, client_secret, public_client,
+           callback_url
+      FROM v1.oauth_integrations
+     WHERE name = %(name)s"""
+
+    SQL_ADD_TOKEN = """\
+    INSERT INTO v1.user_oauth2_tokens(username, integration, external_id,
+                                      access_token, refresh_token)
+         VALUES (%(username)s, %(integration)s, %(external_id)s,
+                 %(access_token)s, %(refresh_token)s)"""
+
+    SQL_GET_TOKENS = """\
+    SELECT access_token, refresh_token, external_id
+      FROM v1.user_oauth2_tokens
+     WHERE username = %(username)s
+       AND integration = %(integration)s
+    """
+
+    def __init__(self, application: 'app.Application', name: str) -> None:
+        self._application = application
+        self.logger = LOGGER.getChild(self.__class__.__name__)
+        self.name = name
+        self.authorization_endpoint: yarl.URL = UNSET_URL
+        self.api_endpoint: typing.Optional[yarl.URL] = None
+        self.token_endpoint: yarl.URL = UNSET_URL
+        self.revoke_endpoint: typing.Optional[yarl.URL] = None
+        self.client_id: str = ''
+        self.client_secret: str = ''
+        self.public_client: bool = True
+        self.callback_url: typing.Optional[yarl.URL] = UNSET_URL
+
+    @classmethod
+    async def by_name(cls, application: 'app.Application',
+                      name: str) -> typing.Optional['OAuth2Integration']:
+        instance = cls(application, name)
+        await instance.refresh()
+        return instance if instance.is_valid else None
+
+    async def refresh(self) -> None:
+        async with self._application.postgres_connector(
+                on_error=self._on_postgres_error) as conn:
+            result = await conn.execute(self.SQL_REFRESH, {'name': self.name})
+
+        if result:
+            self.authorization_endpoint = yarl.URL(
+                result.row['authorization_endpoint'])
+            self.token_endpoint = yarl.URL(result.row['token_endpoint'])
+            self.client_id = result.row['client_id']
+            self.client_secret = result.row['client_secret']
+            self.public_client = result.row['public_client']
+
+            if result.row['api_endpoint']:
+                self.api_endpoint = yarl.URL(result.row['api_endpoint'])
+            else:
+                self.api_endpoint = None
+
+            if result.row['revoke_endpoint']:
+                self.revoke_endpoint = yarl.URL(result.row['revoke_endpoint'])
+            else:
+                self.revoke_endpoint = None
+
+            if result.row['callback_url']:
+                self.callback_url = yarl.URL(result.row['callback_url'])
+            else:
+                self.callback_url = None
+        else:
+            self._reset()
+
+    async def add_user_token(self, user_info: user.User, external_id: str,
+                             access_token: str, refresh_token: str):
+        async with self._application.postgres_connector(
+                on_error=self._on_postgres_error) as conn:
+            await conn.execute(self.SQL_ADD_TOKEN, {
+                'integration': self.name, 'username': user_info.username,
+                'external_id': external_id, 'access_token': access_token,
+                'refresh_token': refresh_token})
+
+    async def get_user_tokens(
+            self, user_info: user.User) -> typing.Sequence[IntegrationToken]:
+        async with self._application.postgres_connector(
+                on_error=self._on_postgres_error) as conn:
+            result = await conn.execute(self.SQL_GET_TOKENS, {
+                'integration': self.name, 'username': user_info.username})
+        return [
+            IntegrationToken(self, row['access_token'], row['refresh_token'],
+                             row['external_id'])
+            for row in result
+        ]
+
+    @property
+    def is_valid(self):
+        return (self.authorization_endpoint != UNSET_URL and
+                self.token_endpoint != UNSET_URL and
+                self.client_id and (self.client_secret or self.public_client))
+
+    @staticmethod
+    def _on_postgres_error(_metric_name: str, exc: Exception) -> None:
+        raise problemdetails.Problem(
+            500, 'database failure: %s', exc,
+            type='https://imbi.aweber.com/errors/#database-error',
+            title='Database failure',
+        )
+
+    def _reset(self):
+        self.api_endpoint = None
+        self.authorization_endpoint = UNSET_URL
+        self.callback_url = UNSET_URL
+        self.token_endpoint = UNSET_URL
+        self.revoke_endpoint = None
+        self.client_id = ''
+        self.client_secret = ''
+        self.public_client = True

--- a/imbi/openapi.py
+++ b/imbi/openapi.py
@@ -12,6 +12,8 @@ from jsonschema import validators as jsonschema_validators
 from openapi_core.schema.specs import factories, models
 from tornado import template
 
+from imbi import transcoders
+
 LOGGER = logging.getLogger(__name__)
 
 
@@ -75,6 +77,7 @@ def request_validator(settings: dict) -> tornado_openapi3.RequestValidator:
             'application/msgpack': umsgpack.unpackb,
             'application/problem+json': json.loads,
             'application/problem+msgpack': umsgpack.unpackb,
+            'application/x-www-form-urlencoded': transcoders.parse_form_body,
             'application/yaml': yaml.safe_load})
 
 

--- a/imbi/server.py
+++ b/imbi/server.py
@@ -34,15 +34,15 @@ DEFAULT_LOG_CONFIG = {
     },
     'loggers': {
         'imbi': {
-            'level': 'INFO',
-            'propagate': True,
-            'handlers': ['console']
+            'level': 'INFO'
         },
         'tornado': {
-            'level': 'INFO',
-            'propagate': True,
-            'handlers': ['console']
+            'level': 'INFO'
         }
+    },
+    'root': {
+        'level': 'WARNING',
+        'handlers': ['console']
     },
     'disable_existing_loggers': True,
     'incremental': False

--- a/imbi/templates/openapi.yaml
+++ b/imbi/templates/openapi.yaml
@@ -1666,6 +1666,18 @@ paths:
                   - revoke_endpoint
                   - client_id
                 additionalProperties: false
+    delete:
+      description: Remove the specified integration
+      summary: Delete an integration
+      tags:
+        - Integrations
+      responses:
+        '204':
+          $ref: '#/paths/~1groups~1%7Bname%7D/delete/responses/204'
+        '401':
+          $ref: '#/paths/~1groups/get/responses/401'
+        '404':
+          $ref: '#/paths/~1groups~1%7Bname%7D/get/responses/404'
   /operations-log:
     get:
       description: |-

--- a/imbi/templates/openapi.yaml
+++ b/imbi/templates/openapi.yaml
@@ -1616,6 +1616,9 @@ paths:
                 - client_secret
                 - public_client
               additionalProperties: false
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/paths/~1integrations/post/requestBody/content/application~1json/schema'
       responses:
         '200':
           description: Success

--- a/imbi/templates/openapi.yaml
+++ b/imbi/templates/openapi.yaml
@@ -3689,6 +3689,22 @@ paths:
                     archived:
                       description: Indicates that the project is archived
                       type: boolean
+                    gitlab_project_id:
+                      description: Optional project ID for the associated gitlab project
+                      type: integer
+                      nullable: true
+                    sentry_project_slug:
+                      description: Optional slug for the project in sentry
+                      type: string
+                      nullable: true
+                    sonarqube_project_key:
+                      description: Optional slug for the project in SonarQube
+                      type: string
+                      nullable: true
+                    pagerduty_service_id:
+                      description: Optional ID for the project in PagerDuty
+                      type: string
+                      nullable: true
                   additionalProperties: false
               example:
                 records:
@@ -3758,6 +3774,22 @@ paths:
                     archived:
                       description: Indicates that the project is archived
                       type: boolean
+                    gitlab_project_id:
+                      description: Optional project ID for the associated gitlab project
+                      type: integer
+                      nullable: true
+                    sentry_project_slug:
+                      description: Optional slug for the project in sentry
+                      type: string
+                      nullable: true
+                    sonarqube_project_key:
+                      description: Optional slug for the project in SonarQube
+                      type: string
+                      nullable: true
+                    pagerduty_service_id:
+                      description: Optional ID for the project in PagerDuty
+                      type: string
+                      nullable: true
                   additionalProperties: false
               example:
                 records:

--- a/imbi/templates/openapi.yaml
+++ b/imbi/templates/openapi.yaml
@@ -1558,6 +1558,58 @@ paths:
         required: true
         schema:
           type: number
+  /integrations:
+    get:
+      description: Retrieve the collection of integrations
+      summary: Get integrations
+      tags:
+        - Integrations
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/paths/~1integrations~1%7Bname%7D/get/responses/200/content/application~1json/schema'
+  '/integrations/{name}':
+    get:
+      description: Retrieve a specific integration by name
+      summary: Fetch a single integration
+      tags:
+        - Integrations
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  api_endpoint:
+                    type: string
+                  callback_url:
+                    type: string
+                  authorization_endpoint:
+                    type: string
+                  token_endpoint:
+                    type: string
+                  revoke_endpoint:
+                    type: string
+                  client_id:
+                    type: string
+                required:
+                  - name
+                  - api_endpoint
+                  - callback_url
+                  - authorization_endpoint
+                  - token_endpoint
+                  - revoke_endpoint
+                  - client_id
+                additionalProperties: false
   /operations-log:
     get:
       description: |-
@@ -1623,6 +1675,7 @@ paths:
           schema:
             type: string
             pattern: ^\d+$
+
       responses:
         '200':
           description: Success
@@ -1631,6 +1684,7 @@ paths:
               schema:
                 type: array
                 items:
+
                   title: Operations Log Entry
                   description: Describes an audit log entry for entity operational changes
                   type: object
@@ -5753,8 +5807,11 @@ tags:
     description: Endpoints used to report on the state of various objects in Imbi
   - name: Settings
     description: Endpoints used for retrieving settings for the Imbi UI
+  - name: Integrations
+    description: Endpoints used to retrieve information about applications that Imbi is integrated with
   - name: Monitoring & Metrics
     description: 'Endpoints used for health checking, service status, and service metrics'
+
 x-tagGroups:
   - name: Activity Feed
     tags:
@@ -5768,6 +5825,7 @@ x-tagGroups:
     tags:
       - Cookie Cutters
       - Environments
+      - Integrations
       - Namespaces
       - Fact Types
       - Fact Type Enums

--- a/imbi/templates/openapi.yaml
+++ b/imbi/templates/openapi.yaml
@@ -1573,6 +1573,59 @@ paths:
                 type: array
                 items:
                   $ref: '#/paths/~1integrations~1%7Bname%7D/get/responses/200/content/application~1json/schema'
+    post:
+      description: Add a new integration
+      summary: Add integration
+      tags:
+        - Integrations
+      requestBody:
+        description: Integration details
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                api_endpoint:
+                  type: string
+                callback_url:
+                  type: string
+                authorization_endpoint:
+                  type: string
+                token_endpoint:
+                  type: string
+                revoke_endpoint:
+                  type: string
+                  nullable: true
+                client_id:
+                  type: string
+                client_secret:
+                  type: string
+                  nullable: true
+                public_client:
+                  type: boolean
+              required:
+                - name
+                - api_endpoint
+                - callback_url
+                - authorization_endpoint
+                - token_endpoint
+                - revoke_endpoint
+                - client_id
+                - client_secret
+                - public_client
+              additionalProperties: false
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  name:
+                    type: string
   '/integrations/{name}':
     get:
       description: Retrieve a specific integration by name
@@ -1675,7 +1728,6 @@ paths:
           schema:
             type: string
             pattern: ^\d+$
-
       responses:
         '200':
           description: Success
@@ -1684,7 +1736,6 @@ paths:
               schema:
                 type: array
                 items:
-
                   title: Operations Log Entry
                   description: Describes an audit log entry for entity operational changes
                   type: object
@@ -5811,7 +5862,6 @@ tags:
     description: Endpoints used to retrieve information about applications that Imbi is integrated with
   - name: Monitoring & Metrics
     description: 'Endpoints used for health checking, service status, and service metrics'
-
 x-tagGroups:
   - name: Activity Feed
     tags:

--- a/imbi/transcoders.py
+++ b/imbi/transcoders.py
@@ -1,6 +1,37 @@
 import decimal
+import urllib.parse
 
-from sprockets.mixins.mediatype import transcoders
+from sprockets.mixins.mediatype import handlers, transcoders
+
+
+def parse_form_body(data) -> dict:
+    def translate_value(v):
+        if not v:
+            return None
+
+        m = {'null': None, 'true': True, 'false': False}
+        try:
+            value = m[v]
+        except KeyError:
+            try:
+                value = float(v)
+            except ValueError:
+                value = v
+        return value
+
+    if hasattr(data, 'decode'):
+        data = data.decode('utf-8')
+    form_body = {}
+    parsed = urllib.parse.parse_qsl(data, keep_blank_values=True)
+    for name, value in parsed:
+        value = translate_value(value)
+        if name in form_body:
+            if not isinstance(form_body[name], list):
+                form_body[name] = [form_body[name]]
+            form_body[name].append(value)
+        else:
+            form_body[name] = value
+    return form_body
 
 
 class DecimalMixin:
@@ -44,3 +75,15 @@ class HTMLTranscoder(transcoders.JSONTranscoder):
     def loads(value):
         """Just pass through the value."""
         return value
+
+
+class FormTranscoder(handlers.TextContentHandler):
+    def __init__(self):
+        super().__init__('application/x-www-form-urlencoded', dumps=self.dumps,
+                         loads=self.loads, default_encoding='utf-8')
+
+    def dumps(self, inst_data) -> str:
+        return urllib.parse.urlencode(inst_data)
+
+    def loads(self, data):
+        return parse_form_body(data)

--- a/imbi/user.py
+++ b/imbi/user.py
@@ -2,6 +2,7 @@
 User Model supporting both LDAP and PostgreSQL data sources
 
 """
+import dataclasses
 import datetime
 import logging
 import typing
@@ -29,6 +30,13 @@ class Group:
     def __repr__(self):
         return '<Group name={} permissions={}>'.format(
             self.name, self.permissions)
+
+
+@dataclasses.dataclass
+class ConnectedIntegration:
+    """The connection between a user and a specific integration."""
+    name: str
+    external_id: str
 
 
 class User:
@@ -59,6 +67,11 @@ class User:
       FROM v1.groups AS a
       JOIN v1.group_members AS b ON b.group = a.name
      WHERE b.username = %(username)s;"""
+
+    SQL_INTEGRATIONS = """\
+    SELECT integration AS name, external_id
+      FROM v1.user_oauth2_tokens
+     WHERE username = %(username)s;"""
 
     SQL_REFRESH = """\
     SELECT username, created_at, last_seen_at, user_type, external_id,
@@ -112,6 +125,7 @@ class User:
         self.display_name: typing.Optional[str] = None
         self.password = password
         self.token = token
+        self.connected_integrations: typing.List[ConnectedIntegration] = []
         self.groups: typing.List[Group] = []
         self.permissions: typing.List[str] = []
 
@@ -144,7 +158,9 @@ class User:
             'password': self._application.encrypt_value(
                 'password', self.password),
             'permissions': self.permissions,
-            'last_refreshed_at': timestamp.isoformat(self.last_refreshed_at)
+            'last_refreshed_at': timestamp.isoformat(self.last_refreshed_at),
+            'integrations': sorted(list(set(
+                app.name for app in self.connected_integrations))),
         }
 
     async def authenticate(self) -> bool:
@@ -248,12 +264,16 @@ class User:
             result = await conn.execute(
                 self.SQL_REFRESH, {'username': self.username},
                 'user-refresh')
+        if result:
             self._assign_values(result.row)
-        self.groups = await self._db_groups()
-        self.permissions = sorted(set(
-            chain.from_iterable([g.permissions for g in self.groups])))
-        self.last_refreshed_at = max(
-            timestamp.utcnow(), self.last_seen_at or timestamp.utcnow())
+            self.groups = await self._db_groups()
+            self.permissions = sorted(set(
+                chain.from_iterable([g.permissions for g in self.groups])))
+            self.connected_integrations = await self._refresh_integrations()
+            self.last_refreshed_at = max(
+                timestamp.utcnow(), self.last_seen_at or timestamp.utcnow())
+        else:
+            self._reset()
 
     async def _ldap_auth(self) -> bool:
         """Authenticate via LDAP"""
@@ -306,7 +326,17 @@ class User:
         self.groups = await self._db_groups()
         self.permissions = sorted(set(
             chain.from_iterable([g.permissions for g in self.groups])))
+        self.connected_integrations = await self._refresh_integrations()
         self.last_refreshed_at = max(timestamp.utcnow(), self.last_seen_at)
+
+    async def _refresh_integrations(self) -> typing.Sequence[
+            ConnectedIntegration]:
+        """Fetch connected integration details from the DB."""
+        async with self._application.postgres_connector(
+                on_error=self.on_postgres_error) as conn:
+            result = await conn.execute(
+                self.SQL_INTEGRATIONS, {'username': self.username})
+            return [ConnectedIntegration(**r) for r in result]
 
     def _reset(self) -> None:
         """Reset the internally assigned values associated with this user
@@ -314,15 +344,16 @@ class User:
 
         """
         self._ldap_conn = None
-        self.created_at: typing.Optional[datetime.datetime] = None
-        self.last_seen_at: typing.Optional[datetime.datetime] = None
+        self.created_at = None
+        self.last_seen_at = None
         self.user_type = 'internal'
-        self.external_id: typing.Optional[str] = None
-        self.email_address: typing.Optional[str] = None
-        self.display_name: typing.Optional[str] = None
-        self.groups: typing.List[Group] = []
-        self.permissions: typing.List[str] = []
-        self.last_refreshed_at: typing.Optional[datetime.datetime] = None
+        self.external_id = None
+        self.email_address = None
+        self.display_name = None
+        self.groups = []
+        self.permissions = []
+        self.last_refreshed_at = None
+        self.connected_integrations = []
 
     async def _token_auth(self) -> bool:
         """Validate via v1.authentication_tokens table"""

--- a/imbi/user.py
+++ b/imbi/user.py
@@ -159,8 +159,8 @@ class User:
                 'password', self.password),
             'permissions': self.permissions,
             'last_refreshed_at': timestamp.isoformat(self.last_refreshed_at),
-            'integrations': sorted(list(set(
-                app.name for app in self.connected_integrations))),
+            'integrations': sorted({
+                app.name for app in self.connected_integrations}),
         }
 
     async def authenticate(self) -> bool:

--- a/openapi/src/endpoints/integrations.yaml
+++ b/openapi/src/endpoints/integrations.yaml
@@ -23,6 +23,9 @@ paths:
           application/json:
             schema:
               $ref: '../schemas/integration.yaml#/write'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '../schemas/integration.yaml#/write'
       responses:
         '200':
           description: Success

--- a/openapi/src/endpoints/integrations.yaml
+++ b/openapi/src/endpoints/integrations.yaml
@@ -48,3 +48,11 @@ paths:
             application/json:
               schema:
                 $ref: '../schemas/integration.yaml#/read'
+    delete:
+      description: Remove the specified integration
+      summary: Delete an integration
+      tags: [Integrations]
+      responses:
+        '204': { $ref: '../components/responses.yaml#/RecordRemoved' }
+        '401': { $ref: '../components/responses.yaml#/Unauthorized' }
+        '404': { $ref: '../components/responses.yaml#/NotFound' }

--- a/openapi/src/endpoints/integrations.yaml
+++ b/openapi/src/endpoints/integrations.yaml
@@ -13,6 +13,26 @@ paths:
                 type: array
                 items:
                   $ref: '../schemas/integration.yaml#/read'
+    post:
+      description: Add a new integration
+      summary: Add integration
+      tags: [Integrations]
+      requestBody:
+        description: Integration details
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/integration.yaml#/write'
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  name:
+                    type: string
   manage:
     get:
       description: Retrieve a specific integration by name

--- a/openapi/src/endpoints/integrations.yaml
+++ b/openapi/src/endpoints/integrations.yaml
@@ -1,0 +1,27 @@
+paths:
+  collection:
+    get:
+      description: Retrieve the collection of integrations
+      summary: Get integrations
+      tags: [Integrations]
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '../schemas/integration.yaml#/read'
+  manage:
+    get:
+      description: Retrieve a specific integration by name
+      summary: Fetch a single integration
+      tags: [Integrations]
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '../schemas/integration.yaml#/read'

--- a/openapi/src/main.yaml
+++ b/openapi/src/main.yaml
@@ -47,6 +47,8 @@ paths:
   /metrics: { $ref: 'endpoints/metrics.yaml#/paths/metrics' }
   /namespaces: { $ref: 'endpoints/namespace.yaml#/paths/collection' }
   /namespaces/{id}: { $ref: 'endpoints/namespace.yaml#/paths/manage' }
+  /integrations: { $ref: 'endpoints/integrations.yaml#/paths/collection' }
+  /integrations/{name}: { $ref: 'endpoints/integrations.yaml#/paths/manage' }
   /operations-log: { '$ref': 'endpoints/operations_log.yaml#/paths/collection' }
   /operations-log/{id}: { '$ref': 'endpoints/operations_log.yaml#/paths/manage' }
   /permissions: { $ref: 'endpoints/permissions.yaml#/paths/collection' }
@@ -159,6 +161,8 @@ tags:
     description: Endpoints used to report on the state of various objects in Imbi
   - name: Settings
     description: Endpoints used for retrieving settings for the Imbi UI
+  - name: Integrations
+    description: Endpoints used to retrieve information about applications that Imbi is integrated with
   - name: Monitoring & Metrics
     description: |-
       Endpoints used for health checking, service status, and service metrics
@@ -176,6 +180,7 @@ x-tagGroups:
     tags:
       - Cookie Cutters
       - Environments
+      - Integrations
       - Namespaces
       - Fact Types
       - Fact Type Enums

--- a/openapi/src/schemas/integration.yaml
+++ b/openapi/src/schemas/integration.yaml
@@ -1,0 +1,19 @@
+read:
+  type: object
+  properties:
+    name:
+      type: string
+    api_endpoint:
+      type: string
+    callback_url:
+      type: string
+    authorization_endpoint:
+      type: string
+    token_endpoint:
+      type: string
+    revoke_endpoint:
+      type: string
+    client_id:
+      type: string
+  required: [name, api_endpoint, callback_url, authorization_endpoint, token_endpoint, revoke_endpoint, client_id]
+  additionalProperties: false

--- a/openapi/src/schemas/integration.yaml
+++ b/openapi/src/schemas/integration.yaml
@@ -17,3 +17,29 @@ read:
       type: string
   required: [name, api_endpoint, callback_url, authorization_endpoint, token_endpoint, revoke_endpoint, client_id]
   additionalProperties: false
+
+write:
+  type: object
+  properties:
+    name:
+      type: string
+    api_endpoint:
+      type: string
+    callback_url:
+      type: string
+    authorization_endpoint:
+      type: string
+    token_endpoint:
+      type: string
+    revoke_endpoint:
+      type: string
+      nullable: true
+    client_id:
+      type: string
+    client_secret:
+      type: string
+      nullable: true
+    public_client:
+      type: boolean
+  required: [name, api_endpoint, callback_url, authorization_endpoint, token_endpoint, revoke_endpoint, client_id, client_secret, public_client]
+  additionalProperties: false

--- a/openapi/src/schemas/project.yaml
+++ b/openapi/src/schemas/project.yaml
@@ -44,6 +44,22 @@ read:
     archived:
       description: Indicates that the project is archived
       type: boolean
+    gitlab_project_id:
+      description: Optional project ID for the associated gitlab project
+      type: integer
+      nullable: true
+    sentry_project_slug:
+      description: Optional slug for the project in sentry
+      type: string
+      nullable: true
+    sonarqube_project_key:
+      description: Optional slug for the project in SonarQube
+      type: string
+      nullable: true
+    pagerduty_service_id:
+      description: Optional ID for the project in PagerDuty
+      type: string
+      nullable: true
   additionalProperties: false
 
 write:

--- a/setup.cfg
+++ b/setup.cfg
@@ -62,6 +62,7 @@ install_requires =
     pyyaml
     sprockets.http>2,<3
     sprockets.mixins.correlation>=2,<3
+    sprockets.mixins.http>=2.2,<3
     sprockets.mixins.mediatype>3,<4
     sprockets-postgres>=1.8.1,<2
     tornado>6,<7
@@ -69,6 +70,7 @@ install_requires =
     tornado_openapi3>=0.2.4,<1
     u-msgpack-python>=2.1,<3
     validators
+    yarl>=1.6,<2
 
 packages = find:
 zip_safe = true

--- a/tests/endpoints/test_project_endpoints.py
+++ b/tests/endpoints/test_project_endpoints.py
@@ -91,7 +91,11 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
             'project_type': self.project_type_name,
             'created_by': self.USERNAME[self.ADMIN_ACCESS],
             'last_modified_by': None,
-            'archived': False
+            'archived': False,
+            'gitlab_project_id': None,
+            'pagerduty_service_id': None,
+            'sentry_project_slug': None,
+            'sonarqube_project_key': None,
         })
         self.assertDictEqual(record, response)
 
@@ -168,7 +172,11 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
             'created_by': self.USERNAME[self.ADMIN_ACCESS],
             'description': None,
             'last_modified_by': None,
-            'archived': False
+            'archived': False,
+            'gitlab_project_id': None,
+            'pagerduty_service_id': None,
+            'sentry_project_slug': None,
+            'sonarqube_project_key': None,
         })
         self.assertDictEqual(record, response)
 

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -97,7 +97,8 @@ class InternalTestCase(base.TestCase):
             'display_name': user_value['display_name'],
             'email_address': user_value['email_address'],
             'groups': [group_value['name']],
-            'permissions': sorted(set(group_value['permissions']))
+            'permissions': sorted(set(group_value['permissions'])),
+            'integrations': [],
         }
         self.assertDictEqual(values, expectation)
 
@@ -147,7 +148,8 @@ class InternalTestCase(base.TestCase):
             'display_name': display_name,
             'email_address': user_value['email_address'],
             'groups': [group_value['name']],
-            'permissions': sorted(set(group_value['permissions']))
+            'permissions': sorted(set(group_value['permissions'])),
+            'integrations': [],
         }
         self.assertDictEqual(values, expectation)
 
@@ -242,7 +244,8 @@ class LDAPTestCase(base.TestCase):
             'display_name': 'Its Imbi',
             'email_address': 'imbi@example.org',
             'groups': ['admin', 'imbi'],
-            'permissions': ['admin', 'reader']
+            'permissions': ['admin', 'reader'],
+            'integrations': [],
         }
         self.assertDictEqual(values, expectation)
         self.assertTrue(obj.has_permission('admin'))

--- a/ui/public/locales/en.js
+++ b/ui/public/locales/en.js
@@ -297,7 +297,8 @@ export default {
           userType: 'User Type',
           externalId: 'External ID',
           emailAddress: 'Email Address',
-          groups: 'Groups'
+          groups: 'Groups',
+          integrations: 'Integrated Applications'
         },
         settings: {
           title: 'User Settings',

--- a/ui/public/locales/en.js
+++ b/ui/public/locales/en.js
@@ -15,6 +15,8 @@ export default {
         icon: 'Icon',
         iconClass: 'Icon Class',
         id: 'ID',
+        import: 'Import',
+        importing: 'Importing',
         initializing: 'Initializing',
         invalidURL: 'Value does not appear to be a URL',
         lastUpdated: 'Last Updated: {{date}}',
@@ -76,6 +78,7 @@ export default {
       headerNavItems: {
         administration: 'Administration',
         dashboard: 'Dashboard',
+        importProject: 'Import from Gitlab',
         newOperationsLogEntry: 'Add Ops Log Entry',
         newProject: 'New Project',
         openNewMenu: 'Open New Menu',
@@ -235,6 +238,10 @@ export default {
         editProject: 'Edit Project',
         environments: 'Environments',
         factHistory: 'Fact History',
+        gitlab: {
+          namespace: 'Gitlab Folder',
+          project: 'Gitlab Project'
+        },
         links: 'Links',
         linksSaved: 'Links Saved',
         logs: 'Logs',

--- a/ui/src/js/components/Form/SimpleForm.jsx
+++ b/ui/src/js/components/Form/SimpleForm.jsx
@@ -11,7 +11,9 @@ function SimpleForm({
   onCancel,
   onSubmit,
   ready,
-  saving
+  saving,
+  submitButtonText,
+  submitSavingText
 }) {
   const { t } = useTranslation()
   return (
@@ -37,7 +39,13 @@ function SimpleForm({
           className={'btn-green'}
           disabled={ready === false || saving === true}
           type="submit">
-          {saving ? t('common.saving') : t('common.save')}
+          {saving
+            ? submitSavingText
+              ? submitSavingText
+              : t('common.save')
+            : submitButtonText
+            ? submitButtonText
+            : t('common.saving')}
         </Button>
       </div>
     </form>
@@ -46,7 +54,9 @@ function SimpleForm({
 SimpleForm.defaultPropTypes = {
   errorMessage: null,
   ready: false,
-  saving: false
+  saving: false,
+  submitSavingText: null,
+  submitButtonText: null
 }
 SimpleForm.propTypes = {
   children: PropTypes.arrayOf(Field),
@@ -54,6 +64,8 @@ SimpleForm.propTypes = {
   onCancel: PropTypes.func.isRequired,
   onSubmit: PropTypes.func.isRequired,
   ready: PropTypes.bool.isRequired,
-  saving: PropTypes.bool.isRequired
+  saving: PropTypes.bool.isRequired,
+  submitButtonText: PropTypes.string,
+  submitSavingText: PropTypes.string
 }
 export { SimpleForm }

--- a/ui/src/js/components/Header/Header.jsx
+++ b/ui/src/js/components/Header/Header.jsx
@@ -31,7 +31,7 @@ function Header({ logo, service, authenticated, user }) {
         {authenticated === true && (
           <Fragment>
             <NavMenu user={user} />
-            <NewMenu />
+            <NewMenu user={user} />
             <UserMenu user={user} />
           </Fragment>
         )}

--- a/ui/src/js/components/Header/NewMenu.jsx
+++ b/ui/src/js/components/Header/NewMenu.jsx
@@ -5,6 +5,7 @@ import PropTypes from 'prop-types'
 import { useTranslation } from 'react-i18next'
 
 import { Icon } from '../'
+import { User } from '../../schema'
 
 function NewMenuItem({ value, to }) {
   return (
@@ -24,7 +25,7 @@ NewMenuItem.propTypes = {
   to: PropTypes.string.isRequired
 }
 
-function NewMenu() {
+function NewMenu({ user }) {
   const { t } = useTranslation()
   return (
     <Menu as="div" className="flex-shrink mr-3">
@@ -46,11 +47,19 @@ function NewMenu() {
           to="/ui/projects/create"
           value={t('headerNavItems.newProject')}
         />
+        {user.integrations.includes('gitlab') && (
+          <NewMenuItem
+            to="/ui/projects/import"
+            value={t('headerNavItems.importProject')}
+          />
+        )}
       </Menu.Items>
     </Menu>
   )
 }
 
-NewMenu.propTypes = {}
+NewMenu.propTypes = {
+  user: PropTypes.shape(User)
+}
 
 export { NewMenu }

--- a/ui/src/js/metadata.js
+++ b/ui/src/js/metadata.js
@@ -39,6 +39,20 @@ function useMetadata(externalRefresh = false) {
   const [timerHandle, setTimerHandle] = useState(null)
   const [refresh, setRefresh] = useState(true)
   const [values, setValues] = useState(undefined)
+  const [gitlabDetails, setGitlabDetails] = useState({
+    authorizationEndpoint: null,
+    clientId: null,
+    redirectURI: null
+  })
+
+  function processGitlabResponse(data) {
+    setGitlabDetails({
+      ...gitlabDetails,
+      authorizationEndpoint: data.authorization_endpoint,
+      clientId: data.client_id,
+      redirectURI: data.callback_url
+    })
+  }
 
   function get(path, onSuccess, key) {
     httpGet(state.fetch, new URL(path, state.baseURL), onSuccess, (error) => {
@@ -60,6 +74,7 @@ function useMetadata(externalRefresh = false) {
       get('/project-fact-types', setProjectFactTypes, 'projectFactTypes')
       get('/project-link-types', setProjectLinkTypes, 'projectLinkTypes')
       get('/project-types', setProjectTypes, 'projectTypes')
+      get('/integrations/gitlab', processGitlabResponse, '')
       setLastUpdated(Date.now())
       setRefresh(false)
     }
@@ -92,6 +107,7 @@ function useMetadata(externalRefresh = false) {
       setValues({
         cookieCutters: cookieCutters,
         environments: environments,
+        gitlabDetails: gitlabDetails,
         groups: groups,
         namespaces: namespaces,
         projectFactTypes: projectFactTypes,
@@ -102,6 +118,7 @@ function useMetadata(externalRefresh = false) {
   }, [
     cookieCutters,
     environments,
+    gitlabDetails,
     groups,
     namespaces,
     projectFactTypes,

--- a/ui/src/js/schema/User.js
+++ b/ui/src/js/schema/User.js
@@ -11,5 +11,6 @@ export const User = {
   groups: PropTypes.arrayOf(PropTypes.string),
   permissions: PropTypes.arrayOf(PropTypes.string),
   last_refreshed_at: PropTypes.string,
-  last_seen_at: PropTypes.string
+  last_seen_at: PropTypes.string,
+  integrations: PropTypes.arrayOf(PropTypes.string)
 }

--- a/ui/src/js/views/Main.jsx
+++ b/ui/src/js/views/Main.jsx
@@ -58,6 +58,9 @@ function Main({ user }) {
                 <Route path="/ui/projects/create">
                   <Project.Create user={user} />
                 </Route>
+                <Route path="/ui/projects/import">
+                  <Project.GitlabImport user={user} />
+                </Route>
                 <Route path="/ui/projects/:projectId">
                   <Project.Detail user={user} />
                 </Route>

--- a/ui/src/js/views/Project/GitlabImport.jsx
+++ b/ui/src/js/views/Project/GitlabImport.jsx
@@ -1,0 +1,212 @@
+import PropTypes from 'prop-types'
+import React, { useContext, useEffect, useState } from 'react'
+import { User } from '../../schema'
+import { ErrorBoundary, Form } from '../../components'
+import { useTranslation } from 'react-i18next'
+import { asOptions } from '../../metadata'
+import { Context } from '../../state'
+import { httpGet, httpPost } from '../../utils'
+import { useHistory } from 'react-router-dom'
+
+function GitlabImport({ user }) {
+  const emptyErrors = {
+    gitlab_namespace_id: null,
+    gitlab_project_id: null,
+    namespace_id: null,
+    project_type_id: null,
+    top_level: null
+  }
+  const [errors, setErrors] = useState(emptyErrors)
+  const [state] = useContext(Context)
+  const history = useHistory()
+  const { t } = useTranslation()
+  const [formReady, setFormReady] = useState(false)
+  const [formValues, setFormValues] = useState({
+    gitlab_namespace_id: null,
+    gitlab_project_id: null,
+    namespace_id: null,
+    project_type_id: null
+  })
+  const [formState, setFormState] = useState({
+    namespaceSelected: false,
+    projectName: null,
+    projectURL: null,
+    saving: false
+  })
+  const [namespaces, setNamespaces] = useState([])
+  const [projects, setProjects] = useState([])
+
+  function onValueChange(key, value) {
+    let values = { ...formValues, [key]: value }
+    if (key === 'gitlab_namespace_id') {
+      values.gitlab_project_id = null
+      setErrors({ ...errors, gitlab_project_id: null })
+      setProjects([])
+      setFormState({
+        ...formState,
+        namespaceSelected: false,
+        projectName: null
+      })
+      if (value) {
+        let url = new URL('/gitlab/projects', state.baseURL)
+        url.searchParams.set('group_id', value)
+        httpGet(
+          state.fetch,
+          url,
+          (data) => {
+            setErrors({ ...errors, [key]: null })
+            if (data.length) {
+              setFormState({ ...formState, namespaceSelected: true })
+              setProjects(data)
+            }
+          },
+          (error) => {
+            setErrors({ ...errors, [key]: error })
+          }
+        )
+      }
+    }
+    if (key === 'gitlab_project_id') {
+      const projectDetails = projects.find((elm) => elm.id === value)
+      if (projectDetails) {
+        setFormState({
+          ...formState,
+          projectName: projectDetails.name,
+          projectURL: projectDetails.web_url
+        })
+      } else {
+        setFormState({ ...formState, projectName: null })
+        if (value) {
+          setErrors({ ...errors, [key]: 'project not found' })
+        }
+      }
+    }
+    setFormValues(values)
+  }
+
+  useEffect(() => {
+    httpGet(
+      state.fetch,
+      new URL('/gitlab/namespaces', state.baseURL),
+      (data) => {
+        setNamespaces(data)
+      },
+      (error) => {
+        setErrors({ ...errors, namespace_id: error })
+      }
+    )
+  }, [])
+
+  useEffect(() => {
+    setErrors(emptyErrors)
+    setFormReady(
+      formValues.gitlab_namespace_id !== null &&
+        formValues.gitlab_project_id !== null &&
+        formValues.namespace_id !== null &&
+        formValues.project_type_id !== null
+    )
+  }, [formValues])
+
+  function importProject() {
+    setFormState({ ...formState, saving: true })
+    httpPost(state.fetch, new URL('/projects', state.baseURL), {
+      environments: ['testing'],
+      name: formState.projectName,
+      namespace_id: formValues.namespace_id,
+      project_type_id: formValues.project_type_id,
+      slug: formState.projectName
+    }).then(({ data, success }) => {
+      if (success === true) {
+        let projectId = data.id
+        const scmLink = state.metadata.projectLinkTypes.find(
+          (elm) => elm.link_type === 'scm'
+        )
+        httpPost(
+          state.fetch,
+          new URL(
+            '/projects/' + projectId.toString() + '/links',
+            state.baseURL
+          ),
+          {
+            link_type_id: scmLink.id,
+            project_id: projectId,
+            url: formState.projectURL
+          }
+        ).then(({ data, success }) => {
+          if (success === true) {
+            history.push(`/ui/projects/${projectId}`)
+          } else {
+            setErrors({ ...errors, top_level: data })
+          }
+          setFormState({ ...formState, saving: false })
+        })
+      } else {
+        setErrors({ ...errors, top_level: data })
+        setFormState({ ...formState, saving: false })
+      }
+    })
+  }
+
+  return (
+    <ErrorBoundary>
+      <Form.SimpleForm
+        errorMessage={errors.top_level}
+        ready={formReady}
+        submitButtonText={t('common.import')}
+        submitSavingText={t('common.importing')}
+        saving={formState.saving}
+        onCancel={() => {}}
+        onSubmit={importProject}>
+        <Form.Field
+          title={t('project.gitlab.namespace')}
+          name="gitlab_namespace_id"
+          type="select"
+          castTo="number"
+          options={asOptions(namespaces)}
+          onChange={onValueChange}
+          errorMessage={errors.gitlab_namespace_id}
+          required={true}
+        />
+        <Form.Field
+          title={t('project.gitlab.project')}
+          name="gitlab_project_id"
+          type="select"
+          castTo="number"
+          options={asOptions(projects)}
+          onChange={onValueChange}
+          errorMessage={errors.gitlab_project_id}
+          required={true}
+          enabled={formState.namespaceSelected}
+          disabled={!formState.namespaceSelected}
+        />
+        <Form.Field
+          title={t('project.namespace')}
+          name="namespace_id"
+          type="select"
+          autoFocus={true}
+          castTo="number"
+          options={asOptions(state.metadata.namespaces)}
+          onChange={onValueChange}
+          errorMessage={errors.namespace_id}
+          required={true}
+        />
+        <Form.Field
+          title={t('project.projectType')}
+          name="project_type_id"
+          type="select"
+          castTo="number"
+          options={asOptions(state.metadata.projectTypes)}
+          onChange={onValueChange}
+          errorMessage={errors.project_type_id}
+          required={true}
+        />
+      </Form.SimpleForm>
+    </ErrorBoundary>
+  )
+}
+
+GitlabImport.propTypes = {
+  user: PropTypes.exact(User)
+}
+
+export { GitlabImport }

--- a/ui/src/js/views/Project/index.js
+++ b/ui/src/js/views/Project/index.js
@@ -1,7 +1,9 @@
 import { Create } from './Create'
+import { GitlabImport } from './GitlabImport'
 import { Project as Detail } from './Project'
 
 export const Project = {
   Create: Create,
-  Detail: Detail
+  Detail: Detail,
+  GitlabImport: GitlabImport
 }

--- a/ui/src/js/views/User/Profile.jsx
+++ b/ui/src/js/views/User/Profile.jsx
@@ -51,7 +51,16 @@ function Profile({ user }) {
   const [state, dispatch] = useContext(Context)
   const { t } = useTranslation()
 
-  function redirectToGitlab() {}
+  function redirectToGitlab(e) {
+    e.preventDefault()
+    document.location =
+      `${state.metadata.gitlabDetails.authorizationEndpoint}` +
+      `?client_id=${state.metadata.gitlabDetails.clientId}` +
+      `&redirect_uri=${state.metadata.gitlabDetails.redirectURI}` +
+      `&response_type=code` +
+      `&state=${user.username}` +
+      `&scope=api`
+  }
 
   useEffect(() => {
     dispatch({

--- a/ui/src/js/views/User/Profile.jsx
+++ b/ui/src/js/views/User/Profile.jsx
@@ -5,6 +5,7 @@ import { useTranslation } from 'react-i18next'
 
 import { Context } from '../../state'
 import { User } from '../../schema'
+import { Button } from '../../components'
 
 function Groups({ groups }) {
   return (
@@ -50,6 +51,8 @@ function Profile({ user }) {
   const [state, dispatch] = useContext(Context)
   const { t } = useTranslation()
 
+  function redirectToGitlab() {}
+
   useEffect(() => {
     dispatch({
       type: 'SET_PAGE',
@@ -87,6 +90,13 @@ function Profile({ user }) {
           <Item label={t('user.profile.groups')}>
             <Groups groups={user.groups} />
           </Item>
+          <Item
+            label={t('user.profile.integrations')}
+            value={user.integrations.join()}
+          />
+          {!user.integrations.includes('gitlab') && (
+            <Button onClick={redirectToGitlab}>Connect to gitlab</Button>
+          )}
         </dl>
       </div>
     </div>


### PR DESCRIPTION
The PR implements some new functionality:
- adds gitlab, sonar, sentry, and pager duty link properties to a project
- allows a user to "connect to gitlab" that results in imbi having OAuth 2 access to gitlab bound to the user
- allows a gitlab connected user to import a gitlab repository and create a matching imbi project
- stores the gitlab project ID in the project details

This should close #10 

If anyone is interested in playing with this, you will need to create a personal OAuth 2 application in gitlab as described in the CONTRIBUTING changes in f3edae4f7e4e10ad10185b577c17ba6e2aa3fc1f.  You will also want to have a local user to connect to gitlab with.  The email address of the user in LDAP needs to match the email address of the gitlab user.  I added some notes [to CONTRIBUTING on how to create a new LDAP user](https://github.com/aweber/imbi/commit/be307a154b6374930ca6084e118671f4fd654886).

# Assistance needed
I am not enough of a JS/React programmer to come close to making the UI look nice at this point.  If anyone can lend a hand, it would be much appreciated.  The connection UI is a poorly formatted button on the user profile.  Once connected, the "Import from Gitlab" option becomes available which has a simple (and slightly better formatted) dialog for selecting the gitlab group & project to import and the imbi namespace & project type.