### PR TITLE
Fix internal user passwords

### DIFF
--- a/ci/test.sh
+++ b/ci/test.sh
@@ -23,6 +23,8 @@ EOF
 
 cat > build/test.yaml <<EOF
 ---
+http:
+  canonical_server_name: imbi.localhost
 ldap:
   enabled: true
   host: ldap

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -1,6 +1,6 @@
 #!/bin/sh -e
 echo "Setting up tests"
-apk --update add curl-dev gcc git libffi-dev libpq libressl-dev make musl-dev postgresql-dev linux-headers tzdata
+apk --update add curl-dev gcc git libffi-dev libpq openssl-dev make musl-dev postgresql-dev linux-headers tzdata cargo
 cd /tmp/test
 tar c -C /source -f - \
     LICENSE \

--- a/imbi/app.py
+++ b/imbi/app.py
@@ -75,25 +75,13 @@ class Application(sprockets_postgres.ApplicationMixin, app.Application):
         """Generate a HMAC-SHA512 hash of `password`."""
         return self.keychain.hash(password).hex()
 
-    def decrypt_value(self, key: str, value: str) -> str:
-        """Decrypt a value that is encrypted using `encrypt_value`.
-
-        :param key: The name of the field containing the value
-        :param value: The value to decrypt
-        :rtype: str
-
-        """
+    def decrypt_value(self, value: str) -> str:
+        """Decrypt a value that is encrypted using `encrypt_value`."""
         plaintext_bytes = self.keychain.decrypt(bytes.fromhex(value))
         return plaintext_bytes.decode('utf-8')
 
-    def encrypt_value(self, key: str, value: str) -> str:
-        """Encrypt a value.
-
-        :param key: The name of the field containing the value
-        :param value: The value to encrypt
-        :rtype: str
-
-        """
+    def encrypt_value(self, value: str) -> str:
+        """Encrypt a value."""
         cipher_bytes = self.keychain.encrypt(value.encode('utf-8'))
         return cipher_bytes.hex()
 

--- a/imbi/app.py
+++ b/imbi/app.py
@@ -73,7 +73,8 @@ class Application(sprockets_postgres.ApplicationMixin, app.Application):
 
     def hash_password(self, password: str) -> str:
         """Generate a HMAC-SHA512 hash of `password`."""
-        return self.keychain.hash(password).hex()
+        hashed_bytes = self.keychain.hash(password)
+        return '{}:{}'.format(self.keychain.algorithm.name, hashed_bytes.hex())
 
     def decrypt_value(self, value: str) -> str:
         """Decrypt a value that is encrypted using `encrypt_value`."""

--- a/imbi/automations.py
+++ b/imbi/automations.py
@@ -32,7 +32,7 @@ class GitLabCreateProjectAutomation:
     def __init__(self,
                  automation_settings: dict,
                  project: Project,
-                 user: imbi.user.User,
+                 user: 'imbi.user.User',
                  db: sprockets_postgres.PostgresConnector):
         self.db = db
         self.imbi_project = project
@@ -122,7 +122,7 @@ class GitLabCreateProjectAutomation:
         return None
 
     async def _get_gitlab_token(self) -> typing.Union[
-            imbi.integrations.IntegrationToken, None]:
+            'imbi.integrations.IntegrationToken', None]:
         tokens = await self.user.fetch_integration_tokens('gitlab')
         if not tokens:
             self._add_error('GitLab token not found for current user')

