### PR TITLE
Create gitlab project

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -74,6 +74,7 @@ EOF
 cat > build/debug.yaml <<EOF
 ---
 http:
+  canonical_server_name: imbi.localhost
   processes: 1
 javascript_url: http://localhost:8080/static/
 ldap:
@@ -122,6 +123,8 @@ EOF
 
 cat > build/test.yaml <<EOF
 ---
+http:
+  canonical_server_name: imbi.example.org
 ldap:
   enabled: true
   host: ${TEST_HOST}

--- a/bootstrap
+++ b/bootstrap
@@ -73,6 +73,9 @@ EOF
 
 cat > build/debug.yaml <<EOF
 ---
+automations:
+  gitlab:
+    repository_link_id: ~
 http:
   canonical_server_name: imbi.localhost
   processes: 1
@@ -123,6 +126,9 @@ EOF
 
 cat > build/test.yaml <<EOF
 ---
+automations:
+  gitlab:
+    repository_link_id: ~
 http:
   canonical_server_name: imbi.example.org
 ldap:

--- a/ddl/tables/v1/namespaces.sql
+++ b/ddl/tables/v1/namespaces.sql
@@ -9,7 +9,8 @@ CREATE TABLE IF NOT EXISTS namespaces (
   "name"            TEXT                      NOT NULL  UNIQUE,
   slug              TEXT                      NOT NULL  UNIQUE,
   icon_class        TEXT                      NOT NULL,
-  maintained_by     TEXT[]);
+  maintained_by     TEXT[],
+  gitlab_group_name TEXT);
 
 COMMENT ON TABLE namespaces IS 'Organizational Teams';
 COMMENT ON COLUMN namespaces.id IS 'Surrogate key for URLs and linking';
@@ -21,6 +22,7 @@ COMMENT ON COLUMN namespaces.name IS 'Team name';
 COMMENT ON COLUMN namespaces.slug IS 'Team path slug';
 COMMENT ON COLUMN namespaces.icon_class IS 'Font Awesome UI icon class';
 COMMENT ON COLUMN namespaces.maintained_by IS 'Optional groups that have access to modify projects in the namespace';
+COMMENT ON COLUMN namespaces.gitlab_group_name IS 'Optional name of the corresponding group in GitLab';
 
 GRANT SELECT ON namespaces TO reader;
 GRANT SELECT, INSERT, UPDATE, DELETE ON namespaces TO admin;

--- a/ddl/tables/v1/project_types.sql
+++ b/ddl/tables/v1/project_types.sql
@@ -1,17 +1,18 @@
 SET search_path=v1;
 
 CREATE TABLE IF NOT EXISTS project_types (
-  id                 SERIAL                    NOT NULL  PRIMARY KEY,
-  created_at         TIMESTAMP WITH TIME ZONE  NOT NULL  DEFAULT CURRENT_TIMESTAMP,
-  created_by         TEXT                      NOT NULL,
-  last_modified_at   TIMESTAMP WITH TIME ZONE,
-  last_modified_by   TEXT,
-  "name"             TEXT                      NOT NULL,
-  slug               TEXT                      NOT NULL,
-  plural_name        TEXT                      NOT NULL,
-  description        TEXT,
-  icon_class         TEXT                                DEFAULT 'fas fa-box',
-  environment_urls   BOOLEAN                   NOT NULL  DEFAULT false
+  id                    SERIAL                    NOT NULL  PRIMARY KEY,
+  created_at            TIMESTAMP WITH TIME ZONE  NOT NULL  DEFAULT CURRENT_TIMESTAMP,
+  created_by            TEXT                      NOT NULL,
+  last_modified_at      TIMESTAMP WITH TIME ZONE,
+  last_modified_by      TEXT,
+  "name"                TEXT                      NOT NULL,
+  slug                  TEXT                      NOT NULL,
+  plural_name           TEXT                      NOT NULL,
+  description           TEXT,
+  icon_class            TEXT                                DEFAULT 'fas fa-box',
+  environment_urls      BOOLEAN                   NOT NULL  DEFAULT false,
+  gitlab_project_prefix TEXT
 );
 
 CREATE UNIQUE INDEX project_types_name ON project_types (name);
@@ -28,6 +29,7 @@ COMMENT ON COLUMN project_types.slug IS 'Slug used when creating namespace URLs'
 COMMENT ON COLUMN project_types.description IS 'Project Type Description';
 COMMENT ON COLUMN project_types.icon_class IS 'Font Awesome UI icon class';
 COMMENT ON COLUMN project_types.environment_urls IS 'Indicates projects of this type have per-environment URLs';
+COMMENT ON COLUMN project_types.gitlab_project_prefix IS 'Path prefix to use when creating projects of this type in GitLab';
 
 GRANT SELECT ON project_types TO reader;
 GRANT SELECT, INSERT, UPDATE, DELETE ON project_types TO admin;

--- a/decisions/0010-automation-configuration.md
+++ b/decisions/0010-automation-configuration.md
@@ -1,0 +1,70 @@
+# 10. Automations
+
+Date: 2021-06-28
+
+## Status
+
+Draft
+
+## Context
+
+Automations are simply pieces of code that are invoked when an action is taken
+in the UI.  They are meant to automate some amount of manual labor.  For
+example, the first automation that was added creates a repository in GitLab
+when a project is created in Imbi.  The automation is fired from the UI when
+the user enables the "Create project in gitlab" option when creating a new
+project.
+
+The GitLab repository creation automation requires some information to do
+what it does:
+
+* GitLab group that the project will be created in
+* Path within the group to create the project
+* Which project link should be updated with the repo path
+
+The GitLab group is tied to the Imbi namespace that the user created the
+project under.  Since the Imbi namespace is flat, the SCM path is formed by
+concatenating a prefix based on the project type to the GitLab group.  For
+example, creating a new "HTTP API" in the "Operations" Imbi namespace might
+result in the project being created in `.../OPS/applications/apis`.  The
+GitLab group is determined by the Imbi namespace so "Operations" needs to be
+configured to map to the SCM prefix of "/OPS".  Similarly, "HTTP API"
+project types are always placed in the "/applications/api" folder.
+
+The project link is a little different since it is up to the user to create
+a generic "GitLab SCM" link type if one is desired.  Even if one exists, it
+might make sense to not automatically populate it.  This is only one type of
+"well-known identfier" that an automation may need to know.  Since they are
+not necessarily tied to existing database tables or concepts, it makes sense
+for them to be configured manually.  
+
+> In general, if an automation needs to add data to Imbi that is not a core
+> data value, then the automation should be configured with the necessary
+> information instead of guessing.
+
+## Decision
+
+### SCM path calcuations
+
+The SCM path is simply the prefix configured on the Imbi namespace followed
+by the suffix configured for the Imbi project type.
+
+### Well-known Imbi Identifiers
+
+I decided to add a sub-tree to the configuration file named `automations` at
+the root.  The immediate child is the name of the automation that is being
+configured with the entire sub-tree being controlled by the automation.  The
+*current* implementation of the GitLab project creation automation uses this
+to know whether it should add a project link for the SCM location or not.
+
+## Consequences
+
+* The Imbi namespace portion of the SCM path allows for different groups to
+  be rooted in different parts of the SCM namespace
+* The Imbi project type portion of the SCM path ensures that different groups
+  use the same internal structure for different project types
+* Separating the SCM path into two components provides flexibility for a
+  variety of SCM layouts while maintaining a decent amount of consistency
+* Using explicit configuration in automations for "well-known identifiers"
+  removes some of the magic of discovering them or the headaches around 
+  having automations modify the database/data elements.

