### PR TITLE
Trust private-range proxies for X-Forwarded-* headers

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -1,6 +1,14 @@
 {
 	auto_https off
 	admin 0.0.0.0:2019
+	servers {
+		# Honor X-Forwarded-* from the fronting load balancer so the
+		# backends see the original client scheme/host. Without this,
+		# Caddy overwrites X-Forwarded-Proto with the scheme it saw
+		# (http), which breaks imbi-api's per-request public URL
+		# derivation for the OAuth/MCP discovery documents.
+		trusted_proxies static private_ranges
+	}
 }
 
 :8080 {


### PR DESCRIPTION
## Summary
Add `trusted_proxies static private_ranges` to the Caddyfile global servers options so Caddy passes the fronting load balancer's `X-Forwarded-*` headers through to the backend services.

## Problem
Remote MCP clients (Claude Desktop) fail to connect to `https://imbi-public.aweber.io/mcp` with `mcp_registration_failed`. The OAuth authorization-server discovery document served on the public host advertises the internal-host endpoints (`https://imbi.aweber.io/api/auth/register` etc.), which Anthropic's cloud cannot reach, so dynamic client registration times out.

imbi-api derives the public origin per request, but only honors it when the request scheme/host match a trusted origin. Caddy does not trust upstream proxies by default, so it overwrites the ALB's `X-Forwarded-Proto: https` with the scheme of the hop it terminated (`http`). The derived origin `http://imbi-public.aweber.io` never matches the trusted `https://` origin, and the discovery document falls back to the internal `IMBI_API_URL`.

## Solution
Trust `X-Forwarded-*` headers from private-range source addresses (the in-cluster ALB targets), so the original client scheme reaches imbi-api intact.

## Impact
- Deployments must also set `IMBI_API_FORWARDED_ALLOW_IPS=127.0.0.1` so imbi-api installs the proxy-headers middleware and honors the headers Caddy forwards (documented in imbi-api's configuration docs).
- Requires an image rebuild/redeploy to take effect.

## Testing
Validated the Caddyfile with `caddy validate` (caddy:2 in Docker). Diagnosed the broken behavior against the production service via port-forward: with `Host: imbi-public.aweber.io` and `X-Forwarded-Proto: https`, `/.well-known/oauth-authorization-server` still returned the internal issuer.