### PR TITLE
Route OAuth discovery documents for MCP login

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -27,7 +27,8 @@
 		reverse_proxy 127.0.0.1:8003
 	}
 
-	handle_path /mcp/* {
+	@mcp path /mcp /mcp/*
+	handle @mcp {
 		reverse_proxy 127.0.0.1:8001
 	}
 

--- a/Caddyfile
+++ b/Caddyfile
@@ -32,6 +32,18 @@
 		reverse_proxy 127.0.0.1:8001
 	}
 
+	# OAuth discovery: imbi-mcp serves Protected Resource Metadata
+	# (RFC 9728); imbi-api serves Authorization Server metadata
+	# (RFC 8414) unprefixed at the root. Both must keep their full path,
+	# so use handle (not handle_path).
+	handle /.well-known/oauth-protected-resource* {
+		reverse_proxy 127.0.0.1:8001
+	}
+
+	handle /.well-known/oauth-authorization-server* {
+		reverse_proxy 127.0.0.1:8000
+	}
+
 	handle /openapi.json {
 		reverse_proxy 127.0.0.1:8000
 	}

--- a/runtime/env-file
+++ b/runtime/env-file
@@ -6,6 +6,12 @@ IMBI_AUTH_JWT_SECRET="dev-jwt-secret-change-in-production"
 # (the API's public URL). Default targets the in-pod loopback used
 # by the all-in-one image.
 IMBI_INTERNAL_API_URL="http://localhost:8000"
+# Enable the imbi-mcp OAuth login flow (browser sign-in for MCP clients)
+# by pointing it at this deployment's public URLs. Leave unset to keep
+# imbi-mcp in token-only pass-through mode. IMBI_MCP_AUTH_SERVER_URL is the
+# public origin (the OAuth issuer); IMBI_MCP_PUBLIC_URL is the public /mcp URL.
+# IMBI_MCP_PUBLIC_URL="https://imbi.example.com/mcp"
+# IMBI_MCP_AUTH_SERVER_URL="https://imbi.example.com"
 IMBI_EMAIL_SMTP_HOST="mailpit"
 IMBI_EMAIL_SMTP_PORT="1025"
 IMBI_EMAIL_SMTP_USE_TLS="false"


### PR DESCRIPTION
## Summary

Final piece of the MCP OAuth login flow (with imbi-api#413, imbi-mcp#12, imbi-ui#390, imbi-common#142). Routes the two OAuth discovery documents and documents the env vars that enable the flow.

## Changes

- Caddy: prefix-preserving `handle` routes so discovery resolves at the host root:
  - `/.well-known/oauth-protected-resource*` → imbi-mcp (RFC 9728 Protected Resource Metadata, served by FastMCP).
  - `/.well-known/oauth-authorization-server*` → imbi-api (RFC 8414 Authorization Server metadata, mounted unprefixed).
- `runtime/env-file`: documents `IMBI_MCP_PUBLIC_URL` and `IMBI_MCP_AUTH_SERVER_URL`. `imbi-mcp serve` reads these from the environment; when set, it becomes an OAuth Resource Server, otherwise it stays in token-only pass-through (no behavior change).

## Discovery chain (once enabled)

1. Client `GET https://host/mcp` (no token) → imbi-mcp `401` + `WWW-Authenticate` pointing at `https://host/.well-known/oauth-protected-resource/mcp`.
2. PRM (imbi-mcp) names imbi-api as the authorization server → client fetches `https://host/.well-known/oauth-authorization-server` (imbi-api).
3. Client registers (`/api/auth/register`), runs authorize + PKCE, exchanges the code for an Imbi JWT, and calls `/mcp` with it.

## Operator note

Set `IMBI_MCP_PUBLIC_URL` (e.g. `https://imbi.example.com/mcp`) and `IMBI_MCP_AUTH_SERVER_URL` (e.g. `https://imbi.example.com`) on the mcp service to enable OAuth. Builds on the `/mcp` prefix-preserving fix (#135); validated with `caddy validate`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)