### PR TITLE
Match bare /docs path in Caddyfile route

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -12,7 +12,7 @@
 		reverse_proxy 127.0.0.1:8002
 	}
 
-	handle /docs/* {
+	handle /docs /docs/* {
 		reverse_proxy 127.0.0.1:8000
 	}
 


### PR DESCRIPTION
## Summary

The Caddyfile's `/docs/*` matcher only catches `/docs/<sub>`, so a request to the bare `/docs` path fell through to the static UI handler and returned `index.html` instead of FastAPI's Swagger UI. As a result, `https://imbi.aweber.io/docs` was serving the main Imbi UI instead of the API documentation.

## Problem

In Caddy, the path matcher `/docs/*` requires at least one character after the slash. The bare path `/docs` does not match, so it falls through to the catch-all `handle { ... }` block on line 35 that serves `/srv/ui/index.html`. FastAPI's Swagger UI is mounted at the exact path `/docs`, so it was effectively unreachable through the proxy. The `/openapi.json` route already uses an exact-path matcher on line 27, which is why the schema endpoint worked.

## Solution

Add `/docs` as a second matcher on the same `handle` directive so both the bare entry point and the assets it loads (e.g. `/docs/oauth2-redirect`) are proxied to imbi-api.

## Test plan

- [ ] Build the image (`just build`) and bring the stack up locally
- [ ] `curl -fI http://localhost:8080/docs` returns 200 with `text/html` from imbi-api (not the UI shell)
- [ ] `curl -fI http://localhost:8080/openapi.json` still returns 200 (regression check)
- [ ] Loading `/docs` in a browser renders Swagger UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)