### PR TITLE
Add Sentry CLI, conditional source map serving, and startup upload

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -36,6 +36,18 @@
 		reverse_proxy 127.0.0.1:8000
 	}
 
+	@sourcemaps path *.map
+	handle @sourcemaps {
+		@maps_allowed expression `{env.SERVE_SOURCE_MAPS} == "true"`
+		handle @maps_allowed {
+			root * /srv/ui
+			file_server
+		}
+		handle {
+			respond "Not Found" 404
+		}
+	}
+
 	handle {
 		root * /srv/ui
 		try_files {path} /index.html

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,12 @@ RUN uv venv --python $(which python3) $UV_PROJECT_DIRECTORY \
 FROM caddy:${CADDY_VERSION} AS caddy
 
 # ---------------------------------------------------------------------------
-# Stage 4: Final runtime image
+# Stage 4: Sentry CLI binary
+# ---------------------------------------------------------------------------
+FROM getsentry/sentry-cli AS sentry-cli
+
+# ---------------------------------------------------------------------------
+# Stage 5: Final runtime image
 # ---------------------------------------------------------------------------
 FROM python:${PYTHON_VERSION}-slim AS runtime
 
@@ -70,6 +75,9 @@ COPY --from=python-builder --chown=imbi:users /app/ /app/
 
 # Copy Caddy binary
 COPY --from=caddy /usr/bin/caddy /usr/local/bin/caddy
+
+# Copy Sentry CLI binary
+COPY --from=sentry-cli /bin/sentry-cli /usr/local/bin/sentry-cli
 
 # Copy Caddyfile
 COPY Caddyfile /etc/caddy/Caddyfile

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -98,6 +98,34 @@ esac
 check_errors "service '$IMBI_SERVICE'"
 
 # --------------------------------------------------------------------------
+# Optional: upload source maps to Sentry
+# --------------------------------------------------------------------------
+# Runs when SENTRY_AUTH_TOKEN, SENTRY_ORG, and SENTRY_PROJECT are all set.
+# SENTRY_RELEASE defaults to unversioned if not provided.
+# Maps remain in the image; whether they are served is controlled by
+# the SERVE_SOURCE_MAPS env var (Caddy returns 404 unless it is "true").
+
+upload_sourcemaps() {
+    if [ -z "${SENTRY_AUTH_TOKEN:-}" ] || \
+       [ -z "${SENTRY_ORG:-}" ] || \
+       [ -z "${SENTRY_PROJECT:-}" ]; then
+        return
+    fi
+    echo "Uploading source maps to Sentry..."
+    local args="--org $SENTRY_ORG --project $SENTRY_PROJECT"
+    if [ -n "${SENTRY_RELEASE:-}" ]; then
+        args="$args --release $SENTRY_RELEASE"
+    fi
+    if [ -n "${SENTRY_URL:-}" ]; then
+        args="$args --url $SENTRY_URL"
+    fi
+    sentry-cli sourcemaps upload $args /srv/ui/assets/
+    echo "Source maps uploaded."
+}
+
+upload_sourcemaps
+
+# --------------------------------------------------------------------------
 # Service startup
 # --------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- `Dockerfile`: add `getsentry/sentry-cli` build stage and copy binary into runtime image (same pattern as Caddy)
- `Caddyfile`: intercept `*.map` requests before the catch-all; return 404 by default, serve only when `SERVE_SOURCE_MAPS=true`
- `entrypoint.sh`: `upload_sourcemaps()` runs at startup and uploads source maps to Sentry when `SENTRY_AUTH_TOKEN`, `SENTRY_ORG`, and `SENTRY_PROJECT` are all set

## Problem

The UI build now generates source maps (see imbi-ui PR), but there was no mechanism to upload them to Sentry or control whether they were served publicly.

## Solution

Source maps are included in the image and blocked by Caddy by default. Operators can opt in to public serving via `SERVE_SOURCE_MAPS=true`. For symbolicated Sentry stack traces, set `SENTRY_AUTH_TOKEN` + `SENTRY_ORG` + `SENTRY_PROJECT` — upload happens once at startup. `SENTRY_URL` is honoured for self-hosted Sentry instances; `SENTRY_RELEASE` enables release correlation.

Since Imbi is open-source the source is already public, so `SERVE_SOURCE_MAPS=true` carries no additional exposure risk for standard deployments.

## Test plan

- [ ] Image builds successfully
- [ ] `*.map` requests return 404 without `SERVE_SOURCE_MAPS=true`
- [ ] `*.map` requests are served with `SERVE_SOURCE_MAPS=true`
- [ ] Source maps uploaded at startup when all three Sentry vars are set
- [ ] Startup completes normally when Sentry vars are absent