--- a/example.yaml
+++ b/example.yaml
@@ -5,6 +5,7 @@ gitlab:
   url: https://gitlab.com   # The URL to the Gitlab instance to integrate with
 
 http:
+  canonical_server_name: imbi.tld
   compress_response: true
   cookie_secret: imbi
   port: 8000

--- a/imbi/app.py
+++ b/imbi/app.py
@@ -118,7 +118,7 @@ class Application(sprockets_postgres.ApplicationMixin, app.Application):
             self._request_logger.warning(
                 REQUEST_LOG_FORMAT, status_code, handler._request_summary(),
                 request_time, handler.request.headers.get('User-Agent'))
-        if status_code > 500:
+        if status_code >= 500:
             self._request_logger.error(
                 REQUEST_LOG_FORMAT, status_code, handler._request_summary(),
                 request_time, handler.request.headers.get('User-Agent'))

--- a/imbi/app.py
+++ b/imbi/app.py
@@ -28,7 +28,8 @@ try:
 except ImportError:
     sentry_logging, sentry_tornado = None, None
 
-from imbi import endpoints, openapi, permissions, stats, transcoders, version
+from imbi import (endpoints, errors, openapi, permissions, stats, transcoders,
+                  version)
 from imbi.endpoints import default
 
 LOGGER = logging.getLogger(__name__)
@@ -66,6 +67,8 @@ class Application(sprockets_postgres.ApplicationMixin, app.Application):
         content.add_binary_content_type(
             self, 'application/json-patch+msgpack',
             umsgpack.packb, umsgpack.unpackb)
+
+        errors.set_canonical_server(self.settings['canonical_server_name'])
 
     def decrypt_value(self, key: str, value: str) -> bytes:
         """Decrypt a value that is encrypted using Tornado's secure cookie

--- a/imbi/automations.py
+++ b/imbi/automations.py
@@ -1,0 +1,120 @@
+import asyncio
+import dataclasses
+import logging
+import typing
+
+import sprockets_postgres
+
+import imbi.integrations
+import imbi.user
+from imbi.endpoints import gitlab
+
+
+@dataclasses.dataclass
+class Project:
+    description: typing.Union[str, None]
+    gitlab_project_id: typing.Union[int, None]
+    name: str
+    namespace_id: int
+    project_id: int
+    project_type_id: int
+    slug: str
+
+    @classmethod
+    def from_database(cls, row: dict) -> 'Project':
+        field_names = {f.name for f in dataclasses.fields(cls)}
+        filtered = {n: v for n, v in row.items() if n in field_names}
+        filtered['project_id'] = row['id']
+        return cls(**filtered)
+
+
+class GitLabCreateProjectAutomation:
+    def __init__(self,
+                 project: Project,
+                 user: imbi.user.User,
+                 db: sprockets_postgres.PostgresConnector):
+        self.db = db
+        self.imbi_project = project
+        self.logger = logging.getLogger(__package__).getChild(
+            self.__class__.__name__)
+        self.user = user
+
+        self._errors: typing.List[str] = []
+        self._gitlab: typing.Optional[gitlab.GitLabClient] = None
+        self._gitlab_parent: typing.Optional[dict] = None
+
+    async def prepare(self) -> typing.List[str]:
+        if self.imbi_project.gitlab_project_id is not None:
+            self._add_error('GitLab project {} already exists for {}',
+                            self.imbi_project.gitlab_project_id,
+                            self.imbi_project.slug)
+        else:
+            project_path, token = await asyncio.gather(
+                self._get_gitlab_project_path(), self._get_gitlab_token())
+            if project_path and token:
+                self._gitlab = gitlab.GitLabClient(token)
+                self._gitlab_parent = await self._get_gitlab_parent(
+                    project_path)
+
+        return self._errors
+
+    async def run(self):
+        gitlab_info = await self._gitlab.create_project(
+            self._gitlab_parent, self.imbi_project.name,
+            description=self.imbi_project.description)
+        await self.db.execute(
+            """UPDATE v1.projects
+                  SET gitlab_project_id = %(gitlab_project_id)s
+                WHERE id = %(project_id)s""",
+            {
+                'project_id': self.imbi_project.project_id,
+                'gitlab_project_id': gitlab_info['id'],
+            })
+        return gitlab_info
+
+    def _add_error(self, msg_format, *args):
+        message = msg_format.format(*args)
+        self.logger.warning('%s', message)
+        self._errors.append(message)
+
+    async def _get_gitlab_project_path(self) -> typing.Union[
+            typing.Tuple[str, str], None]:
+        result = await self.db.execute(
+            """SELECT p.gitlab_project_id,
+                      n.slug AS namespace_slug,
+                      n.gitlab_group_name,
+                      t.slug AS type_slug,
+                      t.gitlab_project_prefix
+                 FROM v1.projects AS p
+                 JOIN v1.namespaces AS n ON (n.id = p.namespace_id)
+                 JOIN v1.project_types AS t ON (t.id = p.project_type_id)
+                WHERE p.id = %(project_id)s
+            """,
+            {'project_id': self.imbi_project.project_id})
+        if result.row_count == 0:
+            self._add_error('project row not found for {}',
+                            self.imbi_project.project_id)
+        elif result.row['gitlab_group_name'] is None:
+            self._add_error('GitLab group is not defined for namespace {}',
+                            result.row['namespace_slug'])
+        elif result.row['gitlab_project_prefix'] is None:
+            self._add_error('GitLab prefix is not defined for project type {}',
+                            result.row['type_slug'])
+        else:
+            return (result.row['gitlab_group_name'],
+                    result.row['gitlab_project_prefix'])
+        return None
+
+    async def _get_gitlab_token(self) -> typing.Union[
+            imbi.integrations.IntegrationToken, None]:
+        tokens = await self.user.fetch_integration_tokens('gitlab')
+        if not tokens:
+            self._add_error('GitLab token not found for current user')
+            return None
+        return tokens[0]
+
+    async def _get_gitlab_parent(self, path) -> dict:
+        gitlab_parent = await self._gitlab.fetch_group(*path)
+        if not gitlab_parent:
+            self._add_error('GitLab path {} does not exist', '/'.join(path))
+        return gitlab_parent

--- a/imbi/endpoints/__init__.py
+++ b/imbi/endpoints/__init__.py
@@ -104,6 +104,7 @@ URLS = [
             project_urls.RecordRequestHandler,
             name='project-url'),
     web.url(r'^/status$', status.RequestHandler),
+    web.url(r'^/ui/automations/gitlab/create', ui.GitLabCreationAutomation),
     web.url(r'^/ui/login$', ui.LoginRequestHandler),
     web.url(r'^/ui/logout$', ui.LogoutRequestHandler),
     web.url(r'^/ui/user$', ui.UserRequestHandler),

--- a/imbi/endpoints/namespaces.py
+++ b/imbi/endpoints/namespaces.py
@@ -6,13 +6,15 @@ from imbi.endpoints import base
 class _RequestHandlerMixin:
 
     ID_KEY = 'id'
-    FIELDS = ['id', 'name', 'slug', 'icon_class', 'maintained_by']
+    FIELDS = ['id', 'name', 'slug', 'icon_class', 'maintained_by',
+              'gitlab_group_name']
     DEFAULTS = {'icon_class': 'fas fa-users', 'maintained_by': []}
 
     GET_SQL = re.sub(r'\s+', ' ', """\
         SELECT id, "name", created_at, created_by,
                last_modified_at, last_modified_by,
