### PR TITLE
Fix Docker image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,9 +21,9 @@ FROM python:${PYTHON_VERSION}-slim AS python-builder
 WORKDIR /tmp/build
 
 RUN pip install uv \
- && apt-get update \
- && apt-get install -y --no-install-recommends git \
- && rm -rf /var/lib/apt/lists/*
+ && apt update \
+ && apt install -y --no-install-recommends git \
+ && apt install -y gcc
 
 # Copy all service sources
 COPY imbi-common/ imbi-common/
@@ -34,16 +34,14 @@ COPY imbi-mcp/ imbi-mcp/
 
 # Build wheels for all services
 RUN for svc in imbi-common imbi-api imbi-assistant imbi-gateway imbi-mcp; do \
-      cd /tmp/build/$svc && uv build --wheel --out-dir /tmp/wheels/; \
-    done
+  uv build /tmp/build/$svc --wheel --out-dir /tmp/wheels/; \
+done
 
 # Install all services into a venv, then clean up source
-RUN uv venv --python $(which python3) /app \
- && ln -sf $(which python3) /app/bin/python3 \
- && . /app/bin/activate \
+ENV UV_LINK_MODE=copy UV_PROJECT_DIRECTORY=/app VIRTUAL_ENV=/app
+RUN uv venv --python $(which python3) $UV_PROJECT_DIRECTORY \
  && uv pip install /tmp/wheels/*.whl \
- && chmod -R a+rX /app \
- && rm -rf /tmp/build /tmp/wheels
+ && chmod -R a+rX /app
 
 # ---------------------------------------------------------------------------
 # Stage 3: Caddy binary
@@ -56,8 +54,8 @@ FROM caddy:${CADDY_VERSION} AS caddy
 FROM python:${PYTHON_VERSION}-slim AS runtime
 
 # Install runtime dependencies
-RUN apt-get update \
- && apt-get install -y --no-install-recommends tini \
+RUN apt update \
+ && apt install -y --no-install-recommends tini \
  && rm -rf /var/lib/apt/lists/*
 
 # Create imbi user

--- a/README.md
+++ b/README.md
@@ -124,7 +124,6 @@ Useful services during UI development:
 ```bash
 # Run all services (default)
 docker run -p 8080:8080 \
-  -e NEO4J_URL=bolt://neo4j:7687 \
   -e CLICKHOUSE_URL=http://default:password@clickhouse:8123/imbi \
   -e IMBI_AUTH_JWT_SECRET=your-secret-here \
   -e IMBI_AUTH_ENCRYPTION_KEY=your-encryption-key \
@@ -138,7 +137,6 @@ docker run -e IMBI_SERVICE=mcp ...
 
 # Run initial setup (create admin user, seed permissions)
 docker run -it \
-  -e NEO4J_URL=bolt://neo4j:7687 \
   -e CLICKHOUSE_URL=http://default:password@clickhouse:8123/imbi \
   -e IMBI_AUTH_JWT_SECRET=your-secret-here \
   -e IMBI_AUTH_ENCRYPTION_KEY=your-encryption-key \
@@ -184,7 +182,6 @@ just update-submodules-tag v1.0.0
 
 | Variable | Description | Services |
 |----------|-------------|----------|
-| `NEO4J_URL` | Neo4j connection URL | api, assistant |
 | `CLICKHOUSE_URL` | ClickHouse connection URL | api |
 | `IMBI_AUTH_JWT_SECRET` | JWT signing secret | api, assistant |
 | `IMBI_AUTH_ENCRYPTION_KEY` | Fernet encryption key | api |

--- a/docs/docs/deployment/docker.md
+++ b/docs/docs/deployment/docker.md
@@ -10,7 +10,6 @@ By default, the container starts all services behind a Caddy reverse proxy:
 
 ```bash
 docker run -p 8080:8080 \
-  -e NEO4J_URL=bolt://neo4j:7687 \
   -e CLICKHOUSE_URL=http://default:password@clickhouse:8123/imbi \
   -e POSTGRES_URL=postgresql://user:pass@postgres/imbi \
   -e IMBI_AUTH_JWT_SECRET=your-secret \
@@ -37,7 +36,6 @@ set `IMBI_SERVICE` to run a single service:
 # Run only the API
 docker run -p 8000:8000 \
   -e IMBI_SERVICE=api \
-  -e NEO4J_URL=bolt://neo4j:7687 \
   -e CLICKHOUSE_URL=http://default:password@clickhouse:8123/imbi \
   -e IMBI_AUTH_JWT_SECRET=your-secret \
   -e IMBI_AUTH_ENCRYPTION_KEY=your-key \
@@ -53,7 +51,6 @@ The `setup` command initializes the authentication system:
 
 ```bash
 docker run -it \
-  -e NEO4J_URL=bolt://neo4j:7687 \
   -e CLICKHOUSE_URL=http://default:password@clickhouse:8123/imbi \
   -e IMBI_AUTH_JWT_SECRET=your-secret \
   -e IMBI_AUTH_ENCRYPTION_KEY=your-key \

--- a/docs/docs/getting-started/configuration.md
+++ b/docs/docs/getting-started/configuration.md
@@ -16,12 +16,6 @@ all service-specific variables are required.
 | `IMBI_AUTH_JWT_SECRET` | Secret key for signing JWT tokens. Use a random string of at least 32 characters. |
 | `IMBI_AUTH_ENCRYPTION_KEY` | Fernet encryption key for encrypting sensitive data at rest. |
 
-### API and Assistant
-
-| Variable | Description |
-|----------|-------------|
-| `NEO4J_URL` | Neo4j Bolt connection URL (e.g. `bolt://neo4j:7687`) |
-
 ### API only
 
 | Variable | Description |
@@ -33,14 +27,6 @@ all service-specific variables are required.
 | Variable | Description |
 |----------|-------------|
 | `POSTGRES_URL` | PostgreSQL connection URL (e.g. `postgresql://user:pass@host/db`) |
-
-## Neo4j
-
-| Variable | Description | Default |
-|----------|-------------|---------|
-| `NEO4J_URL` | Bolt connection URL. Credentials can be embedded: `bolt://user:pass@host:7687` | - |
-| `NEO4J_USER` | Username (overrides URL credentials) | - |
-| `NEO4J_PASSWORD` | Password (overrides URL credentials) | - |
 
 ## ClickHouse
 

--- a/docs/docs/getting-started/installation.md
+++ b/docs/docs/getting-started/installation.md
@@ -28,7 +28,6 @@ services:
     ports:
       - "8080:8080"
     environment:
-      NEO4J_URL: bolt://neo4j:7687
       CLICKHOUSE_URL: http://default:password@clickhouse:8123/imbi
       POSTGRES_URL: postgresql://postgres:secret@postgres/imbi
       IMBI_AUTH_JWT_SECRET: change-me-to-a-random-secret

--- a/docs/docs/getting-started/setup.md
+++ b/docs/docs/getting-started/setup.md
@@ -10,7 +10,6 @@ your first admin user.
 
 ```bash
 docker run -it \
-  -e NEO4J_URL=bolt://neo4j:7687 \
   -e CLICKHOUSE_URL=http://default:password@clickhouse:8123/imbi \
   -e IMBI_AUTH_JWT_SECRET=your-secret \
   -e IMBI_AUTH_ENCRYPTION_KEY=your-key \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -21,7 +21,6 @@ require_var() {
 }
 
 require_common_vars() {
-    require_var NEO4J_URL "Neo4j connection URL (e.g. bolt://neo4j:7687)"
     require_var IMBI_AUTH_JWT_SECRET "JWT signing secret for authentication"
 }
 

--- a/helm/imbi/templates/deployment.yaml
+++ b/helm/imbi/templates/deployment.yaml
@@ -42,11 +42,6 @@ spec:
                 secretKeyRef:
                   name: {{ include "imbi.secretName" . }}
                   key: encryption-key
-            - name: NEO4J_URL
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "imbi.secretName" . }}
-                  key: neo4j-url
             - name: CLICKHOUSE_URL
               valueFrom:
                 secretKeyRef:

--- a/justfile
+++ b/justfile
@@ -1,5 +1,11 @@
 image := "ghcr.io/aweber-imbi/imbi"
 
+[doc("Display the available commands")]
+[default]
+[group("Development")]
+@help:
+    just --list
+
 [doc("Build the Docker image")]
 [group("Build")]
 build tag="latest":
@@ -9,6 +15,11 @@ build tag="latest":
 [group("Build")]
 release tag:
     docker build -t {{ image }}:{{ tag }} -t {{ image }}:latest .
+
+[doc("Update all submodules to what is currently checked in")]
+[group("Submodules")]
+checkout-submodules:
+    git submodule update --remote --checkout
 
 [doc("Update all submodules to the latest commit on their tracking branch")]
 [group("Submodules")]
@@ -47,3 +58,14 @@ docs-serve:
 [group("Build")]
 clean:
     rm -rf docs/site
+
+[doc("Build and initialize docker environment")]
+[group("Development")]
+bootstrap:
+    docker compose up --build --wait --detach
+    docker compose exec imbi imbi-api setup
+
+[doc("Destroy docker environment and remove artifacts")]
+[group("Development")]
+teardown: clean
+    docker compose down --remove-orphans --volumes


### PR DESCRIPTION
## Summary
- Fix Dockerfile multi-stage build so that `uv build` and `uv venv` work
  correctly without `cd` into each service directory
- Remove errant `NEO4J_URL` requirement from entrypoint since Neo4j was
  removed in the previous commit

## Changes
- Use `uv build /tmp/build/$svc` instead of `cd` + `uv build` to avoid
  working directory issues
- Simplify venv creation with `UV_LINK_MODE`, `UV_PROJECT_DIRECTORY`, and
  `VIRTUAL_ENV` environment variables
- Remove `NEO4J_URL` from `require_common_vars()` in `entrypoint.sh`
- Add `gcc` package for building native extensions

## Test plan
- [ ] `just build` completes successfully
- [ ] `docker compose up` starts all services
- [ ] Verify entrypoint no longer requires `NEO4J_URL`