--- a/imbi/endpoints/base.py
+++ b/imbi/endpoints/base.py
@@ -110,7 +110,7 @@ class RequestHandler(postgres.RequestHandlerMixin,
         """Override Tornado's built-in ETag generation"""
         return None
 
-    async def get_current_user(self) -> typing.Optional[user.User]:
+    async def get_current_user(self) -> typing.Optional['user.User']:
         """Used by the system to manage authentication behaviors"""
         if self.session and self.session.user:
             return self.session.user

--- a/imbi/endpoints/gitlab.py
+++ b/imbi/endpoints/gitlab.py
@@ -32,7 +32,7 @@ PROJECT_DEFAULTS = {
 
 
 class GitLabClient(sprockets.mixins.http.HTTPClientMixin):
-    def __init__(self, token: integrations.IntegrationToken):
+    def __init__(self, token: 'integrations.IntegrationToken'):
         super().__init__()
         self.logger = logging.getLogger(__package__).getChild('GitLabClient')
         self.token = token
@@ -112,7 +112,7 @@ class GitLabClient(sprockets.mixins.http.HTTPClientMixin):
 
 class RedirectHandler(sprockets.mixins.http.HTTPClientMixin,
                       base.RequestHandler):
-    integration: integrations.OAuth2Integration
+    integration: 'integrations.OAuth2Integration'
 
     async def prepare(self) -> None:
         await super().prepare()

--- a/imbi/keychain.py
+++ b/imbi/keychain.py
@@ -26,6 +26,8 @@ class Keychain:
     then compare it to a newly encrypted value for raw byte equality.
 
     """
+    algorithm = hashes.SHA512()
+
     def __init__(self, key: bytes):
         if len(key) != 32:
             raise ValueError('Keychain requires a 32-byte key')
@@ -49,6 +51,6 @@ class Keychain:
 
     def hash(self, data: str) -> bytes:
         """Generate a HMAC-SHA512 of the supplied data."""
-        hasher = hmac.HMAC(self._key, hashes.SHA512())
+        hasher = hmac.HMAC(self._key, self.algorithm)
         hasher.update(data.encode('utf-8'))
         return hasher.finalize()

--- a/imbi/keychain.py
+++ b/imbi/keychain.py
@@ -1,0 +1,54 @@
+import base64
+
+from cryptography import fernet
+from cryptography.hazmat.primitives import hashes, hmac
+
+
+class DecryptionFailure(RuntimeError):
+    """Raised when a value cannot be decrypted."""
+    ...
+
+
+class Keychain:
+    """Simple keychain abstraction.
+
+    This class takes a random 32-byte key and uses it for symmetric
+    encryption and one-way hashing.  The interfaces are ALWAYS in
+    terms of byte strings.
+
+    .. rubric:: Import Note
+
+    Though this keychain can decrypt any message that was encrypted
+    using the same key, it is not true that encrypting the same plain
+    text twice will result in the same cipher text value.  In fact,
+    the current implementation will guarantee that this is not the
+    case so you should never store an encrypted value somewhere and
+    then compare it to a newly encrypted value for raw byte equality.
+
+    """
+    def __init__(self, key: bytes):
+        if len(key) != 32:
+            raise ValueError('Keychain requires a 32-byte key')
+        self._key = key
+        self._fernet = fernet.Fernet(base64.urlsafe_b64encode(key))
+
+    def encrypt(self, plaintext: bytes) -> bytes:
+        """Encrypt `ciphertext` using the configured key."""
+        return base64.urlsafe_b64decode(self._fernet.encrypt(plaintext))
+
+    def decrypt(self, ciphertext: bytes) -> bytes:
+        """Decrypt `ciphertext` using the configured key.
+
+        :raises: :exc:`DecryptionFailure` when the value cannot be
+            decrypted.
+        """
+        try:
+            return self._fernet.decrypt(base64.urlsafe_b64encode(ciphertext))
+        except fernet.InvalidToken as error:
+            raise DecryptionFailure() from error
+
+    def hash(self, data: str) -> bytes:
+        """Generate a HMAC-SHA512 of the supplied data."""
+        hasher = hmac.HMAC(self._key, hashes.SHA512())
+        hasher.update(data.encode('utf-8'))
+        return hasher.finalize()

--- a/imbi/session.py
+++ b/imbi/session.py
@@ -122,7 +122,7 @@ class Session:
 
         password = data['user'].pop('password', None)
         if password is not None:
-            password = self._application.decrypt_value('password', password)
+            password = self._application.decrypt_value(password)
 
         user_obj = user.User(self._handler.application, password=password)
         for key, value in data['user'].items():

--- a/imbi/session.py
+++ b/imbi/session.py
@@ -37,7 +37,7 @@ class Session:
 
         """
         self.user = user.User(
-            self._handler.application, username, password)
+            self._handler.application, username=username, password=password)
         self.authenticated = await self.user.authenticate()
         if not self.authenticated:
             self.user = None
@@ -120,11 +120,11 @@ class Session:
         if not data.get('user'):
             return
 
-        if 'password' in data['user']:
-            data['user']['password'] = self._application.decrypt_value(
-                'password', data['user']['password']).decode('utf-8')
+        password = data['user'].pop('password', None)
+        if password is not None:
+            password = self._application.decrypt_value('password', password)
 
-        user_obj = user.User(self._handler.application)
+        user_obj = user.User(self._handler.application, password=password)
         for key, value in data['user'].items():
             setattr(user_obj, key, value)
         return user_obj

--- a/imbi/session.py
+++ b/imbi/session.py
@@ -103,7 +103,7 @@ class Session:
         if value:
             return value.decode('utf-8')
 
-    async def _load_data(self) -> typing.Optional[user.User]:
+    async def _load_data(self) -> typing.Optional['user.User']:
         """Load the data from Redis, creating the user object and returning it
         if there was a previously saved user,
 

--- a/imbi/templates/openapi.yaml
+++ b/imbi/templates/openapi.yaml
@@ -3668,6 +3668,7 @@ paths:
                 gitlab_project_prefix:
                   description: Prefix for this project type in GitLab
                   type: string
+                  nullable: true
               required:
                 - name
                 - plural_name

--- a/openapi/src/schemas/project_type.yaml
+++ b/openapi/src/schemas/project_type.yaml
@@ -35,6 +35,7 @@ read:
     gitlab_project_prefix:
       description: Prefix for this project type in GitLab
       type: string
+      nullable: true
   additionalProperties: false
 
 write:

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,6 +48,7 @@ install_requires =
     aioredis>=1.2.0,<2
     aiopg>=1.0.0,<2
     arrow>=0.15.5,<1
+	cryptography==3.4.7
     distro==1.5.0
     jsonpatch>=1.25,<2
     ietfparse>=1.5.1,<2

--- a/tests/endpoints/test_namespaces.py
+++ b/tests/endpoints/test_namespaces.py
@@ -14,11 +14,16 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
 
     def test_namespace_lifecycle(self):
         record = {
+            field: namespaces.CollectionRequestHandler.DEFAULTS.get(
+                field, None)
+            for field in namespaces.CollectionRequestHandler.FIELDS
+            if field != namespaces.CollectionRequestHandler.ID_KEY
+        }
+        record.update({
             'name': str(uuid.uuid4()),
             'slug': str(uuid.uuid4().hex),
             'icon_class': 'fas fa-blind',
-            'maintained_by': []
-        }
+        })
 
         # Create
         result = self.fetch(

--- a/tests/endpoints/test_project_types.py
+++ b/tests/endpoints/test_project_types.py
@@ -14,13 +14,19 @@ class AsyncHTTPTestCase(base.TestCaseWithReset):
 
     def test_project_type_lifecycle(self):
         record = {
+            field: project_types.CollectionRequestHandler.DEFAULTS.get(
+                field, None)
+            for field in project_types.CollectionRequestHandler.FIELDS
+            if field != project_types.CollectionRequestHandler.ID_KEY
+        }
+        record.update({
             'name': str(uuid.uuid4()),
             'plural_name': str(uuid.uuid4()),
             'slug': str(uuid.uuid4()),
             'description': str(uuid.uuid4()),
             'icon_class': 'fas fa-blind',
             'environment_urls': False
-        }
+        })
 
         # Create
         result = self.fetch(

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -7,5 +7,5 @@ class EncryptionTestCase(base.TestCase):
 
     def test_lifecycle(self):
         value = str(uuid.uuid4())
-        encrypted = self._app.encrypt_value('REMOVEME', value)
-        self.assertEqual(self._app.decrypt_value('REMOVEME', encrypted), value)
+        encrypted = self._app.encrypt_value(value)
+        self.assertEqual(self._app.decrypt_value(encrypted), value)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -5,15 +5,7 @@ from tests import base
 
 class EncryptionTestCase(base.TestCase):
 
-    def test_is_encrypted_false(self):
-        self.assertFalse(self._app.is_encrypted_value(str(uuid.uuid4())))
-
-    def test_is_encrypted_none(self):
-        self.assertFalse(self._app.is_encrypted_value(None))
-
     def test_lifecycle(self):
-        key = str(uuid.uuid4()).encode('utf-8')
-        value = str(uuid.uuid4()).encode('utf-8')
-        encrypted = self._app.encrypt_value(key, value)
-        self.assertTrue(self._app.is_encrypted_value(encrypted))
-        self.assertEqual(self._app.decrypt_value(key, encrypted), value)
+        value = str(uuid.uuid4())
+        encrypted = self._app.encrypt_value('REMOVEME', value)
+        self.assertEqual(self._app.decrypt_value('REMOVEME', encrypted), value)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -9,3 +9,11 @@ class EncryptionTestCase(base.TestCase):
         value = str(uuid.uuid4())
         encrypted = self._app.encrypt_value(value)
         self.assertEqual(self._app.decrypt_value(encrypted), value)
+
+
+class PasswordHashingTestCase(base.TestCase):
+    def test_that_password_hashes_include_algorithm(self):
+        hashed = self._app.hash_password('my password')
+        self.assertTrue(
+            hashed.startswith(self._app.keychain.algorithm.name + ':'),
+            'Hashed password is not prefixed by algorithm')

--- a/tests/test_keychain.py
+++ b/tests/test_keychain.py
@@ -1,0 +1,58 @@
+import hmac
+import random
+import string
+import unittest
+
+import imbi.keychain
+
+
+class KeychainCreationTests(unittest.TestCase):
+    def test_that_32_byte_key_is_required(self):
+        with self.assertRaises(ValueError):
+            imbi.keychain.Keychain(b'not 32 bytes')
+
+
+class PasswordHashingTests(unittest.TestCase):
+    def setUp(self):
+        super().setUp()
+        self.key = b'some thirty-two character secret'
+
+    def test_that_hash_uses_secret_as_hmac_key(self):
+        encrypter = hmac.new(self.key, digestmod='SHA512')
+        encrypter.update(b'my secret')
+        keychain = imbi.keychain.Keychain(self.key)
+        self.assertEqual(encrypter.digest(), keychain.hash('my secret'))
+
+
+class EncryptionTests(unittest.TestCase):
+    def setUp(self):
+        super().setUp()
+        self.key = b'some thirty-two character secret'
+
+    def test_symmetric_encryption(self):
+        # generate some random "words"
+        plaintext = ' '.join(
+            ''.join(random.choice(string.ascii_letters)
+                    for _ in range(random.randint(5, 10)))
+            for _ in range(random.randint(10, 15))
+        ).encode()
+
+        # round trip them through the keychain
+        keychain = imbi.keychain.Keychain(self.key)
+        ciphertext = keychain.encrypt(plaintext)
+        self.assertEqual(plaintext, keychain.decrypt(ciphertext))
+
+    def test_decryption_with_tampered_ciphertext(self):
+        keychain = imbi.keychain.Keychain(self.key)
+        ciphertext = keychain.encrypt(b'some plain text')
+        ciphertext = ciphertext[5:] + ciphertext[:5]
+        with self.assertRaises(imbi.keychain.DecryptionFailure):
+            keychain.decrypt(ciphertext)
+
+    def test_that_keychains_with_same_key_can_roundtrip(self):
+        plaintext = b'my dirty little secret'
+        keychain1 = imbi.keychain.Keychain(self.key)
+        ciphertext = keychain1.encrypt(plaintext)
+
+        keychain2 = imbi.keychain.Keychain(self.key)
+        self.assertEqual(plaintext, keychain2.decrypt(ciphertext))

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,0 +1,69 @@
+import base64
+import os
+import tempfile
+import unittest.mock
+import uuid
+
+import yaml
+
+from imbi import server
+
+
+class LoadConfigurationTests(unittest.TestCase):
+    def setUp(self):
+        super().setUp()
+        self._patchers = []
+        self.mock_stderr = self.add_patch(server.sys, 'stderr')
+
+    def tearDown(self):
+        for patcher in self._patchers:
+            patcher.stop()
+        super().tearDown()
+
+    def add_patch(self, target, attribute, **kwargs):
+        self._patchers.append(
+            unittest.mock.patch.object(target, attribute, **kwargs))
+        return self._patchers[-1].start()
+
+    def test_missing_configuration_file(self):
+        with self.assertRaises(SystemExit):
+            server.load_configuration(str(uuid.uuid4()), False)
+        self.mock_stderr.write.assert_called()
+
+    def test_yaml_load_failure(self):
+        with tempfile.NamedTemporaryFile() as config_file:
+            config_file.write(b'\x00\x01\x02\x03')
+            config_file.flush()
+            with self.assertRaises(SystemExit):
+                server.load_configuration(config_file.name, False)
+            self.mock_stderr.write.assert_called()
+
+    def test_bad_yaml_doc(self):
+        with tempfile.NamedTemporaryFile() as config_file:
+            config_file.write(b'<config/>')
+            config_file.flush()
+            with self.assertRaises(SystemExit):
+                server.load_configuration(config_file.name, False)
+            self.mock_stderr.write.assert_called()
+
+    def test_encryption_key_encoding(self):
+        secret = os.urandom(32)
+        with tempfile.NamedTemporaryFile(
+                mode='w+t', encoding='utf-8') as config_file:
+            yaml.dump(
+                {
+                    'encryption_key': base64.b64encode(secret).decode(),
+                    'http': {'canonical_server_name': 'server.example.com'},
+                }, config_file)
+            config, _ = server.load_configuration(config_file.name, False)
+            self.assertEqual(secret, config['encryption_key'])
+
+            config_file.seek(0)
+            secret = b'not valid base64'
+            yaml.dump(
+                {
+                    'encryption_key': secret.decode(),
+                    'http': {'canonical_server_name': 'server.example.com'},
+                }, config_file)
+            config, _ = server.load_configuration(config_file.name, False)
+            self.assertEqual(secret, config['encryption_key'])

--- a/ui/public/locales/en.js
+++ b/ui/public/locales/en.js
@@ -193,6 +193,11 @@ export default {
           itemName: 'Project Type',
           pluralName: 'Pluralized Name',
           environmentURLs: 'Per-Environment URLs',
+          gitLabProjectPrefix: {
+            title: 'GitLab Project Prefix',
+            description:
+              'Prefix to use when creating GitLab projects of this type'
+          },
           errors: {
             uniqueViolation: 'A project type with the same name already exists'
           }

--- a/ui/public/locales/en.js
+++ b/ui/public/locales/en.js
@@ -136,11 +136,18 @@ export default {
         namespaces: {
           collectionName: 'Namespaces',
           itemName: 'Namespace',
-          maintainedBy: 'Managed By',
-          maintainedByDescription:
-            'Groups that have access to manage projects in this namespace',
+          maintainedBy: {
+            title: 'Managed By',
+            description:
+              'Groups that have access to manage projects in this namespace'
+          },
           errors: {
             uniqueViolation: 'A namespace with the same name already exists'
+          },
+          gitLabGroupName: {
+            title: 'GitLab Group Name',
+            description:
+              'GitLab group that new projects for this namespace will be created in'
           }
         },
         projectFactTypes: {

--- a/ui/src/js/schema/Namespace.js
+++ b/ui/src/js/schema/Namespace.js
@@ -20,6 +20,9 @@ export const jsonSchema = {
     },
     maintained_by: {
       oneOf: [{ type: 'array', items: { type: 'string' } }, { type: 'null' }]
+    },
+    gitlab_group_name: {
+      oneOf: [{ type: 'string' }, { type: 'null' }]
     }
   },
   additionalProperties: false,
@@ -30,5 +33,6 @@ export const Namespace = {
   name: PropTypes.string.isRequired,
   slug: PropTypes.string.isRequired,
   icon_class: PropTypes.string,
-  maintained_by: PropTypes.string
+  maintained_by: PropTypes.string,
+  gitlab_group_name: PropTypes.string
 }

--- a/ui/src/js/schema/ProjectType.js
+++ b/ui/src/js/schema/ProjectType.js
@@ -27,6 +27,9 @@ export const jsonSchema = {
     },
     environment_urls: {
       type: 'boolean'
+    },
+    gitlab_project_prefix: {
+      oneOf: [{ type: 'string' }, { type: 'null' }]
     }
   },
   additionalProperties: false,
@@ -40,5 +43,6 @@ export const propTypes = {
   slug: PropTypes.string.isRequired,
   description: PropTypes.string,
   icon_class: PropTypes.string,
-  environment_urls: PropTypes.bool
+  environment_urls: PropTypes.bool,
+  gitlab_project_prefix: PropTypes.string
 }

--- a/ui/src/js/views/Admin/Namespaces.jsx
+++ b/ui/src/js/views/Admin/Namespaces.jsx
@@ -42,7 +42,7 @@ export function Namespaces() {
           type: 'text',
           tableOptions: {
             className: 'truncate',
-            headerClassName: 'w-5/12'
+            headerClassName: 'w-4/12'
           }
         },
         {
@@ -52,19 +52,28 @@ export function Namespaces() {
           description: t('common.slugDescription'),
           tableOptions: {
             className: 'font-mono font-gray-500',
-            headerClassName: 'w-4/12'
+            headerClassName: 'w-3/12'
           }
         },
         {
-          title: t('admin.namespaces.maintainedBy'),
+          title: t('admin.namespaces.maintainedBy.title'),
           name: 'maintained_by',
           default: [],
-          description: t('admin.namespaces.maintainedByDescription'),
+          description: t('admin.namespaces.maintainedBy.description'),
           multiple: true,
           options: asOptions(state.metadata.groups, 'name', 'name'),
           type: 'select',
           tableOptions: {
             hide: true
+          }
+        },
+        {
+          title: t('admin.namespaces.gitLabGroupName.title'),
+          name: 'gitlab_group_name',
+          description: t('admin.namespaces.gitLabGroupName.description'),
+          type: 'text',
+          tableOptions: {
+            headerClassName: 'w-4/12'
           }
         }
       ]}

--- a/ui/src/js/views/Admin/ProjectTypes.jsx
+++ b/ui/src/js/views/Admin/ProjectTypes.jsx
@@ -77,6 +77,15 @@ export function ProjectTypes() {
           tableOptions: {
             hide: true
           }
+        },
+        {
+          title: t('admin.projectTypes.gitLabProjectPrefix.title'),
+          name: 'gitlab_project_prefix',
+          description: t('admin.projectTypes.gitLabProjectPrefix.description'),
+          type: 'text',
+          tableOptions: {
+            headerClassName: 'w-3/12'
+          }
         }
       ]}
       errorStrings={{


### PR DESCRIPTION
Internal user password authentication was assuming that the return value of `self.application.encrypt_value(x)` for the same value of `x` would always be the same.  Since it was using timestamp-based cookie encryption this was not the case.  This PR switches to using [pyca/cryptography](https://cryptography.io/en/latest/) for encryption.  Instead of storing the encrypted password in the database, we now store a HMAC-SHA256 digest using a configured key.  The password is still stored encrypted in the user session since it is required to LDAP refreshing to work properly.  I switched this to using [Fernet symmetric keys](https://cryptography.io/en/latest/fernet/) instead of [tornado secure cookies](https://www.tornadoweb.org/en/stable/web.html#tornado.web.RequestHandler.get_secure_cookie).

The encryption key is required to be a 32 byte value and is set in the configuration file.  You can use a 32 character string or a Base64-encoded 32-byte value including padding.  If you want the default value, then go spelunking in the source code.  You shouldn't be using the default anyway.

I also fixed some tests that were broken in the last PR (ba9647f) and added missing values to the Admin UI (c5237b0 and 6e3d701)