-               slug, icon_class, maintained_by
+               slug, icon_class, maintained_by,
+               gitlab_group_name
           FROM v1.namespaces WHERE id=%(id)s""")
 
 
@@ -23,14 +25,15 @@ class CollectionRequestHandler(_RequestHandlerMixin,
     ITEM_NAME = 'namespace'
 
     COLLECTION_SQL = re.sub(r'\s+', ' ', """ \
-        SELECT id, "name", slug, icon_class, maintained_by
+        SELECT id, "name", slug, icon_class, maintained_by, gitlab_group_name
           FROM v1.namespaces ORDER BY "name" ASC""")
 
     POST_SQL = re.sub(r'\s+', ' ', """\
         INSERT INTO v1.namespaces
-                    ("name", created_by, slug, icon_class, "maintained_by")
+                    ("name", created_by, slug, icon_class, "maintained_by",
+                     gitlab_group_name)
              VALUES (%(name)s, %(username)s, %(slug)s, %(icon_class)s,
-                     %(maintained_by)s)
+                     %(maintained_by)s, %(gitlab_group_name)s)
           RETURNING id""")
 
 
@@ -47,5 +50,6 @@ class RecordRequestHandler(_RequestHandlerMixin, base.AdminCRUDRequestHandler):
                last_modified_by = %(username)s,
                slug = %(slug)s,
                icon_class = %(icon_class)s,
-               "maintained_by" = %(maintained_by)s
+               "maintained_by" = %(maintained_by)s,
+               gitlab_group_name = %(gitlab_group_name)s
          WHERE id=%(id)s""")

--- a/imbi/endpoints/project_facts.py
+++ b/imbi/endpoints/project_facts.py
@@ -1,10 +1,9 @@
 import re
 import typing
 
-import problemdetails
-from psycopg2 import errors
+import psycopg2.errors
 
-from imbi import common
+from imbi import common, errors
 from imbi.endpoints import base
 
 
@@ -88,8 +87,6 @@ class CollectionRequestHandler(base.CollectionRequestHandler):
         it here.
 
         """
-        if isinstance(exc, errors.lookup('P0001')):
-            return problemdetails.Problem(
-                status_code=400, title='Bad Request',
-                detail=str(exc).split('\n')[0])
+        if isinstance(exc, psycopg2.errors.lookup('P0001')):
+            return errors.BadRequest(str(exc).split('\n')[0])
         super().on_postgres_error(metric_name, exc)

--- a/imbi/endpoints/project_types.py
+++ b/imbi/endpoints/project_types.py
@@ -7,13 +7,14 @@ class _RequestHandlerMixin:
 
     ID_KEY = 'id'
     FIELDS = ['id', 'name', 'plural_name', 'description', 'icon_class',
-              'environment_urls']
+              'environment_urls', 'gitlab_project_prefix']
     DEFAULTS = {'icon_class': 'fas fa-folder'}
 
     GET_SQL = re.sub(r'\s+', ' ', """\
         SELECT id, "name", created_at, created_by,
                last_modified_at, last_modified_by,
-               description, plural_name, slug, icon_class, environment_urls
+               description, plural_name, slug, icon_class,
+               environment_urls, gitlab_project_prefix
           FROM v1.project_types
          WHERE id=%(id)s""")
 
@@ -26,16 +27,17 @@ class CollectionRequestHandler(_RequestHandlerMixin,
 
     COLLECTION_SQL = re.sub(r'\s+', ' ', """\
         SELECT id, "name", plural_name, description, slug, icon_class,
-               environment_urls
+               environment_urls, gitlab_project_prefix
           FROM v1.project_types
          ORDER BY "name" ASC""")
 
     POST_SQL = re.sub(r'\s+', ' ', """\
         INSERT INTO v1.project_types
                     ("name", created_by, plural_name, description,
-                     slug, icon_class, environment_urls)
+                     slug, icon_class, environment_urls, gitlab_project_prefix)
              VALUES (%(name)s, %(username)s, %(plural_name)s, %(description)s,
-                     %(slug)s, %(icon_class)s, %(environment_urls)s)
+                     %(slug)s, %(icon_class)s, %(environment_urls)s,
+                     %(gitlab_project_prefix)s)
           RETURNING id""")
 
 
@@ -54,5 +56,6 @@ class RecordRequestHandler(_RequestHandlerMixin, base.AdminCRUDRequestHandler):
                description=%(description)s,
                slug=%(slug)s,
                icon_class=%(icon_class)s,
-               environment_urls=%(environment_urls)s
+               environment_urls=%(environment_urls)s,
+               gitlab_project_prefix=%(gitlab_project_prefix)s
          WHERE id=%(id)s""")

--- a/imbi/endpoints/projects.py
+++ b/imbi/endpoints/projects.py
@@ -1,8 +1,7 @@
 import asyncio
 import re
 
-import problemdetails
-
+from imbi import errors
 from imbi.endpoints import base
 
 
