### PR TITLE
Auto-refresh UI when a new release is built

### DIFF
--- a/.github/workflows/build-and-deploy.yaml
+++ b/.github/workflows/build-and-deploy.yaml
@@ -46,6 +46,10 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Resolve tag for build args
+        id: ref
+        run: echo "tag=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
+
       - name: Build and push by digest
         id: build
         uses: docker/build-push-action@v6
@@ -53,6 +57,8 @@ jobs:
           context: .
           file: ./Dockerfile
           platforms: ${{ matrix.platform }}
+          build-args: |
+            VITE_GIT_REF=${{ steps.ref.outputs.tag }}
           outputs: type=image,name=${{ env.GHCR_IMAGE }},push-by-digest=true,name-canonical=true,push=true
           cache-from: type=gha,scope=${{ env.PLATFORM_PAIR }}
           cache-to: type=gha,mode=max,scope=${{ env.PLATFORM_PAIR }}

--- a/Caddyfile
+++ b/Caddyfile
@@ -4,6 +4,9 @@
 }
 
 :8080 {
+	@no_cache path /index.html /version.json
+	header @no_cache Cache-Control "no-cache, no-store, must-revalidate"
+
 	handle /api/* {
 		reverse_proxy 127.0.0.1:8000
 	}

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,8 @@ ARG NODE_VERSION=22
 FROM node:${NODE_VERSION}-slim AS ui-builder
 
 WORKDIR /tmp/build
+ARG VITE_GIT_REF=""
+ENV VITE_GIT_REF=${VITE_GIT_REF}
 COPY imbi-ui/package.json imbi-ui/package-lock.json ./
 RUN npm ci
 COPY imbi-ui/ ./

--- a/justfile
+++ b/justfile
@@ -9,12 +9,12 @@ image := "ghcr.io/aweber-imbi/imbi"
 [doc("Build the Docker image")]
 [group("Build Docker")]
 build tag="latest":
-    docker build -t {{ image }}:{{ tag }} .
+    docker build --build-arg VITE_GIT_REF={{ tag }} -t {{ image }}:{{ tag }} .
 
 [doc("Build the Docker image and tag as both version and latest")]
 [group("Build Docker")]
 release tag:
-    docker build -t {{ image }}:{{ tag }} -t {{ image }}:latest .
+    docker build --build-arg VITE_GIT_REF={{ tag }} -t {{ image }}:{{ tag }} -t {{ image }}:latest .
 
 [doc("Update all submodules to what is currently checked in")]
 [group("Submodules")]


### PR DESCRIPTION
## Summary
- Plumbs the release tag into the UI build as `VITE_GIT_REF` via Docker build-arg (Dockerfile, justfile, CI workflow)
- Caddy now serves `/index.html` and `/version.json` with `Cache-Control: no-cache, no-store, must-revalidate` so the browser actually sees new releases

## Companion change
Pairs with [imbi-ui#X](https://github.com/AWeber-Imbi/imbi-ui) which adds the version manifest and client-side polling hook. Without that PR this change is a no-op (no `/version.json` is emitted by the UI build).

## Test plan
- [ ] `just build v0.0.0-test` succeeds and produces an image with `/srv/ui/version.json` containing the tag
- [ ] Curl `:8080/version.json` returns `Cache-Control: no-cache, no-store, must-revalidate`
- [ ] CI tag push passes `VITE_GIT_REF` through to the build