### PR TITLE
Use IMBI_API_URL path prefix in api healthcheck

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -105,23 +105,17 @@ start_api() {
     echo "Starting imbi-api on :8000..."
     IMBI_HOST=0.0.0.0 IMBI_PORT=8000 imbi-api serve &
 
-    local api_prefix=""
-    if [ -n "$IMBI_API_URL" ]; then
-        local tmp="${IMBI_API_URL#*://}"
-        case "$tmp" in
-            */*) api_prefix="/${tmp#*/}" ;;
-        esac
-        api_prefix="${api_prefix%/}"
-    fi
-
-    echo "Waiting for imbi-api to become healthy at ${api_prefix}/status..."
+    echo "Waiting for imbi-api to become healthy..."
     local attempts=0
     local max_attempts=30
     until python3 -c "
+import os
+from urllib import parse
 import http.client
+parsed = parse.urlparse(os.environ.get('IMBI_API_URL', ''))
 try:
     conn = http.client.HTTPConnection('localhost', 8000, timeout=2)
-    conn.request('GET', '${api_prefix}/status')
+    conn.request('GET', f'{parsed.path.removesuffix("/")}/status')
     resp = conn.getresponse()
     exit(0 if resp.status == 200 else 1)
 except Exception:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -105,14 +105,23 @@ start_api() {
     echo "Starting imbi-api on :8000..."
     IMBI_HOST=0.0.0.0 IMBI_PORT=8000 imbi-api serve &
 
-    echo "Waiting for imbi-api to become healthy..."
+    local api_prefix=""
+    if [ -n "$IMBI_API_URL" ]; then
+        local tmp="${IMBI_API_URL#*://}"
+        case "$tmp" in
+            */*) api_prefix="/${tmp#*/}" ;;
+        esac
+        api_prefix="${api_prefix%/}"
+    fi
+
+    echo "Waiting for imbi-api to become healthy at ${api_prefix}/status..."
     local attempts=0
     local max_attempts=30
     until python3 -c "
 import http.client
 try:
     conn = http.client.HTTPConnection('localhost', 8000, timeout=2)
-    conn.request('GET', '/status')
+    conn.request('GET', '${api_prefix}/status')
     resp = conn.getresponse()
     exit(0 if resp.status == 200 else 1)
 except Exception:


### PR DESCRIPTION
## Summary
- Parse the path component out of `IMBI_API_URL` in `entrypoint.sh` and prepend it to the `/status` request issued by the api healthcheck.
- `https://imbi.aweber.io/api` → healthcheck hits `/api/status`; `https://imbi.aweber.io` → healthcheck hits `/status`.

## Problem
Caddy was switched from `handle_path` to `handle`, so imbi-api now serves under the prefix declared in `IMBI_API_URL` (e.g. `/api/status`). The in-container healthcheck was hardcoded to `GET /status` and would fail in any deployment with a non-empty path component.

## Test plan
- [ ] Deploy with `IMBI_API_URL=https://imbi.aweber.io/api` and confirm `start_api` reports healthy.
- [ ] Deploy with `IMBI_API_URL=https://imbi.aweber.io` (no path) and confirm `start_api` reports healthy.
- [ ] Verify imbi-api still serves a `/status` endpoint (the previous commit on `main` removed it).