@@ -264,8 +263,7 @@ class RecordRequestHandler(_RequestHandlerMixin, base.CRUDRequestHandler):
                     self.GET_URLS_SQL, query_args, 'get-project-urls'))
 
             if not project.row_count or not project.row:
-                raise problemdetails.Problem(
-                    status_code=404, title='Item not found')
+                raise errors.ItemNotFound()
 
             output = project.row
             output.update({

--- a/imbi/endpoints/ui.py
+++ b/imbi/endpoints/ui.py
@@ -107,6 +107,7 @@ class GitLabCreationAutomation(GitLabAutomationHandler,
                                         project_id)
 
             automation = automations.GitLabCreateProjectAutomation(
+                self.settings['automations'],
                 automations.Project.from_database(result.row),
                 await self.get_current_user(),
                 transaction)

--- a/imbi/endpoints/ui.py
+++ b/imbi/endpoints/ui.py
@@ -2,7 +2,10 @@
 API Endpoint for returning UI Settings
 
 """
-from imbi.endpoints import base
+import problemdetails
+
+from imbi import integrations
+from imbi.endpoints import base, gitlab
 
 
 class IndexRequestHandler(base.RequestHandler):
@@ -59,3 +62,102 @@ class UserRequestHandler(base.AuthenticatedRequestHandler):
         user = self.current_user.as_dict()
         del user['password']
         self.send_response(user)
+
+
+class GitLabAutomationHandler(base.AuthenticatedRequestHandler):
+
+    NAME = 'GitLabAutomationHandler'
+    ENDPOINT = 'ui-gitlab'
+
+    async def prepare(self):
+        await super().prepare()
+        if not self._finished:
+            gitlab_int = await integrations.OAuth2Integration.by_name(
+                self.application, 'gitlab')
+            if not gitlab_int:
+                raise problemdetails.Problem(
+                    500, 'application lookup failed for gitlab',
+                    title='Integration Missing',
+                    detail='GitLab integration is not configured')
+
+            imbi_user = await self.get_current_user()  # never None
+            tokens = await gitlab_int.get_user_tokens(imbi_user)
+            if not tokens:
+                raise problemdetails.Problem(
+                    403, 'no gitlab tokens for %r', imbi_user,
+                    title='GitLab Not Connected')
+            self.gitlab = gitlab.GitLabClient(tokens[0])
+
+
+class GitLabCreationAutomation(GitLabAutomationHandler,
+                               base.ValidatingRequestHandler):
+    NAME = 'GitLabCreationAutomation'
+    ENDPOINT = 'ui-gitlab-create'
+
+    async def post(self):
+        request = self.get_request_body()
+        description = request['description']
+        project_id = int(request['project_id'])
+        project_name = request['name']
+
+        async with self.postgres_transaction() as transaction:
+            result = await transaction.execute(
+                """
+                SELECT p.gitlab_project_id,
+                       n.slug AS namespace_slug,
+                       n.gitlab_group_name,
+                       t.slug AS type_slug,
+                       t.gitlab_project_prefix
+                  FROM v1.projects AS p
+                  JOIN v1.namespaces AS n ON (n.id = p.namespace_id)
+                  JOIN v1.project_types AS t ON (t.id = p.project_type_id)
+                 WHERE p.id = %(project_id)s
+                """,
+                {'project_id': project_id})
+            if result.row_count == 0:
+                raise problemdetails.Problem(
+                    400, 'non-existent project %s', project_id,
+                    title='Invalid Request',
+                    detail=f'{project_id} is not a valid namespace')
+            project_info = result.row
+
+            if project_info['gitlab_group_name'] is None:
+                raise problemdetails.Problem(
+                    400, 'namespace %s does not have a gitlab group',
+                    project_info['namespace_slug'],
+                    title='Invalid Request',
+                    detail=(project_info['namespace_slug'] +
+                            ' is not connected to gitlab'))
+            if project_info['gitlab_project_prefix'] is None:
+                raise problemdetails.Problem(
+                    400, 'project type %s does not have a gitlab prefix',
+                    project_info['type_slug'], title='Invalid Request',
+                    detail=(project_info['type_slug'] +
+                            ' is missing a gitlab prefix'))
+
+            parent = await self.gitlab.fetch_group(
+                project_info['gitlab_group_name'],
+                project_info['gitlab_project_prefix'])
+            if parent is None:
+                raise problemdetails.Problem(
+                    400, 'GitLab parent %s/%s does not exist',
+                    project_info['gitlab_group_name'],
+                    project_info['gitlab_project_prefix'],
+                    title='GitLab Group Not Found')
+
+            project_info = await self.gitlab.create_project(
+                parent, project_name, description=description)
+            self.logger.info('created GitLab project %s', project_info['id'])
+            await transaction.execute(
+                """UPDATE v1.projects
+                      SET gitlab_project_id = %(gitlab_project_id)s
+                    WHERE id = %(project_id)s""",
+                {
+                    'project_id': project_id,
+                    'gitlab_project_id': project_info['id'],
+                })
+
+        self.send_response({
+            'gitlab_project_id': project_info['id'],
+            'gitlab_project_url': project_info['_links']['self'],
+        })

--- a/imbi/errors.py
+++ b/imbi/errors.py
@@ -1,0 +1,124 @@
+"""Nicer application errors.
+
+This module contains specializations of :class:`problemdetails.Problem`
+that provide a customizable ``type`` member along with some useful
+functionality for specific error cases.
+
+"""
+import typing
+
+import problemdetails
+import tornado.httputil
+import tornado.web
+import yarl
+
+
+ERROR_URL = yarl.URL('https://localhost/')
+
+
+def set_canonical_server(server_name: str) -> None:
+    """Call this to override the ``type`` URL in errors."""
+    global ERROR_URL
+    ERROR_URL = yarl.URL.build(scheme='https', host=server_name)
+
+
+class ApplicationError(problemdetails.Problem):
+    """Generic error with some niceties added.
+
+    The ``log_message`` parameter is required to ensure that we
+    have log output when we are returning an error.  There is
+    additional code to handle incongruent log format and args
+    so that we avoid *most* log format failure exceptions.
+
+    The ``reason`` attribute is always set.  It will use the
+    ``title`` parameter or the appropriate HTTP reason.
+
+    The ``type`` property is set to the current ``ERROR_URL``
+    with the supplied `fragment` appended.
+
+    The ``detail`` property is set to the formatted log
+    message.
+
+    """
+
+    # work around some typing weirdness in problemdetails...
+    document: typing.Dict[str, typing.Any]
+    log_message: str
+    reason: str
+
+    def __init__(self, status_code: int, fragment: str,
+                 log_message: str, *log_args, **kwargs):
+        # NB -- tornado.web.HTTPError DOES NOT set the reason for us :/
+        kwargs['reason'] = kwargs.get(
+            'reason',
+            kwargs.get(
+                'title',
+                tornado.httputil.responses.get(status_code,
+                                               'Unknown Status Code')).title())
+        kwargs.setdefault('type', str(ERROR_URL.with_fragment(fragment)))
+
+        # tornado provides partial protection against log message format
+        # edge cases but does not insulate against having unnecessary args
+        log_args = () if '%' not in log_message else log_args
+
+        super().__init__(status_code, log_message, *log_args, **kwargs)
+        self.document.setdefault('title', self.reason)
+        self.document.setdefault('detail', self.log_message % log_args)
+
+
+class BadRequest(ApplicationError):
+    def __init__(self, log_message, *log_args, **kwargs):
+        super().__init__(400, 'bad-request', log_message, *log_args, **kwargs)
+
+
+class Forbidden(ApplicationError):
+    def __init__(self, log_message, *log_args, **kwargs):
+        super().__init__(403, 'forbidden', log_message, *log_args, **kwargs)
+
+
+class ItemNotFound(ApplicationError):
+    def __init__(self, log_message=None, *log_args, **kwargs):
+        kwargs.setdefault('title', 'Item not found')
+        super().__init__(
+            404, 'not-found',
+            'Item not found' if log_message is None else log_message,
+            *log_args, **kwargs)
+
+
+class MethodNotAllowed(ApplicationError):
+    def __init__(self, requested_method: str, **kwargs):
+        super().__init__(405, 'method-not-allowed',
+                         '%s is not a supported HTTP method',
+                         requested_method.upper(), **kwargs)
+
+
+class UnsupportedMediaType(ApplicationError):
+    def __init__(self, media_type: str, **kwargs):
+        super().__init__(
+            415, 'unsupported-media-type', '%s is not a supported media type',
+            media_type, **kwargs)
+
+
+class InternalServerError(ApplicationError):
+    def __init__(self, log_message, *log_args, **kwargs):
+        super().__init__(500, 'server-error', log_message, *log_args, **kwargs)
+
+
+class DatabaseError(InternalServerError):
+    def __init__(self, log_message=None, *log_args,
+                 error: typing.Optional[Exception] = None, **kwargs):
+        kwargs.setdefault('title', 'Database Error')
+        if log_message is None:
+            if error is not None:
+                log_message = 'Database failure: %s'
+                log_args = (error, )
+            else:
+                log_message = 'Database failure'
+                log_args = ()
+        super().__init__(log_message, *log_args, **kwargs)
+
+
+class IntegrationNotFound(InternalServerError):
+    def __init__(self, integration_name: str):
+        super().__init__('integration lookup failed for %s', integration_name,
+                         title='Integration Missing')

--- a/imbi/integrations.py
+++ b/imbi/integrations.py
@@ -2,10 +2,9 @@ import dataclasses
 import logging
 import typing
 
-import problemdetails
 import yarl
 
-from imbi import app, user
+from imbi import app, errors, user
 
 
 LOGGER = logging.getLogger(__name__)
@@ -122,11 +121,7 @@ class OAuth2Integration:
 
     @staticmethod
     def _on_postgres_error(_metric_name: str, exc: Exception) -> None:
-        raise problemdetails.Problem(
-            500, 'database failure: %s', exc,
-            type='https://imbi.aweber.com/errors/#database-error',
-            title='Database failure',
-        )
+        raise errors.DatabaseError(error=exc)
 
     def _reset(self):
         self.api_endpoint = None

--- a/imbi/integrations.py
+++ b/imbi/integrations.py
@@ -4,7 +4,9 @@ import typing
 
 import yarl
 
-from imbi import app, errors, user
+from imbi import app, errors
+if typing.TYPE_CHECKING:
+    from imbi import user
 
 
 LOGGER = logging.getLogger(__name__)
@@ -92,7 +94,7 @@ class OAuth2Integration:
         else:
             self._reset()
 
-    async def add_user_token(self, user_info: user.User, external_id: str,
+    async def add_user_token(self, user_info: 'user.User', external_id: str,
                              access_token: str, refresh_token: str):
         async with self._application.postgres_connector(
                 on_error=self._on_postgres_error) as conn:
@@ -102,7 +104,7 @@ class OAuth2Integration:
                 'refresh_token': refresh_token})
 
     async def get_user_tokens(
-            self, user_info: user.User) -> typing.Sequence[IntegrationToken]:
+            self, user_info: 'user.User') -> typing.Sequence[IntegrationToken]:
         async with self._application.postgres_connector(
                 on_error=self._on_postgres_error) as conn:
             result = await conn.execute(self.SQL_GET_TOKENS, {

--- a/imbi/server.py
+++ b/imbi/server.py
@@ -79,6 +79,7 @@ def load_configuration(config: str, debug: bool) -> typing.Tuple[dict, dict]:
     module_path = pathlib.Path(sys.modules['imbi'].__file__).parent
 
     settings = {
+        'canonical_server_name': http_settings['canonical_server_name'],
         'compress_response': http_settings.get('compress_response', True),
         'cookie_secret': http_settings.get('cookie_secret', 'imbi'),
         'debug': debug,

--- a/imbi/server.py
+++ b/imbi/server.py
@@ -68,7 +68,6 @@ def load_configuration(config: str, debug: bool) -> typing.Tuple[dict, dict]:
     log_config = config.get('logging', DEFAULT_LOG_CONFIG)
 
     footer_link = config.get('footer_link', {})
-    gitlab = config.get('gitlab', {})
     http_settings = config.get('http', {})
     ldap = config.get('ldap', {})
     postgres = config.get('postgres', {})
@@ -88,9 +87,6 @@ def load_configuration(config: str, debug: bool) -> typing.Tuple[dict, dict]:
             'text': footer_link.get('text', ''),
             'url': footer_link.get('url', '')
         },
-        'gitlab_application_id': gitlab.get('application_id'),
-        'gitlab_secret': gitlab.get('secret'),
-        'gitlab_url': gitlab.get('url', 'https://gitlab.com'),
         'javascript_url': config.get('javascript_url', None),
         'ldap': {
             'enabled': ldap.get('enabled'),

--- a/imbi/server.py
+++ b/imbi/server.py
@@ -67,6 +67,7 @@ def load_configuration(config: str, debug: bool) -> typing.Tuple[dict, dict]:
 
     log_config = config.get('logging', DEFAULT_LOG_CONFIG)
 
+    automations = config.get('automations', {})
     footer_link = config.get('footer_link', {})
     http_settings = config.get('http', {})
     ldap = config.get('ldap', {})
@@ -78,6 +79,7 @@ def load_configuration(config: str, debug: bool) -> typing.Tuple[dict, dict]:
     module_path = pathlib.Path(sys.modules['imbi'].__file__).parent
 
     settings = {
+        'automations': {'gitlab': automations.get('gitlab', {})},
         'canonical_server_name': http_settings['canonical_server_name'],
         'compress_response': http_settings.get('compress_response', True),
         'cookie_secret': http_settings.get('cookie_secret', 'imbi'),
@@ -128,6 +130,7 @@ def load_configuration(config: str, debug: bool) -> typing.Tuple[dict, dict]:
         'xsrf_cookies': False,
         'version': version
     }
+
     return {k: v for k, v in settings.items() if v is not None}, log_config
 
 

--- a/imbi/templates/openapi.yaml
+++ b/imbi/templates/openapi.yaml
@@ -778,6 +778,99 @@ paths:
         schema:
           type: string
           pattern: '[\w_]+'
+  /gitlab/auth:
+    get:
+      description: |
+        This endpoint is invoked during the GitLab authorization flow for a specific user.
+        It exchanges the code for an access/refresh token pair and stores them in the database
+        for future use.
+      summary: GitLab OAuth 2 callback
+      security: []
+      tags:
+        - Integrations
+      parameters:
+        - name: code
+          in: query
+          required: true
+          schema:
+            type: string
+        - name: state
+          in: query
+          required: false
+          schema:
+            type: string
+      responses:
+        '302':
+          description: Redirect back to profile
+  /gitlab/namespaces:
+    get:
+      description: Retrieve GitLab namespaces for the current user
+      summary: Available GitLab namespaces
+      tags:
+        - Integrations
+        - User
+      responses:
+        '200':
+          description: List of available namespaces
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                      description: Full name of the GitLab namespace
+                    id:
+                      type: integer
+                      description: Unique identifier of the GitLab namespace
+  /gitlab/projects:
+    get:
+      description: Retrieve projects visible to the current user
+      summary: Available GitLab projects
+      tags:
+        - Integrations
+        - User
+      parameters:
+        - name: group_id
+          in: query
+          description: Unique GitLab group/namespace ID
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Possibly empty list of projects in the requested namespace
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    description:
+                      type: string
+                      description: Editable (and optional) description of the repository
+                    name:
+                      type: string
+                      minLength: 1
+                      description: Name of the repository
+                    id:
+                      type: integer
+                      description: Unique repository identifier assigned by GitLab
+                    web_url:
+                      type: string
+                      description: URL for the web view of the repository
+                  required:
+                    - description
+                    - name
+                    - id
+                    - web_url
+        '400':
+          description: Invalid request -- missing query parameter
+        '500':
+          description: GitLab integration is not available/configured
   /groups:
     get:
       description: Retrieve the collection of groups
@@ -5877,6 +5970,8 @@ tags:
     description: Endpoints used to retrieve information about applications that Imbi is integrated with
   - name: Monitoring & Metrics
     description: 'Endpoints used for health checking, service status, and service metrics'
+  - name: User
+    description: Endpoints related to the current user
 x-tagGroups:
   - name: Activity Feed
     tags:

--- a/imbi/templates/openapi.yaml
+++ b/imbi/templates/openapi.yaml
@@ -5926,9 +5926,53 @@ paths:
                 $ref: '#/paths/~1status/get/responses/200/content/application~1json/schema'
               example:
                 $ref: '#/paths/~1status/get/responses/503/content/application~1json/example'
+  /ui/automations/gitlab/create:
+    post:
+      summary: Create GitLab repo
+      description: |
+        Create a new GitLab repository for a specific project.
+
+        The GitLab parent namespace is calculated from the namespace configured in the parent Imbi group and the
+        prefix configured in the project type.  If either value is not configured, then an error response is
+        returned.
+      tags:
+        - Automations
+      requestBody:
+        description: Project details
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  description: Name for the GitLab project
+                  type: string
+                description:
+                  type: string
+                project_id:
+                  description: Imbi project ID to create the repository for
+                  type: integer
+      responses:
+        '200':
+          description: GitLab repository was created successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  gitlab_project_url:
+                    type: string
+                  gitlab_project_id:
+                    type: integer
+        '400':
+          description: Request could not be processed
+        '422':
+          description: Request is semantically invalid
 tags:
   - name: Activity Feed
     description: Endpoints that detail changes to projects and other entities in Imbi
+  - name: Automations
+    description: Endpoints related to project automations
   - name: Cookie Cutters
     description: Endpoints used for the management of project creation cookie cutters
   - name: Environments
@@ -6033,6 +6077,7 @@ x-tagGroups:
       - User
   - name: UI Specific
     tags:
+      - Automations
       - Dashboard
       - Settings
   - name: Other

--- a/imbi/templates/openapi.yaml
+++ b/imbi/templates/openapi.yaml
@@ -1400,6 +1400,10 @@ paths:
                       items:
                         type: string
                       nullable: true
+                    gitlab_group_name:
+                      description: Optional name of associated GitLab group
+                      type: string
+                      nullable: true
                   required:
                     - name
                     - slug
@@ -1455,6 +1459,10 @@ paths:
                       items:
                         type: string
                       nullable: true
+                    gitlab_group_name:
+                      description: Optional name of associated GitLab group
+                      type: string
+                      nullable: true
                   required:
                     - name
                     - slug
@@ -1506,6 +1514,10 @@ paths:
                   type: array
                   items:
                     type: string
+                  nullable: true
+                gitlab_group_name:
+                  description: Optional name of associated GitLab group
+                  type: string
                   nullable: true
               required:
                 - name

--- a/imbi/templates/openapi.yaml
+++ b/imbi/templates/openapi.yaml
@@ -5944,14 +5944,11 @@ paths:
             schema:
               type: object
               properties:
-                name:
-                  description: Name for the GitLab project
-                  type: string
-                description:
-                  type: string
                 project_id:
                   description: Imbi project ID to create the repository for
                   type: integer
+              required:
+                - project_id
       responses:
         '200':
           description: GitLab repository was created successfully
@@ -5966,8 +5963,6 @@ paths:
                     type: integer
         '400':
           description: Request could not be processed
-        '422':
-          description: Request is semantically invalid
 tags:
   - name: Activity Feed
     description: Endpoints that detail changes to projects and other entities in Imbi

--- a/imbi/templates/openapi.yaml
+++ b/imbi/templates/openapi.yaml
@@ -3555,6 +3555,9 @@ paths:
                     environment_urls:
                       description: Indicates that projects of this type have per-environment URLs
                       type: boolean
+                    gitlab_project_prefix:
+                      description: Prefix for this project type in GitLab
+                      type: string
                   additionalProperties: false
               example:
                 records:
@@ -3607,6 +3610,9 @@ paths:
                     environment_urls:
                       description: Indicates that projects of this type have per-environment URLs
                       type: boolean
+                    gitlab_project_prefix:
+                      description: Prefix for this project type in GitLab
+                      type: string
                   additionalProperties: false
               example:
                 records:
@@ -3659,6 +3665,9 @@ paths:
                   description: Indicates that projects of this type have per-environment URLs
                   type: boolean
                   default: false
+                gitlab_project_prefix:
+                  description: Prefix for this project type in GitLab
+                  type: string
               required:
                 - name
                 - plural_name

--- a/imbi/user.py
+++ b/imbi/user.py
@@ -12,7 +12,7 @@ import ldap3
 import psycopg2.errors
 from tornado import web
 
-from imbi import ldap, timestamp
+from imbi import integrations, ldap, timestamp
 
 LOGGER = logging.getLogger(__name__)
 
@@ -231,6 +231,14 @@ class User:
                 {'username': self.username},
                 'user-update-last-seen-at')
             self.last_seen_at = result.row['last_seen_at']
+
+    async def fetch_integration_tokens(self,
+                                       integration: str) -> typing.Sequence[
+                                                integrations.IntegrationToken]:
+        """Retrieve access tokens for the specified integration."""
+        obj = await integrations.OAuth2Integration.by_name(
+            self._application, integration)
+        return await obj.get_user_tokens(self)
 
     def _assign_values(self, data: dict) -> None:
         """Assign values from the cursor row to the instance"""

--- a/openapi/src/endpoints/automations.yaml
+++ b/openapi/src/endpoints/automations.yaml
@@ -17,14 +17,11 @@ gitlab:
             schema:
               type: object
               properties:
-                name:
-                  description: Name for the GitLab project
-                  type: string
-                description:
-                  type: string
                 project_id:
                   description: Imbi project ID to create the repository for
                   type: integer
+              required:
+                - project_id
       responses:
         "200":
           description: GitLab repository was created successfully
@@ -39,5 +36,3 @@ gitlab:
                     type: integer
         "400":
           description: Request could not be processed
-        "422":
-          description: Request is semantically invalid

--- a/openapi/src/endpoints/automations.yaml
+++ b/openapi/src/endpoints/automations.yaml
@@ -1,0 +1,43 @@
+gitlab:
+  create:
+    post:
+      summary: Create GitLab repo
+      description: |
+        Create a new GitLab repository for a specific project.
+
+        The GitLab parent namespace is calculated from the namespace configured in the parent Imbi group and the
+        prefix configured in the project type.  If either value is not configured, then an error response is
+        returned.
+      tags:
+        - Automations
+      requestBody:
+        description: Project details
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  description: Name for the GitLab project
+                  type: string
+                description:
+                  type: string
+                project_id:
+                  description: Imbi project ID to create the repository for
+                  type: integer
+      responses:
+        "200":
+          description: GitLab repository was created successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  gitlab_project_url:
+                    type: string
+                  gitlab_project_id:
+                    type: integer
+        "400":
+          description: Request could not be processed
+        "422":
+          description: Request is semantically invalid

--- a/openapi/src/endpoints/gitlab.yaml
+++ b/openapi/src/endpoints/gitlab.yaml
@@ -1,0 +1,94 @@
+paths:
+  auth:
+    get:
+      description: |
+        This endpoint is invoked during the GitLab authorization flow for a specific user.
+        It exchanges the code for an access/refresh token pair and stores them in the database
+        for future use.
+      summary: GitLab OAuth 2 callback
+      security: []
+      tags:
+        - Integrations
+      parameters:
+        - name: code
+          in: query
+          required: true
+          schema:
+            type: string
+        - name: state
+          in: query
+          required: false
+          schema:
+            type: string
+      responses:
+        '302':
+          description: Redirect back to profile
+  namespaces:
+    get:
+      description: Retrieve GitLab namespaces for the current user
+      summary: Available GitLab namespaces
+      tags:
+        - Integrations
+        - User
+      responses:
+        '200':
+          description: List of available namespaces
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                      description: Full name of the GitLab namespace
+                    id:
+                      type: integer
+                      description: Unique identifier of the GitLab namespace
+  projects:
+    get:
+      description: Retrieve projects visible to the current user
+      summary: Available GitLab projects
+      tags:
+        - Integrations
+        - User
+      parameters:
+        - name: group_id
+          in: query
+          description: Unique GitLab group/namespace ID
+          required: true
+          schema:
+            type: integer
+      responses:
+        200:
+          description: Possibly empty list of projects in the requested namespace
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    description:
+                      type: string
+                      description: Editable (and optional) description of the repository
+                    name:
+                      type: string
+                      minLength: 1
+                      description: Name of the repository
+                    id:
+                      type: integer
+                      description: Unique repository identifier assigned by GitLab
+                    web_url:
+                      type: string
+                      description: URL for the web view of the repository
+                  required:
+                    - description
+                    - name
+                    - id
+                    - web_url
+        400:
+          description: Invalid request -- missing query parameter
+        500:
+          description: GitLab integration is not available/configured

--- a/openapi/src/main.yaml
+++ b/openapi/src/main.yaml
@@ -42,6 +42,9 @@ paths:
   /cookie-cutters/{name}: { $ref: 'endpoints/cookie_cutter.yaml#/paths/manage' }
   /environments: { $ref: 'endpoints/environment.yaml#/paths/collection' }
   /environments/{name}: { $ref: 'endpoints/environment.yaml#/paths/manage' }
+  /gitlab/auth: { $ref: 'endpoints/gitlab.yaml#/paths/auth' }
+  /gitlab/namespaces: { $ref: 'endpoints/gitlab.yaml#/paths/namespaces' }
+  /gitlab/projects: { $ref: 'endpoints/gitlab.yaml#/paths/projects' }
   /groups: { $ref: 'endpoints/group.yaml#/paths/collection' }
   /groups/{name}: { $ref: 'endpoints/group.yaml#/paths/manage' }
   /metrics: { $ref: 'endpoints/metrics.yaml#/paths/metrics' }
@@ -166,6 +169,8 @@ tags:
   - name: Monitoring & Metrics
     description: |-
       Endpoints used for health checking, service status, and service metrics
+  - name: User
+    description: Endpoints related to the current user
 
 x-tagGroups:
   - name: Activity Feed

--- a/openapi/src/main.yaml
+++ b/openapi/src/main.yaml
@@ -100,10 +100,14 @@ paths:
   /reports/system-shs-history:
     { $ref: 'endpoints/system_shs_history.yaml#/paths/collection' }
   /status: { $ref: 'endpoints/status.yaml#/paths/status' }
+  /ui/automations/gitlab/create:
+    { $ref: 'endpoints/automations.yaml#/gitlab/create'}
 
 tags:
   - name: Activity Feed
     description: Endpoints that detail changes to projects and other entities in Imbi
+  - name: Automations
+    description: Endpoints related to project automations
   - name: Cookie Cutters
     description: Endpoints used for the management of project creation cookie cutters
   - name: Environments
@@ -212,6 +216,7 @@ x-tagGroups:
       - User
   - name: UI Specific
     tags:
+      - Automations
       - Dashboard
       - Settings
   - name: Other

--- a/openapi/src/schemas/namespace.yaml
+++ b/openapi/src/schemas/namespace.yaml
@@ -27,6 +27,10 @@ read:
       items:
         type: string
       nullable: true
+    gitlab_group_name:
+      description: Optional name of associated GitLab group
+      type: string
+      nullable: true
   required:
     - name
     - slug
@@ -52,6 +56,10 @@ write:
       type: array
       items:
         type: string
+      nullable: true
+    gitlab_group_name:
+      description: Optional name of associated GitLab group
+      type: string
       nullable: true
   required:
     - name

--- a/openapi/src/schemas/project_type.yaml
+++ b/openapi/src/schemas/project_type.yaml
@@ -32,6 +32,9 @@ read:
     environment_urls:
       description: Indicates that projects of this type have per-environment URLs
       type: boolean
+    gitlab_project_prefix:
+      description: Prefix for this project type in GitLab
+      type: string
   additionalProperties: false
 
 write:
@@ -60,6 +63,9 @@ write:
       description: Indicates that projects of this type have per-environment URLs
       type: boolean
       default: false
+    gitlab_project_prefix:
+      description: Prefix for this project type in GitLab
+      type: string
   required:
     - name
     - plural_name

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1,0 +1,96 @@
+import unittest
+
+import tornado.httputil
+
+from imbi import errors
+
+
+class DefaultFunctionalityTests(unittest.TestCase):
+    def test_that_error_url_can_be_configured(self):
+        saved_error_url = errors.ERROR_URL
+        try:
+            errors.set_canonical_server('server.example.com')
+            err = errors.ApplicationError(500, 'error-fragment', '')
+            self.assertEqual('https://server.example.com/#error-fragment',
+                             err.document['type'])
+        finally:
+            errors.ERROR_URL = saved_error_url
+
+    def test_that_reason_is_set_from_status_code(self):
+        err = errors.ApplicationError(500, 'fragment', '')
+        self.assertEqual(tornado.httputil.responses[500], err.reason)
+
+    def test_that_reason_is_title_if_set(self):
+        err = errors.ApplicationError(500, 'fragment', '', title='title')
+        self.assertEqual('title'.title(), err.reason)
+
+    def test_that_unknown_status_codes_are_handled(self):
+        err = errors.ApplicationError(1, 'fragment', '')
+        self.assertEqual('Unknown Status Code', err.reason)
+
+        err = errors.ApplicationError(600, 'fragment', '')
+        self.assertEqual('Unknown Status Code', err.reason)
+
+    def test_that_type_can_be_overridden(self):
+        err = errors.ApplicationError(
+            500, 'error-fragment', '',
+            type='https://example.com/troubleshooting')
+        self.assertEqual('https://example.com/troubleshooting',
+                         err.document['type'])
+
+    def test_that_title_defaults_to_reason(self):
+        err = errors.ApplicationError(500, 'fragment', '')
+        self.assertEqual(tornado.httputil.responses[500],
+                         err.document['title'])
+
+    def test_that_detail_defaults_to_formatted_log_message(self):
+        err = errors.ApplicationError(500, 'fragment', '1+1=%s', 1 + 1)
+        self.assertEqual('1+1=2', err.document['detail'])
+
+    def test_with_missing_log_args(self):
+        err = errors.ApplicationError(500, 'fragment', '%s')
+        self.assertEqual('%s', err.document['detail'])
+
+    def test_with_unused_log_args(self):
+        err = errors.ApplicationError(500, 'fragment', 'No args', 'arg')
+        self.assertEqual('No args', err.document['detail'])
+
+
+class SpecificErrorBehaviorTests(unittest.TestCase):
+    def test_item_not_found_default_title(self):
+        err = errors.ItemNotFound()
+        self.assertEqual('Item not found', err.document['title'])
+
+    def test_item_not_found_log_message(self):
+        err = errors.ItemNotFound()
+        self.assertEqual('Item not found', err.log_message)
+
+    def test_method_not_allowed_log_message(self):
+        err = errors.MethodNotAllowed('post')
+        self.assertEqual('POST is not a supported HTTP method',
+                         err.document['detail'])
+
+    def test_unsupported_media_type_log_message(self):
+        err = errors.UnsupportedMediaType('application/xml')
+        self.assertEqual('application/xml is not a supported media type',
+                         err.document['detail'])
+
+    def test_database_error_defaults(self):
+        err = errors.DatabaseError()
+        self.assertEqual('Database Error', err.document['title'])
+        self.assertEqual('Database Error', err.reason)
+        self.assertEqual('Database failure', err.log_message)
+
+    def test_database_error_with_exception(self):
+        failure = RuntimeError('whatever')
+        err = errors.DatabaseError(error=failure)
+        self.assertEqual('Database Error', err.document['title'])
+        self.assertEqual('Database Error', err.reason)
+        self.assertEqual('Database failure: %s', err.log_message)
+        self.assertEqual((failure, ), err.args)
+
+    def test_database_error_with_explicit_title(self):
+        err = errors.DatabaseError(title='No rows returned')
+        self.assertEqual('No rows returned', err.document['title'])
+        self.assertEqual('No rows returned'.title(), err.reason)
+        self.assertEqual('Database failure', err.log_message)


### PR DESCRIPTION
This PR will create GitLab repositories when a new project is created in imbi provided that the following conditions hold for the project:

1. the imbi namespace has a GitLab group name configured for it
2. the project type has a GitLab project prefix configured for it
3. the current user has connected to GitLab in their profile (`.../ui/user/profile`)

If all of the conditions hold true, then an empty GitLab repository will be created in the configured GitLab group using the new project name and GitLab project prefix.

The new configuration options for the GitLab group name and project prefix are columns in the `namespaces` and `project_types` tables respectively.  After upgrading the database, you can `PATCH` values into existing namespaces and project types.  I haven't added the ability to edit via the admin UI as of yet.  _TBH, I wasn't even aware that there was an admin UI._