### PR TITLE
Wait for imbi-api health before continuing

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -105,6 +105,28 @@ check_errors "service '$IMBI_SERVICE'"
 start_api() {
     echo "Starting imbi-api on :8000..."
     IMBI_HOST=0.0.0.0 IMBI_PORT=8000 imbi-api serve &
+
+    echo "Waiting for imbi-api to become healthy..."
+    local attempts=0
+    local max_attempts=30
+    until python3 -c "
+import http.client
+try:
+    conn = http.client.HTTPConnection('localhost', 8000, timeout=2)
+    conn.request('GET', '/status')
+    resp = conn.getresponse()
+    exit(0 if resp.status == 200 else 1)
+except Exception:
+    exit(1)
+" 2>/dev/null; do
+        attempts=$((attempts + 1))
+        if [ "$attempts" -ge "$max_attempts" ]; then
+            echo "ERROR: imbi-api did not become healthy after ${max_attempts}s" >&2
+            exit 1
+        fi
+        sleep 1
+    done
+    echo "imbi-api is healthy"
 }
 
 start_assistant() {


### PR DESCRIPTION
## Summary
- Add a health check wait loop to `start_api()` in `entrypoint.sh`
- After starting imbi-api in the background, poll the `/status` endpoint
  until it returns HTTP 200 (up to a fixed number of attempts)
- Fail with an error if the API never becomes healthy

## Problem
When running in `all` mode, dependent services (assistant, gateway, mcp)
could start before imbi-api was ready to accept requests, leading to
startup failures or race conditions.

## Solution
Added a polling loop using `python3 http.client` (since curl is not
available in the runtime image) that waits for the API to respond on
`/status` before the entrypoint continues starting other services.

## Test plan
- [ ] Run `docker compose up --build` and verify imbi-api health check
      messages appear in logs before other services start
- [ ] Verify that a slow-starting imbi-api is waited for correctly
- [ ] Verify the 30-second timeout triggers if imbi-api fails to start