### PR TITLE
Fix /mcp Caddy routing to preserve path prefix

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -27,7 +27,8 @@
 		reverse_proxy 127.0.0.1:8003
 	}
 
-	handle_path /mcp/* {
+	@mcp path /mcp /mcp/*
+	handle @mcp {
 		reverse_proxy 127.0.0.1:8001
 	}
 


### PR DESCRIPTION
## Summary

The `imbi-mcp` server is unreachable in production because Caddy strips the `/mcp` prefix before proxying, but FastMCP's streamable-http transport mounts its endpoint at `/mcp`.

## Problem

The route used `handle_path /mcp/*`, which **strips** the matched prefix. FastMCP serves the MCP endpoint at `/mcp` (verified locally):

| Path at imbi-mcp | Result |
|---|---|
| `/` (what `handle_path` produced from `/mcp/`) | **404** |
| `/mcp` | 200 |
| `/mcp/` | 307 → `/mcp` |

So `/mcp/` requests arrived as `/` → 404, and bare `/mcp` didn't match `/mcp/*` at all → fell through to the SPA catch-all and returned `index.html`. Either way the MCP server could not be reached.

## Solution

Switch to a path matcher + `handle` (preserves the prefix), covering both `/mcp` and `/mcp/*` — mirroring how `/api/*` and `/assistant/*` are already routed.

```caddy
@mcp path /mcp /mcp/*
handle @mcp {
    reverse_proxy 127.0.0.1:8001
}
```

Validated with `caddy validate` (clean) and confirmed end-to-end that auth-header forwarding works once the path reaches imbi-mcp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)