### PR TITLE
Add document version history and editing presence

### DIFF
--- a/apps/api/src/imbi/api/endpoints/_document_history.py
+++ b/apps/api/src/imbi/api/endpoints/_document_history.py
@@ -1,0 +1,171 @@
+"""Version-history recording for documents (ClickHouse write side).
+
+Owns the versioning policy: what counts as a new version
+(:func:`resolve_change`) and how snapshots are recorded
+(:func:`record_created` / :func:`record_updated`). The read-side
+endpoints live in ``document_versions.py``; keeping the recorder here
+lets both ``documents.py`` and ``document_versions.py`` import it
+top-level without a cycle.
+
+Snapshot capture is best-effort: the graph is the source of truth, so
+a failed ClickHouse insert is logged rather than surfaced as an error
+(the affected version number is simply absent from the history).
+"""
+
+import datetime
+import logging
+import typing
+
+import pydantic
+
+from imbi.common import clickhouse
+
+LOGGER = logging.getLogger(__name__)
+
+ChangeKind = typing.Literal['create', 'update', 'restore', 'baseline']
+
+
+class DocumentVersionRow(pydantic.BaseModel):
+    """One row in the ``document_versions`` ClickHouse table."""
+
+    document_id: str
+    version: int
+    title: str
+    content: str
+    tags: list[str]
+    change_kind: ChangeKind
+    updated_by: str
+    updated_at: datetime.datetime
+    recorded_at: datetime.datetime
+
+
+def has_changed(
+    existing: dict[str, typing.Any],
+    title: str,
+    content: str,
+    tags: list[str],
+) -> bool:
+    """Whether an update produces a new version.
+
+    Only title/content/tag changes count; pin toggles and no-op
+    patches keep the current version. The version number itself is
+    assigned atomically by the graph ``SET`` so concurrent saves
+    cannot collide on it.
+    """
+    return (
+        title != str(existing.get('title') or '')
+        or content != existing['content']
+        or sorted(tags) != sorted(t['slug'] for t in existing.get('tags', []))
+    )
+
+
+async def _has_history(document_id: str) -> bool:
+    """Whether any version rows exist for the document."""
+    rows = await clickhouse.query(
+        'SELECT count() AS c FROM document_versions '
+        'WHERE document_id = {document_id:String}',
+        {'document_id': document_id},
+    )
+    return bool(rows and int(rows[0].get('c') or 0))
+
+
+async def record_created(
+    document_id: str,
+    title: str,
+    content: str,
+    tags: list[str],
+    created_by: str,
+    created_at: datetime.datetime,
+) -> None:
+    """Record version 1 for a newly created document. Best-effort."""
+    try:
+        await clickhouse.insert(
+            'document_versions',
+            [
+                DocumentVersionRow(
+                    document_id=document_id,
+                    version=1,
+                    title=title,
+                    content=content,
+                    tags=tags,
+                    change_kind='create',
+                    updated_by=created_by,
+                    updated_at=created_at,
+                    recorded_at=created_at,
+                )
+            ],
+        )
+    except Exception:
+        LOGGER.exception(
+            'failed to record create snapshot for document %s', document_id
+        )
+
+
+async def record_updated(
+    document_id: str,
+    previous: dict[str, typing.Any],
+    new_version: int,
+    title: str,
+    content: str,
+    tags: list[str],
+    change_kind: ChangeKind,
+    updated_by: str,
+    updated_at: datetime.datetime,
+) -> None:
+    """Record a snapshot for an edited document. Best-effort.
+
+    ``previous`` is the parsed document dict as it was before the edit.
+    When a document at version 1 has no history yet (it predates
+    versioning, or its create snapshot was lost), the pre-edit state is
+    first written as a ``baseline`` row so the original content is
+    retained. Documents already past version 1 were versioned by this
+    code path, so the existence probe is skipped for them.
+    """
+    now = datetime.datetime.now(datetime.UTC)
+    try:
+        rows: list[pydantic.BaseModel] = []
+        if new_version <= 2 and not await _has_history(document_id):
+            prev_ts = str(
+                previous.get('updated_at') or previous.get('created_at') or ''
+            )
+            rows.append(
+                DocumentVersionRow(
+                    document_id=document_id,
+                    version=new_version - 1,
+                    title=str(previous.get('title') or ''),
+                    content=str(previous.get('content') or ''),
+                    tags=[t['slug'] for t in previous.get('tags', [])],
+                    change_kind='baseline',
+                    updated_by=str(
+                        previous.get('updated_by')
+                        or previous.get('created_by')
+                        or ''
+                    ),
+                    updated_at=(
+                        datetime.datetime.fromisoformat(prev_ts)
+                        if prev_ts
+                        else now
+                    ),
+                    recorded_at=now,
+                )
+            )
+        rows.append(
+            DocumentVersionRow(
+                document_id=document_id,
+                version=new_version,
+                title=title,
+                content=content,
+                tags=tags,
+                change_kind=change_kind,
+                updated_by=updated_by,
+                updated_at=updated_at,
+                recorded_at=now,
+            )
+        )
+        await clickhouse.insert('document_versions', rows)
+    except Exception:
+        LOGGER.exception(
+            'failed to record version %s for document %s',
+            new_version,
+            document_id,
+        )

--- a/apps/api/src/imbi/api/endpoints/document_presence.py
+++ b/apps/api/src/imbi/api/endpoints/document_presence.py
@@ -1,0 +1,133 @@
+"""Advisory "currently editing" presence markers for documents.
+
+Editors are tracked in a Valkey sorted set per document
+(``imbi:document:editing:<document_id>``) whose members are principal
+names (emails) scored by their expiry timestamp. A heartbeat refreshes
+the caller's entry; stale entries are pruned on every read. Presence
+is purely advisory — it never blocks an edit — so every operation
+degrades to "nobody is editing" when Valkey is unavailable rather
+than failing the request.
+
+Document existence is deliberately not verified here: heartbeats fire
+every few seconds per open editor and a graph round-trip per beat
+would be wasted load for a marker that expires on its own.
+"""
+
+import logging
+import time
+import typing
+
+import fastapi
+import pydantic
+from valkey import asyncio as valkey_asyncio
+
+from imbi.api.auth import permissions
+from imbi.common import valkey
+
+LOGGER = logging.getLogger(__name__)
+
+document_presence_router = fastapi.APIRouter(tags=['Documents'])
+
+PRESENCE_KEY_PREFIX = 'imbi:document:editing'
+PRESENCE_TTL_SECONDS = 30
+
+
+class DocumentEditorsResponse(pydantic.BaseModel):
+    """Who currently holds an editing marker on the document."""
+
+    editors: list[str]
+    ttl_seconds: int = PRESENCE_TTL_SECONDS
+
+
+def _key(document_id: str) -> str:
+    return f'{PRESENCE_KEY_PREFIX}:{document_id}'
+
+
+async def _active_editors(
+    client: valkey_asyncio.Valkey, document_id: str
+) -> list[str]:
+    """Prune expired entries and return the remaining editors, sorted."""
+    key = _key(document_id)
+    await client.zremrangebyscore(key, '-inf', time.time())
+    raw = await client.zrange(  # pyright: ignore[reportUnknownMemberType]
+        key, 0, -1
+    )
+    members = typing.cast('list[bytes]', raw)
+    return sorted(m.decode() for m in members)
+
+
+@document_presence_router.get('', response_model=DocumentEditorsResponse)
+async def get_document_editors(
+    org_slug: str,
+    document_id: str,
+    client: valkey.Client,
+    _auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(permissions.require_permission('document:read')),
+    ],
+) -> DocumentEditorsResponse:
+    """List who is currently editing the document."""
+    try:
+        editors = await _active_editors(client, document_id)
+    except Exception:
+        LOGGER.exception(
+            'failed to read editing presence for document %s', document_id
+        )
+        editors = []
+    return DocumentEditorsResponse(editors=editors)
+
+
+@document_presence_router.put('', response_model=DocumentEditorsResponse)
+async def heartbeat_document_editing(
+    org_slug: str,
+    document_id: str,
+    client: valkey.Client,
+    auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(permissions.require_permission('document:write')),
+    ],
+) -> DocumentEditorsResponse:
+    """Start or refresh the caller's editing marker.
+
+    Idempotent; clients call this every few seconds while the editor
+    is open. The response includes every active editor (including the
+    caller) so the editing client needs no separate GET poll.
+    """
+    key = _key(document_id)
+    try:
+        await client.zadd(
+            key, {auth.principal_name: time.time() + PRESENCE_TTL_SECONDS}
+        )
+        # Cap the key's own lifetime so abandoned documents leave no
+        # keys behind once every member has expired.
+        await client.expire(key, PRESENCE_TTL_SECONDS)
+        editors = await _active_editors(client, document_id)
+    except Exception:
+        LOGGER.exception(
+            'failed to record editing presence for document %s', document_id
+        )
+        editors = []
+    return DocumentEditorsResponse(editors=editors)
+
+
+@document_presence_router.delete('', status_code=204)
+async def clear_document_editing(
+    org_slug: str,
+    document_id: str,
+    client: valkey.Client,
+    auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(permissions.require_permission('document:write')),
+    ],
+) -> None:
+    """Remove the caller's editing marker (done editing).
+
+    Best-effort — the marker expires on its own within
+    ``PRESENCE_TTL_SECONDS`` regardless.
+    """
+    try:
+        await client.zrem(_key(document_id), auth.principal_name)
+    except Exception:
+        LOGGER.exception(
+            'failed to clear editing presence for document %s', document_id
+        )

--- a/apps/api/src/imbi/api/endpoints/document_presence.py
+++ b/apps/api/src/imbi/api/endpoints/document_presence.py
@@ -1,9 +1,9 @@
 """Advisory "currently editing" presence markers for documents.
 
 Editors are tracked in a Valkey sorted set per document
-(``imbi:document:editing:<document_id>``) whose members are principal
-names (emails) scored by their expiry timestamp. A heartbeat refreshes
-the caller's entry; stale entries are pruned on every read. Presence
+(``imbi:document:editing:<org_slug>:<document_id>``) whose members are
+principal names (emails) scored by their expiry timestamp. A heartbeat
+refreshes the caller's entry; stale entries are pruned on every read. Presence
 is purely advisory — it never blocks an edit — so every operation
 degrades to "nobody is editing" when Valkey is unavailable rather
 than failing the request.
@@ -39,21 +39,30 @@ class DocumentEditorsResponse(pydantic.BaseModel):
     ttl_seconds: int = PRESENCE_TTL_SECONDS
 
 
-def _key(document_id: str) -> str:
-    return f'{PRESENCE_KEY_PREFIX}:{document_id}'
+def _key(org_slug: str, document_id: str) -> str:
+    # Keyed by org so presence for one org's documents can never be
+    # read or written through another org's URL space.
+    return f'{PRESENCE_KEY_PREFIX}:{org_slug}:{document_id}'
+
+
+def _decode_members(raw: typing.Any) -> list[str]:
+    members = typing.cast('list[bytes]', raw)
+    return sorted(m.decode() for m in members)
 
 
 async def _active_editors(
-    client: valkey_asyncio.Valkey, document_id: str
+    client: valkey_asyncio.Valkey, org_slug: str, document_id: str
 ) -> list[str]:
-    """Prune expired entries and return the remaining editors, sorted."""
-    key = _key(document_id)
-    await client.zremrangebyscore(key, '-inf', time.time())
-    raw = await client.zrange(  # pyright: ignore[reportUnknownMemberType]
-        key, 0, -1
-    )
-    members = typing.cast('list[bytes]', raw)
-    return sorted(m.decode() for m in members)
+    """Prune expired entries and return the remaining editors, sorted.
+
+    Batched in a single pipeline so a read costs one round-trip.
+    """
+    key = _key(org_slug, document_id)
+    pipe = client.pipeline(transaction=False)
+    pipe.zremrangebyscore(key, '-inf', time.time())
+    pipe.zrange(key, 0, -1)  # pyright: ignore[reportUnknownMemberType]
+    results = await pipe.execute()  # pyright: ignore[reportUnknownVariableType, reportUnknownMemberType]
+    return _decode_members(results[-1])
 
 
 @document_presence_router.get('', response_model=DocumentEditorsResponse)
@@ -68,7 +77,7 @@ async def get_document_editors(
 ) -> DocumentEditorsResponse:
     """List who is currently editing the document."""
     try:
-        editors = await _active_editors(client, document_id)
+        editors = await _active_editors(client, org_slug, document_id)
     except Exception:
         LOGGER.exception(
             'failed to read editing presence for document %s', document_id
@@ -91,17 +100,21 @@ async def heartbeat_document_editing(
 
     Idempotent; clients call this every few seconds while the editor
     is open. The response includes every active editor (including the
-    caller) so the editing client needs no separate GET poll.
+    caller) so the editing client needs no separate GET poll. All four
+    Valkey commands are batched in one pipeline (one round-trip).
     """
-    key = _key(document_id)
+    key = _key(org_slug, document_id)
+    now = time.time()
     try:
-        await client.zadd(
-            key, {auth.principal_name: time.time() + PRESENCE_TTL_SECONDS}
-        )
+        pipe = client.pipeline(transaction=False)
+        pipe.zadd(key, {auth.principal_name: now + PRESENCE_TTL_SECONDS})
         # Cap the key's own lifetime so abandoned documents leave no
         # keys behind once every member has expired.
-        await client.expire(key, PRESENCE_TTL_SECONDS)
-        editors = await _active_editors(client, document_id)
+        pipe.expire(key, PRESENCE_TTL_SECONDS)
+        pipe.zremrangebyscore(key, '-inf', now)
+        pipe.zrange(key, 0, -1)  # pyright: ignore[reportUnknownMemberType]
+        results = await pipe.execute()  # pyright: ignore[reportUnknownVariableType, reportUnknownMemberType]
+        editors = _decode_members(results[-1])
     except Exception:
         LOGGER.exception(
             'failed to record editing presence for document %s', document_id
@@ -126,7 +139,7 @@ async def clear_document_editing(
     ``PRESENCE_TTL_SECONDS`` regardless.
     """
     try:
-        await client.zrem(_key(document_id), auth.principal_name)
+        await client.zrem(_key(org_slug, document_id), auth.principal_name)
     except Exception:
         LOGGER.exception(
             'failed to clear editing presence for document %s', document_id

--- a/apps/api/src/imbi/api/endpoints/document_versions.py
+++ b/apps/api/src/imbi/api/endpoints/document_versions.py
@@ -1,52 +1,25 @@
-"""Document version history backed by ClickHouse.
+"""Document version-history endpoints (ClickHouse read side).
 
-Every content-affecting change to a ``Document`` node (title, content,
-or tags) appends a full snapshot row to the ``document_versions``
-ClickHouse table; the node itself carries the monotonically increasing
-``version`` counter. Documents that predate versioning get a
-``baseline`` snapshot of their pre-edit state the first time they are
-edited so the original content is never lost.
-
-Snapshot capture is best-effort: the graph is the source of truth, so
-a failed ClickHouse insert is logged rather than surfaced as an error
-(the affected version number is simply absent from the history).
-
-``documents.py`` calls :func:`record_created` / :func:`record_updated`
-via deferred imports; this module imports ``documents`` at module
-level, so the reverse edge must stay lazy to avoid a cycle.
+Snapshots are recorded by :mod:`imbi.api.endpoints._document_history`
+on every content-affecting change; these endpoints list them, fetch a
+single snapshot, and restore one — restore applies the old snapshot as
+a normal update producing a new version, so history is never
+rewritten.
 """
 
 import datetime
-import logging
 import typing
 
 import fastapi
 import pydantic
 
-from imbi.api import patch as json_patch
 from imbi.api.auth import permissions
 from imbi.api.endpoints import documents
+from imbi.api.endpoints._document_history import ChangeKind
+from imbi.api.endpoints._helpers import fetch_or_404
 from imbi.common import clickhouse, graph
 
-LOGGER = logging.getLogger(__name__)
-
 document_versions_router = fastapi.APIRouter(tags=['Documents'])
-
-ChangeKind = typing.Literal['create', 'update', 'restore', 'baseline']
-
-
-class DocumentVersionRow(pydantic.BaseModel):
-    """One row in the ``document_versions`` ClickHouse table."""
-
-    document_id: str
-    version: int
-    title: str
-    content: str
-    tags: list[str]
-    change_kind: ChangeKind
-    updated_by: str
-    updated_at: datetime.datetime
-    recorded_at: datetime.datetime
 
 
 class DocumentVersionInfo(pydantic.BaseModel):
@@ -68,131 +41,6 @@ class DocumentVersionListResponse(pydantic.BaseModel):
     data: list[DocumentVersionInfo]
 
 
-async def _insert_rows(rows: list[DocumentVersionRow]) -> None:
-    await clickhouse.insert('document_versions', list(rows))
-
-
-async def _max_recorded_version(document_id: str) -> int | None:
-    """Highest version recorded in ClickHouse, or None when no history."""
-    rows = await clickhouse.query(
-        'SELECT max(version) AS v, count() AS c FROM document_versions '
-        'WHERE document_id = {document_id:String}',
-        {'document_id': document_id},
-    )
-    if not rows or not int(rows[0].get('c') or 0):
-        return None
-    return int(rows[0]['v'])
-
-
-def _parse_ts(
-    value: typing.Any, fallback: datetime.datetime
-) -> datetime.datetime:
-    if isinstance(value, datetime.datetime):
-        return value
-    if isinstance(value, str) and value:
-        try:
-            return datetime.datetime.fromisoformat(value)
-        except ValueError:
-            return fallback
-    return fallback
-
-
-async def record_created(
-    document_id: str,
-    title: str,
-    content: str,
-    tags: list[str],
-    created_by: str,
-    created_at: datetime.datetime,
-) -> None:
-    """Record version 1 for a newly created document. Best-effort."""
-    try:
-        await _insert_rows(
-            [
-                DocumentVersionRow(
-                    document_id=document_id,
-                    version=1,
-                    title=title,
-                    content=content,
-                    tags=tags,
-                    change_kind='create',
-                    updated_by=created_by,
-                    updated_at=created_at,
-                    recorded_at=created_at,
-                )
-            ]
-        )
-    except Exception:
-        LOGGER.exception(
-            'failed to record create snapshot for document %s', document_id
-        )
-
-
-async def record_updated(
-    document_id: str,
-    previous: dict[str, typing.Any],
-    new_version: int,
-    title: str,
-    content: str,
-    tags: list[str],
-    change_kind: ChangeKind,
-    updated_by: str,
-    updated_at: datetime.datetime,
-) -> None:
-    """Record a snapshot for an edited document. Best-effort.
-
-    ``previous`` is the parsed document dict as it was before the edit.
-    When the document has no history yet (it predates versioning, or
-    its create snapshot was lost), the pre-edit state is first written
-    as a ``baseline`` row so the original content is retained.
-    """
-    now = datetime.datetime.now(datetime.UTC)
-    try:
-        rows: list[DocumentVersionRow] = []
-        if await _max_recorded_version(document_id) is None:
-            rows.append(
-                DocumentVersionRow(
-                    document_id=document_id,
-                    version=new_version - 1,
-                    title=str(previous.get('title') or ''),
-                    content=str(previous.get('content') or ''),
-                    tags=[t['slug'] for t in previous.get('tags', [])],
-                    change_kind='baseline',
-                    updated_by=str(
-                        previous.get('updated_by')
-                        or previous.get('created_by')
-                        or ''
-                    ),
-                    updated_at=_parse_ts(
-                        previous.get('updated_at')
-                        or previous.get('created_at'),
-                        now,
-                    ),
-                    recorded_at=now,
-                )
-            )
-        rows.append(
-            DocumentVersionRow(
-                document_id=document_id,
-                version=new_version,
-                title=title,
-                content=content,
-                tags=tags,
-                change_kind=change_kind,
-                updated_by=updated_by,
-                updated_at=updated_at,
-                recorded_at=now,
-            )
-        )
-        await _insert_rows(rows)
-    except Exception:
-        LOGGER.exception(
-            'failed to record version %s for document %s',
-            new_version,
-            document_id,
-        )
-
-
 def _row_to_dict(row: dict[str, typing.Any]) -> dict[str, typing.Any]:
     """Attach UTC to naive DateTime64 values coming back from ClickHouse."""
     out = dict(row)
@@ -200,18 +48,6 @@ def _row_to_dict(row: dict[str, typing.Any]) -> dict[str, typing.Any]:
     if isinstance(ts, datetime.datetime) and ts.tzinfo is None:
         out['updated_at'] = ts.replace(tzinfo=datetime.UTC)
     return out
-
-
-async def _require_document(
-    db: graph.Pool, org_slug: str, document_id: str
-) -> dict[str, typing.Any]:
-    """404 unless the document exists within the caller's org."""
-    existing = await documents.fetch_document(db, org_slug, document_id)
-    if existing is None:
-        raise fastapi.HTTPException(
-            status_code=404, detail=f'Document {document_id!r} not found'
-        )
-    return existing
 
 
 @document_versions_router.get('', response_model=DocumentVersionListResponse)
@@ -225,7 +61,13 @@ async def list_document_versions(
     ],
 ) -> dict[str, typing.Any]:
     """List a document's version history, newest first."""
-    await _require_document(db, org_slug, document_id)
+    await fetch_or_404(
+        documents.fetch_document,
+        db,
+        org_slug,
+        document_id,
+        detail=f'Document {document_id!r} not found',
+    )
     rows = await clickhouse.query(
         'SELECT version, title, change_kind, updated_by, updated_at '
         'FROM document_versions FINAL '
@@ -263,14 +105,19 @@ async def get_document_version(
     ],
 ) -> dict[str, typing.Any]:
     """Retrieve the full snapshot of a single document version."""
-    await _require_document(db, org_slug, document_id)
-    row = await _fetch_version(document_id, version)
-    if row is None:
-        raise fastapi.HTTPException(
-            status_code=404,
-            detail=f'Version {version} of document {document_id!r} not found',
-        )
-    return row
+    await fetch_or_404(
+        documents.fetch_document,
+        db,
+        org_slug,
+        document_id,
+        detail=f'Document {document_id!r} not found',
+    )
+    return await fetch_or_404(
+        _fetch_version,
+        document_id,
+        version,
+        detail=f'Version {version} of document {document_id!r} not found',
+    )
 
 
 @document_versions_router.post(
@@ -285,30 +132,43 @@ async def restore_document_version(
         permissions.AuthContext,
         fastapi.Depends(permissions.require_permission('document:write')),
     ],
+    background_tasks: fastapi.BackgroundTasks,
 ) -> dict[str, typing.Any]:
     """Restore a document to a previous version.
 
     Applies the old snapshot as a normal update, producing a new
     version with ``change_kind='restore'`` — history is never
-    rewritten.
+    rewritten. Snapshot tags that no longer exist in the org are
+    dropped rather than failing the restore.
     """
-    await _require_document(db, org_slug, document_id)
-    row = await _fetch_version(document_id, version)
-    if row is None:
-        raise fastapi.HTTPException(
-            status_code=404,
-            detail=f'Version {version} of document {document_id!r} not found',
-        )
-    operations = [
-        json_patch.PatchOperation.model_validate(
-            {'op': 'replace', 'path': path, 'value': value}
-        )
-        for path, value in (
-            ('/title', row['title']),
-            ('/content', row['content']),
-            ('/tags', list(row.get('tags') or [])),
-        )
-    ]
-    return await documents.patch_document_impl(
-        db, auth, org_slug, document_id, operations, change_kind='restore'
+    existing = await fetch_or_404(
+        documents.fetch_document,
+        db,
+        org_slug,
+        document_id,
+        detail=f'Document {document_id!r} not found',
+    )
+    row = await fetch_or_404(
+        _fetch_version,
+        document_id,
+        version,
+        detail=f'Version {version} of document {document_id!r} not found',
+    )
+    raw_tags: list[typing.Any] = row.get('tags') or []
+    tags = await documents.filter_existing_tag_slugs(
+        db, org_slug, [str(t) for t in raw_tags]
+    )
+    return await documents.apply_document_update(
+        db,
+        auth,
+        background_tasks,
+        org_slug,
+        document_id,
+        existing,
+        title=str(row['title']),
+        content=str(row['content']),
+        tags=tags,
+        replace_tags=True,
+        is_pinned=bool(existing.get('is_pinned', False)),
+        change_kind='restore',
     )

--- a/apps/api/src/imbi/api/endpoints/document_versions.py
+++ b/apps/api/src/imbi/api/endpoints/document_versions.py
@@ -1,0 +1,314 @@
+"""Document version history backed by ClickHouse.
+
+Every content-affecting change to a ``Document`` node (title, content,
+or tags) appends a full snapshot row to the ``document_versions``
+ClickHouse table; the node itself carries the monotonically increasing
+``version`` counter. Documents that predate versioning get a
+``baseline`` snapshot of their pre-edit state the first time they are
+edited so the original content is never lost.
+
+Snapshot capture is best-effort: the graph is the source of truth, so
+a failed ClickHouse insert is logged rather than surfaced as an error
+(the affected version number is simply absent from the history).
+
+``documents.py`` calls :func:`record_created` / :func:`record_updated`
+via deferred imports; this module imports ``documents`` at module
+level, so the reverse edge must stay lazy to avoid a cycle.
+"""
+
+import datetime
+import logging
+import typing
+
+import fastapi
+import pydantic
+
+from imbi.api import patch as json_patch
+from imbi.api.auth import permissions
+from imbi.api.endpoints import documents
+from imbi.common import clickhouse, graph
+
+LOGGER = logging.getLogger(__name__)
+
+document_versions_router = fastapi.APIRouter(tags=['Documents'])
+
+ChangeKind = typing.Literal['create', 'update', 'restore', 'baseline']
+
+
+class DocumentVersionRow(pydantic.BaseModel):
+    """One row in the ``document_versions`` ClickHouse table."""
+
+    document_id: str
+    version: int
+    title: str
+    content: str
+    tags: list[str]
+    change_kind: ChangeKind
+    updated_by: str
+    updated_at: datetime.datetime
+    recorded_at: datetime.datetime
+
+
+class DocumentVersionInfo(pydantic.BaseModel):
+    """Version metadata without the (potentially large) content."""
+
+    version: int
+    title: str
+    change_kind: ChangeKind
+    updated_by: str
+    updated_at: datetime.datetime
+
+
+class DocumentVersionResponse(DocumentVersionInfo):
+    content: str
+    tags: list[str] = []
+
+
+class DocumentVersionListResponse(pydantic.BaseModel):
+    data: list[DocumentVersionInfo]
+
+
+async def _insert_rows(rows: list[DocumentVersionRow]) -> None:
+    await clickhouse.insert('document_versions', list(rows))
+
+
+async def _max_recorded_version(document_id: str) -> int | None:
+    """Highest version recorded in ClickHouse, or None when no history."""
+    rows = await clickhouse.query(
+        'SELECT max(version) AS v, count() AS c FROM document_versions '
+        'WHERE document_id = {document_id:String}',
+        {'document_id': document_id},
+    )
+    if not rows or not int(rows[0].get('c') or 0):
+        return None
+    return int(rows[0]['v'])
+
+
+def _parse_ts(
+    value: typing.Any, fallback: datetime.datetime
+) -> datetime.datetime:
+    if isinstance(value, datetime.datetime):
+        return value
+    if isinstance(value, str) and value:
+        try:
+            return datetime.datetime.fromisoformat(value)
+        except ValueError:
+            return fallback
+    return fallback
+
+
+async def record_created(
+    document_id: str,
+    title: str,
+    content: str,
+    tags: list[str],
+    created_by: str,
+    created_at: datetime.datetime,
+) -> None:
+    """Record version 1 for a newly created document. Best-effort."""
+    try:
+        await _insert_rows(
+            [
+                DocumentVersionRow(
+                    document_id=document_id,
+                    version=1,
+                    title=title,
+                    content=content,
+                    tags=tags,
+                    change_kind='create',
+                    updated_by=created_by,
+                    updated_at=created_at,
+                    recorded_at=created_at,
+                )
+            ]
+        )
+    except Exception:
+        LOGGER.exception(
+            'failed to record create snapshot for document %s', document_id
+        )
+
+
+async def record_updated(
+    document_id: str,
+    previous: dict[str, typing.Any],
+    new_version: int,
+    title: str,
+    content: str,
+    tags: list[str],
+    change_kind: ChangeKind,
+    updated_by: str,
+    updated_at: datetime.datetime,
+) -> None:
+    """Record a snapshot for an edited document. Best-effort.
+
+    ``previous`` is the parsed document dict as it was before the edit.
+    When the document has no history yet (it predates versioning, or
+    its create snapshot was lost), the pre-edit state is first written
+    as a ``baseline`` row so the original content is retained.
+    """
+    now = datetime.datetime.now(datetime.UTC)
+    try:
+        rows: list[DocumentVersionRow] = []
+        if await _max_recorded_version(document_id) is None:
+            rows.append(
+                DocumentVersionRow(
+                    document_id=document_id,
+                    version=new_version - 1,
+                    title=str(previous.get('title') or ''),
+                    content=str(previous.get('content') or ''),
+                    tags=[t['slug'] for t in previous.get('tags', [])],
+                    change_kind='baseline',
+                    updated_by=str(
+                        previous.get('updated_by')
+                        or previous.get('created_by')
+                        or ''
+                    ),
+                    updated_at=_parse_ts(
+                        previous.get('updated_at')
+                        or previous.get('created_at'),
+                        now,
+                    ),
+                    recorded_at=now,
+                )
+            )
+        rows.append(
+            DocumentVersionRow(
+                document_id=document_id,
+                version=new_version,
+                title=title,
+                content=content,
+                tags=tags,
+                change_kind=change_kind,
+                updated_by=updated_by,
+                updated_at=updated_at,
+                recorded_at=now,
+            )
+        )
+        await _insert_rows(rows)
+    except Exception:
+        LOGGER.exception(
+            'failed to record version %s for document %s',
+            new_version,
+            document_id,
+        )
+
+
+def _row_to_dict(row: dict[str, typing.Any]) -> dict[str, typing.Any]:
+    """Attach UTC to naive DateTime64 values coming back from ClickHouse."""
+    out = dict(row)
+    ts = out.get('updated_at')
+    if isinstance(ts, datetime.datetime) and ts.tzinfo is None:
+        out['updated_at'] = ts.replace(tzinfo=datetime.UTC)
+    return out
+
+
+async def _require_document(
+    db: graph.Pool, org_slug: str, document_id: str
+) -> dict[str, typing.Any]:
+    """404 unless the document exists within the caller's org."""
+    existing = await documents.fetch_document(db, org_slug, document_id)
+    if existing is None:
+        raise fastapi.HTTPException(
+            status_code=404, detail=f'Document {document_id!r} not found'
+        )
+    return existing
+
+
+@document_versions_router.get('', response_model=DocumentVersionListResponse)
+async def list_document_versions(
+    org_slug: str,
+    document_id: str,
+    db: graph.Pool,
+    _auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(permissions.require_permission('document:read')),
+    ],
+) -> dict[str, typing.Any]:
+    """List a document's version history, newest first."""
+    await _require_document(db, org_slug, document_id)
+    rows = await clickhouse.query(
+        'SELECT version, title, change_kind, updated_by, updated_at '
+        'FROM document_versions FINAL '
+        'WHERE document_id = {document_id:String} '
+        'ORDER BY version DESC',
+        {'document_id': document_id},
+    )
+    return {'data': [_row_to_dict(r) for r in rows]}
+
+
+async def _fetch_version(
+    document_id: str, version: int
+) -> dict[str, typing.Any] | None:
+    rows = await clickhouse.query(
+        'SELECT version, title, content, tags, change_kind, updated_by, '
+        'updated_at FROM document_versions FINAL '
+        'WHERE document_id = {document_id:String} '
+        'AND version = {version:UInt32} LIMIT 1',
+        {'document_id': document_id, 'version': version},
+    )
+    return _row_to_dict(rows[0]) if rows else None
+
+
+@document_versions_router.get(
+    '/{version}', response_model=DocumentVersionResponse
+)
+async def get_document_version(
+    org_slug: str,
+    document_id: str,
+    version: int,
+    db: graph.Pool,
+    _auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(permissions.require_permission('document:read')),
+    ],
+) -> dict[str, typing.Any]:
+    """Retrieve the full snapshot of a single document version."""
+    await _require_document(db, org_slug, document_id)
+    row = await _fetch_version(document_id, version)
+    if row is None:
+        raise fastapi.HTTPException(
+            status_code=404,
+            detail=f'Version {version} of document {document_id!r} not found',
+        )
+    return row
+
+
+@document_versions_router.post(
+    '/{version}/restore', response_model=documents.DocumentResponse
+)
+async def restore_document_version(
+    org_slug: str,
+    document_id: str,
+    version: int,
+    db: graph.Pool,
+    auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(permissions.require_permission('document:write')),
+    ],
+) -> dict[str, typing.Any]:
+    """Restore a document to a previous version.
+
+    Applies the old snapshot as a normal update, producing a new
+    version with ``change_kind='restore'`` — history is never
+    rewritten.
+    """
+    await _require_document(db, org_slug, document_id)
+    row = await _fetch_version(document_id, version)
+    if row is None:
+        raise fastapi.HTTPException(
+            status_code=404,
+            detail=f'Version {version} of document {document_id!r} not found',
+        )
+    operations = [
+        json_patch.PatchOperation.model_validate(
+            {'op': 'replace', 'path': path, 'value': value}
+        )
+        for path, value in (
+            ('/title', row['title']),
+            ('/content', row['content']),
+            ('/tags', list(row.get('tags') or [])),
+        )
+    ]
+    return await documents.patch_document_impl(
+        db, auth, org_slug, document_id, operations, change_kind='restore'
+    )

--- a/apps/api/src/imbi/api/endpoints/documents.py
+++ b/apps/api/src/imbi/api/endpoints/documents.py
@@ -24,6 +24,7 @@ import pydantic
 
 from imbi.api import patch as json_patch
 from imbi.api.auth import permissions
+from imbi.api.endpoints import _document_history
 from imbi.api.endpoints._helpers import fetch_or_404
 from imbi.api.endpoints._pagination import (
     build_link_header,
@@ -275,11 +276,12 @@ async def _detach_all_tags(
     await db.execute(query, {'document_id': document_id}, columns=['removed'])
 
 
-async def _validate_tag_slugs(
+async def _find_missing_tag_slugs(
     db: graph.Pool, org_slug: str, tag_slugs: list[str]
-) -> None:
+) -> list[str]:
+    """Return the subset of ``tag_slugs`` that do not exist in the org."""
     if not tag_slugs:
-        return
+        return []
     query: typing.LiteralString = """
     MATCH (o:Organization {{slug: {org_slug}}})
     UNWIND {slugs} AS tag_slug
@@ -291,16 +293,35 @@ async def _validate_tag_slugs(
         {'org_slug': org_slug, 'slugs': tag_slugs},
         columns=['tag_slug', 'found'],
     )
-    missing = [
-        graph.parse_agtype(r['tag_slug'])
+    return [
+        str(graph.parse_agtype(r['tag_slug']))
         for r in records
         if not graph.parse_agtype(r['found'])
     ]
+
+
+async def _validate_tag_slugs(
+    db: graph.Pool, org_slug: str, tag_slugs: list[str]
+) -> None:
+    missing = await _find_missing_tag_slugs(db, org_slug, tag_slugs)
     if missing:
         raise fastapi.HTTPException(
             status_code=422,
             detail=f'Tag slug(s) not found: {sorted(missing)!r}',
         )
+
+
+async def filter_existing_tag_slugs(
+    db: graph.Pool, org_slug: str, tag_slugs: list[str]
+) -> list[str]:
+    """Drop tag slugs that no longer exist in the org.
+
+    Used by version restore, where a snapshot may reference tags
+    deleted since it was taken — the restore should proceed without
+    them rather than fail.
+    """
+    missing = set(await _find_missing_tag_slugs(db, org_slug, tag_slugs))
+    return [t for t in tag_slugs if t not in missing]
 
 
 _DOCUMENT_CREATE_FRAGMENT: typing.LiteralString = """
@@ -321,6 +342,7 @@ _DOCUMENT_CREATE_FRAGMENT: typing.LiteralString = """
 async def _create_document_impl(
     db: graph.Pool,
     auth: permissions.AuthContext,
+    background_tasks: fastapi.BackgroundTasks,
     org_slug: str,
     data: DocumentCreate,
     anchor_match: typing.LiteralString,
@@ -353,11 +375,11 @@ async def _create_document_impl(
     if tag_slugs:
         await _attach_tags(db, org_slug, document_id, tag_slugs)
 
-    # Deferred import: document_versions imports this module for its
-    # helpers and response model, so this edge must stay lazy.
-    from imbi.api.endpoints import document_versions
-
-    await document_versions.record_created(
+    # Snapshot capture is best-effort and independent of the response,
+    # so run it after the response instead of adding ClickHouse latency
+    # (or outage stalls) to the save path.
+    background_tasks.add_task(
+        _document_history.record_created,
         document_id=document_id,
         title=data.title,
         content=data.content,
@@ -387,6 +409,7 @@ async def create_document(
         permissions.AuthContext,
         fastapi.Depends(permissions.require_permission('document:create')),
     ],
+    background_tasks: fastapi.BackgroundTasks,
 ) -> dict[str, typing.Any]:
     """Create a document attached to a project, optionally with tags."""
     anchor: typing.LiteralString = """
@@ -397,6 +420,7 @@ async def create_document(
     return await _create_document_impl(
         db,
         auth,
+        background_tasks,
         org_slug,
         data,
         anchor,
@@ -417,6 +441,7 @@ async def create_project_type_document(
         permissions.AuthContext,
         fastapi.Depends(permissions.require_permission('document:create')),
     ],
+    background_tasks: fastapi.BackgroundTasks,
 ) -> dict[str, typing.Any]:
     """Create a document attached to a project type."""
     anchor: typing.LiteralString = """
@@ -426,6 +451,7 @@ async def create_project_type_document(
     return await _create_document_impl(
         db,
         auth,
+        background_tasks,
         org_slug,
         data,
         anchor,
@@ -446,6 +472,7 @@ async def create_user_document(
         permissions.AuthContext,
         fastapi.Depends(permissions.require_permission('document:create')),
     ],
+    background_tasks: fastapi.BackgroundTasks,
 ) -> dict[str, typing.Any]:
     """Create a document attached to a user (org member)."""
     anchor: typing.LiteralString = """
@@ -455,6 +482,7 @@ async def create_user_document(
     return await _create_document_impl(
         db,
         auth,
+        background_tasks,
         org_slug,
         data,
         anchor,
@@ -802,17 +830,20 @@ def _resolve_patched_field(
 async def patch_document_impl(
     db: graph.Pool,
     auth: permissions.AuthContext,
+    background_tasks: fastapi.BackgroundTasks,
     org_slug: str,
     document_id: str,
     operations: list[json_patch.PatchOperation],
     project_id: str | None = None,
-    change_kind: typing.Literal['update', 'restore'] = 'update',
 ) -> dict[str, typing.Any]:
-    existing = await fetch_document(db, org_slug, document_id, project_id)
-    if existing is None:
-        raise fastapi.HTTPException(
-            status_code=404, detail=f'Document {document_id!r} not found'
-        )
+    existing = await fetch_or_404(
+        fetch_document,
+        db,
+        org_slug,
+        document_id,
+        project_id,
+        detail=f'Document {document_id!r} not found',
+    )
 
     current = {
         'title': str(existing.get('title') or ''),
@@ -869,16 +900,50 @@ async def patch_document_impl(
         bool(existing.get('is_pinned', False)),
     )
 
-    # Only title/content/tag changes produce a new version; pin
-    # toggles and no-op patches leave the history untouched.
-    old_version = int(existing.get('version') or 1)
-    content_changed = (
-        new_title != str(existing.get('title') or '')
-        or new_content != existing['content']
-        or sorted(new_tags)
-        != sorted(t['slug'] for t in existing.get('tags', []))
+    return await apply_document_update(
+        db,
+        auth,
+        background_tasks,
+        org_slug,
+        document_id,
+        existing,
+        title=new_title,
+        content=new_content,
+        tags=new_tags,
+        replace_tags=replace_tags,
+        is_pinned=new_is_pinned,
+        project_id=project_id,
     )
-    new_version = old_version + 1 if content_changed else old_version
+
+
+async def apply_document_update(
+    db: graph.Pool,
+    auth: permissions.AuthContext,
+    background_tasks: fastapi.BackgroundTasks,
+    org_slug: str,
+    document_id: str,
+    existing: dict[str, typing.Any],
+    *,
+    title: str,
+    content: str,
+    tags: list[str],
+    replace_tags: bool,
+    is_pinned: bool,
+    project_id: str | None = None,
+    change_kind: _document_history.ChangeKind = 'update',
+) -> dict[str, typing.Any]:
+    """Write resolved field values to a document and record the version.
+
+    The update core shared by the JSON Patch endpoints and version
+    restore. Callers are responsible for tag-slug validation or
+    filtering; unknown slugs are silently skipped by edge creation.
+    The version counter is bumped atomically in the graph when
+    title/content/tags changed, so concurrent saves get distinct
+    version numbers and every save survives in the history.
+    """
+    content_changed = _document_history.has_changed(
+        existing, title, content, tags
+    )
 
     scope, scope_params = _scope_filter(project_id)
     now = datetime.datetime.now(datetime.UTC)
@@ -894,8 +959,8 @@ async def patch_document_impl(
         n.updated_by = {updated_by},
         n.updated_at = {updated_at},
         n.is_pinned = {is_pinned},
-        n.version = {version}
-    RETURN n.id AS id
+        n.version = coalesce(n.version, 1) + {version_bump}
+    RETURN n.id AS id, n.version AS version
     """
     )
     records = await db.execute(
@@ -903,37 +968,38 @@ async def patch_document_impl(
         {
             'org_slug': org_slug,
             'document_id': document_id,
-            'title': new_title,
-            'content': new_content,
+            'title': title,
+            'content': content,
             'updated_by': auth.principal_name,
             'updated_at': now.isoformat(),
-            'is_pinned': new_is_pinned,
-            'version': new_version,
+            'is_pinned': is_pinned,
+            'version_bump': 1 if content_changed else 0,
             **scope_params,
         },
-        columns=['id'],
+        columns=['id', 'version'],
     )
     if not records:
         raise fastapi.HTTPException(
             status_code=404, detail=f'Document {document_id!r} not found'
         )
+    new_version = int(graph.parse_agtype(records[0]['version']) or 1)
 
     if replace_tags:
         await _detach_all_tags(db, document_id)
-        await _attach_tags(db, org_slug, document_id, new_tags)
+        await _attach_tags(db, org_slug, document_id, tags)
 
     if content_changed:
-        # Deferred import: document_versions imports this module for
-        # its helpers and response model, so this edge must stay lazy.
-        from imbi.api.endpoints import document_versions
-
-        await document_versions.record_updated(
+        # Snapshot capture is best-effort and independent of the
+        # response, so run it after the response instead of adding
+        # ClickHouse latency (or outage stalls) to the save path.
+        background_tasks.add_task(
+            _document_history.record_updated,
             document_id=document_id,
             previous=existing,
             new_version=new_version,
-            title=new_title,
-            content=new_content,
-            tags=new_tags,
+            title=title,
+            content=content,
+            tags=tags,
             change_kind=change_kind,
             updated_by=auth.principal_name,
             updated_at=now,
@@ -957,10 +1023,11 @@ async def patch_org_document(
         permissions.AuthContext,
         fastapi.Depends(permissions.require_permission('document:write')),
     ],
+    background_tasks: fastapi.BackgroundTasks,
 ) -> dict[str, typing.Any]:
     """Update a document via JSON Patch regardless of attachment kind."""
     return await patch_document_impl(
-        db, auth, org_slug, document_id, operations
+        db, auth, background_tasks, org_slug, document_id, operations
     )
 
 
@@ -977,10 +1044,17 @@ async def patch_document(
         permissions.AuthContext,
         fastapi.Depends(permissions.require_permission('document:write')),
     ],
+    background_tasks: fastapi.BackgroundTasks,
 ) -> dict[str, typing.Any]:
     """Update document content and/or tag attachments via JSON Patch."""
     return await patch_document_impl(
-        db, auth, org_slug, document_id, operations, project_id
+        db,
+        auth,
+        background_tasks,
+        org_slug,
+        document_id,
+        operations,
+        project_id,
     )
 
 

--- a/apps/api/src/imbi/api/endpoints/documents.py
+++ b/apps/api/src/imbi/api/endpoints/documents.py
@@ -53,6 +53,7 @@ _DOCUMENT_READONLY_PATHS: frozenset[str] = frozenset(
         '/created_at',
         '/updated_by',
         '/updated_at',
+        '/version',
     ]
 )
 
@@ -91,6 +92,7 @@ class DocumentResponse(pydantic.BaseModel):
     is_pinned: bool = False
     comment_count: int = 0
     tags: list[TagRef] = []
+    version: int = 1
 
 
 class DocumentCreate(pydantic.BaseModel):
@@ -172,6 +174,7 @@ def _parse_document_row(
     # Defaults for rows written before these columns landed.
     document['is_pinned'] = bool(document.get('is_pinned', False))
     document['title'] = str(document.get('title') or '')
+    document['version'] = int(document.get('version') or 1)
     return document
 
 
@@ -307,7 +310,8 @@ _DOCUMENT_CREATE_FRAGMENT: typing.LiteralString = """
         content: {content},
         created_by: {created_by},
         created_at: {created_at},
-        is_pinned: {is_pinned}
+        is_pinned: {is_pinned},
+        version: 1
     }})
     CREATE (n)-[:ATTACHED_TO]->(target)
     RETURN n.id AS id
@@ -349,7 +353,20 @@ async def _create_document_impl(
     if tag_slugs:
         await _attach_tags(db, org_slug, document_id, tag_slugs)
 
-    document = await _fetch_document(db, org_slug, document_id)
+    # Deferred import: document_versions imports this module for its
+    # helpers and response model, so this edge must stay lazy.
+    from imbi.api.endpoints import document_versions
+
+    await document_versions.record_created(
+        document_id=document_id,
+        title=data.title,
+        content=data.content,
+        tags=tag_slugs,
+        created_by=auth.principal_name,
+        created_at=now,
+    )
+
+    document = await fetch_document(db, org_slug, document_id)
     if document is None:
         raise fastapi.HTTPException(
             status_code=500,
@@ -675,7 +692,7 @@ def _scope_filter(
     return ' AND p.id = {project_id}', {'project_id': project_id}
 
 
-async def _fetch_document(
+async def fetch_document(
     db: graph.Pool,
     org_slug: str,
     document_id: str,
@@ -719,7 +736,7 @@ async def get_org_document(
 ) -> dict[str, typing.Any]:
     """Retrieve a single document regardless of attachment kind."""
     return await fetch_or_404(
-        _fetch_document,
+        fetch_document,
         db,
         org_slug,
         document_id,
@@ -742,7 +759,7 @@ async def get_document(
 ) -> dict[str, typing.Any]:
     """Retrieve a single project document."""
     return await fetch_or_404(
-        _fetch_document,
+        fetch_document,
         db,
         org_slug,
         document_id,
@@ -782,15 +799,16 @@ def _resolve_patched_field(
     return fallback
 
 
-async def _patch_document_impl(
+async def patch_document_impl(
     db: graph.Pool,
     auth: permissions.AuthContext,
     org_slug: str,
     document_id: str,
     operations: list[json_patch.PatchOperation],
     project_id: str | None = None,
+    change_kind: typing.Literal['update', 'restore'] = 'update',
 ) -> dict[str, typing.Any]:
-    existing = await _fetch_document(db, org_slug, document_id, project_id)
+    existing = await fetch_document(db, org_slug, document_id, project_id)
     if existing is None:
         raise fastapi.HTTPException(
             status_code=404, detail=f'Document {document_id!r} not found'
@@ -851,6 +869,17 @@ async def _patch_document_impl(
         bool(existing.get('is_pinned', False)),
     )
 
+    # Only title/content/tag changes produce a new version; pin
+    # toggles and no-op patches leave the history untouched.
+    old_version = int(existing.get('version') or 1)
+    content_changed = (
+        new_title != str(existing.get('title') or '')
+        or new_content != existing['content']
+        or sorted(new_tags)
+        != sorted(t['slug'] for t in existing.get('tags', []))
+    )
+    new_version = old_version + 1 if content_changed else old_version
+
     scope, scope_params = _scope_filter(project_id)
     now = datetime.datetime.now(datetime.UTC)
     set_query: str = (
@@ -864,7 +893,8 @@ async def _patch_document_impl(
         n.content = {content},
         n.updated_by = {updated_by},
         n.updated_at = {updated_at},
-        n.is_pinned = {is_pinned}
+        n.is_pinned = {is_pinned},
+        n.version = {version}
     RETURN n.id AS id
     """
     )
@@ -878,6 +908,7 @@ async def _patch_document_impl(
             'updated_by': auth.principal_name,
             'updated_at': now.isoformat(),
             'is_pinned': new_is_pinned,
+            'version': new_version,
             **scope_params,
         },
         columns=['id'],
@@ -891,7 +922,24 @@ async def _patch_document_impl(
         await _detach_all_tags(db, document_id)
         await _attach_tags(db, org_slug, document_id, new_tags)
 
-    document = await _fetch_document(db, org_slug, document_id, project_id)
+    if content_changed:
+        # Deferred import: document_versions imports this module for
+        # its helpers and response model, so this edge must stay lazy.
+        from imbi.api.endpoints import document_versions
+
+        await document_versions.record_updated(
+            document_id=document_id,
+            previous=existing,
+            new_version=new_version,
+            title=new_title,
+            content=new_content,
+            tags=new_tags,
+            change_kind=change_kind,
+            updated_by=auth.principal_name,
+            updated_at=now,
+        )
+
+    document = await fetch_document(db, org_slug, document_id, project_id)
     if document is None:
         raise fastapi.HTTPException(
             status_code=404, detail=f'Document {document_id!r} not found'
@@ -911,7 +959,7 @@ async def patch_org_document(
     ],
 ) -> dict[str, typing.Any]:
     """Update a document via JSON Patch regardless of attachment kind."""
-    return await _patch_document_impl(
+    return await patch_document_impl(
         db, auth, org_slug, document_id, operations
     )
 
@@ -931,7 +979,7 @@ async def patch_document(
     ],
 ) -> dict[str, typing.Any]:
     """Update document content and/or tag attachments via JSON Patch."""
-    return await _patch_document_impl(
+    return await patch_document_impl(
         db, auth, org_slug, document_id, operations, project_id
     )
 

--- a/apps/api/src/imbi/api/endpoints/organizations.py
+++ b/apps/api/src/imbi/api/endpoints/organizations.py
@@ -14,7 +14,9 @@ from imbi.api.relationships import RelationshipSpec, build_relationships
 from imbi.common import graph, models
 
 from .comments import comments_router
+from .document_presence import document_presence_router
 from .document_templates import document_templates_router
+from .document_versions import document_versions_router
 from .documents import (
     documents_project_router,
     documents_project_type_router,
@@ -100,6 +102,14 @@ organizations_router.include_router(
 organizations_router.include_router(
     documents_router,
     prefix='/{org_slug}/documents',
+)
+organizations_router.include_router(
+    document_versions_router,
+    prefix='/{org_slug}/documents/{document_id}/versions',
+)
+organizations_router.include_router(
+    document_presence_router,
+    prefix='/{org_slug}/documents/{document_id}/editing',
 )
 organizations_router.include_router(
     documents_project_router,

--- a/apps/api/tests/endpoints/test_document_presence.py
+++ b/apps/api/tests/endpoints/test_document_presence.py
@@ -10,6 +10,8 @@ from apps.api.tests import support
 from imbi.api import models
 from imbi.common import valkey
 
+KEY = 'imbi:document:editing:engineering:document-1'
+
 
 class DocumentPresenceEndpointsTestCase(support.SharedAppTestCase):
     """Advisory editing markers backed by a Valkey sorted set."""
@@ -43,7 +45,12 @@ class DocumentPresenceEndpointsTestCase(support.SharedAppTestCase):
             mock_get_current_user
         )
 
+        # Presence batches its Valkey commands through a pipeline; the
+        # command methods queue synchronously, only execute() awaits.
         self.mock_valkey = mock.AsyncMock()
+        self.mock_pipe = mock.Mock()
+        self.mock_pipe.execute = mock.AsyncMock(return_value=[0, []])
+        self.mock_valkey.pipeline = mock.Mock(return_value=self.mock_pipe)
         self.test_app.dependency_overrides[valkey._inject_client] = (
             lambda: self.mock_valkey
         )
@@ -53,9 +60,9 @@ class DocumentPresenceEndpointsTestCase(support.SharedAppTestCase):
     # -- GET ---------------------------------------------------------------
 
     def test_get_editors(self) -> None:
-        self.mock_valkey.zrange.return_value = [
-            b'zed@example.com',
-            b'alice@example.com',
+        self.mock_pipe.execute.return_value = [
+            2,
+            [b'zed@example.com', b'alice@example.com'],
         ]
         response = self.client.get(
             '/organizations/engineering/documents/document-1/editing'
@@ -66,10 +73,12 @@ class DocumentPresenceEndpointsTestCase(support.SharedAppTestCase):
             ['alice@example.com', 'zed@example.com'],
         )
         # Stale entries are pruned before reading.
-        self.mock_valkey.zremrangebyscore.assert_awaited_once()
+        self.mock_pipe.zremrangebyscore.assert_called_once()
+        self.assertEqual(
+            self.mock_pipe.zremrangebyscore.call_args.args[0], KEY
+        )
 
     def test_get_editors_empty(self) -> None:
-        self.mock_valkey.zrange.return_value = []
         response = self.client.get(
             '/organizations/engineering/documents/document-1/editing'
         )
@@ -78,7 +87,7 @@ class DocumentPresenceEndpointsTestCase(support.SharedAppTestCase):
 
     def test_get_editors_valkey_down(self) -> None:
         """Presence degrades to empty rather than failing the request."""
-        self.mock_valkey.zremrangebyscore.side_effect = ConnectionError()
+        self.mock_pipe.execute.side_effect = ConnectionError()
         with self.assertLogs(
             'imbi.api.endpoints.document_presence', level='ERROR'
         ):
@@ -91,20 +100,24 @@ class DocumentPresenceEndpointsTestCase(support.SharedAppTestCase):
     # -- PUT (heartbeat) -----------------------------------------------------
 
     def test_heartbeat_registers_editor(self) -> None:
-        self.mock_valkey.zrange.return_value = [b'admin@example.com']
+        self.mock_pipe.execute.return_value = [
+            1,
+            True,
+            0,
+            [b'admin@example.com'],
+        ]
         response = self.client.put(
             '/organizations/engineering/documents/document-1/editing'
         )
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json()['editors'], ['admin@example.com'])
-        zadd_call = self.mock_valkey.zadd.await_args
-        key, mapping = zadd_call.args
-        self.assertEqual(key, 'imbi:document:editing:document-1')
+        key, mapping = self.mock_pipe.zadd.call_args.args
+        self.assertEqual(key, KEY)
         self.assertEqual(list(mapping), ['admin@example.com'])
-        self.mock_valkey.expire.assert_awaited_once()
+        self.mock_pipe.expire.assert_called_once()
 
     def test_heartbeat_valkey_down(self) -> None:
-        self.mock_valkey.zadd.side_effect = ConnectionError()
+        self.mock_pipe.execute.side_effect = ConnectionError()
         with self.assertLogs(
             'imbi.api.endpoints.document_presence', level='ERROR'
         ):
@@ -122,7 +135,7 @@ class DocumentPresenceEndpointsTestCase(support.SharedAppTestCase):
         )
         self.assertEqual(response.status_code, 204)
         self.mock_valkey.zrem.assert_awaited_once_with(
-            'imbi:document:editing:document-1', 'admin@example.com'
+            KEY, 'admin@example.com'
         )
 
     def test_clear_editing_valkey_down(self) -> None:

--- a/apps/api/tests/endpoints/test_document_presence.py
+++ b/apps/api/tests/endpoints/test_document_presence.py
@@ -1,0 +1,140 @@
+"""Tests for the document editing-presence endpoints."""
+
+import datetime
+import unittest
+from unittest import mock
+
+import fastapi.testclient
+
+from apps.api.tests import support
+from imbi.api import models
+from imbi.common import valkey
+
+
+class DocumentPresenceEndpointsTestCase(support.SharedAppTestCase):
+    """Advisory editing markers backed by a Valkey sorted set."""
+
+    def setUp(self) -> None:
+        from imbi.api.auth import permissions
+
+        self.admin_user = models.User(
+            email='admin@example.com',
+            display_name='Admin User',
+            password_hash='$argon2id$hashed',
+            is_active=True,
+            is_admin=True,
+            is_service_account=False,
+            created_at=datetime.datetime.now(datetime.UTC),
+        )
+        self.auth_context = permissions.AuthContext(
+            user=self.admin_user,
+            session_id='test-session',
+            auth_method='jwt',
+            permissions={
+                'document:read',
+                'document:write',
+            },
+        )
+
+        async def mock_get_current_user():
+            return self.auth_context
+
+        self.test_app.dependency_overrides[permissions.get_current_user] = (
+            mock_get_current_user
+        )
+
+        self.mock_valkey = mock.AsyncMock()
+        self.test_app.dependency_overrides[valkey._inject_client] = (
+            lambda: self.mock_valkey
+        )
+
+        self.client = fastapi.testclient.TestClient(self.test_app)
+
+    # -- GET ---------------------------------------------------------------
+
+    def test_get_editors(self) -> None:
+        self.mock_valkey.zrange.return_value = [
+            b'zed@example.com',
+            b'alice@example.com',
+        ]
+        response = self.client.get(
+            '/organizations/engineering/documents/document-1/editing'
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.json()['editors'],
+            ['alice@example.com', 'zed@example.com'],
+        )
+        # Stale entries are pruned before reading.
+        self.mock_valkey.zremrangebyscore.assert_awaited_once()
+
+    def test_get_editors_empty(self) -> None:
+        self.mock_valkey.zrange.return_value = []
+        response = self.client.get(
+            '/organizations/engineering/documents/document-1/editing'
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()['editors'], [])
+
+    def test_get_editors_valkey_down(self) -> None:
+        """Presence degrades to empty rather than failing the request."""
+        self.mock_valkey.zremrangebyscore.side_effect = ConnectionError()
+        with self.assertLogs(
+            'imbi.api.endpoints.document_presence', level='ERROR'
+        ):
+            response = self.client.get(
+                '/organizations/engineering/documents/document-1/editing'
+            )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()['editors'], [])
+
+    # -- PUT (heartbeat) -----------------------------------------------------
+
+    def test_heartbeat_registers_editor(self) -> None:
+        self.mock_valkey.zrange.return_value = [b'admin@example.com']
+        response = self.client.put(
+            '/organizations/engineering/documents/document-1/editing'
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()['editors'], ['admin@example.com'])
+        zadd_call = self.mock_valkey.zadd.await_args
+        key, mapping = zadd_call.args
+        self.assertEqual(key, 'imbi:document:editing:document-1')
+        self.assertEqual(list(mapping), ['admin@example.com'])
+        self.mock_valkey.expire.assert_awaited_once()
+
+    def test_heartbeat_valkey_down(self) -> None:
+        self.mock_valkey.zadd.side_effect = ConnectionError()
+        with self.assertLogs(
+            'imbi.api.endpoints.document_presence', level='ERROR'
+        ):
+            response = self.client.put(
+                '/organizations/engineering/documents/document-1/editing'
+            )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()['editors'], [])
+
+    # -- DELETE ---------------------------------------------------------------
+
+    def test_clear_editing(self) -> None:
+        response = self.client.delete(
+            '/organizations/engineering/documents/document-1/editing'
+        )
+        self.assertEqual(response.status_code, 204)
+        self.mock_valkey.zrem.assert_awaited_once_with(
+            'imbi:document:editing:document-1', 'admin@example.com'
+        )
+
+    def test_clear_editing_valkey_down(self) -> None:
+        self.mock_valkey.zrem.side_effect = ConnectionError()
+        with self.assertLogs(
+            'imbi.api.endpoints.document_presence', level='ERROR'
+        ):
+            response = self.client.delete(
+                '/organizations/engineering/documents/document-1/editing'
+            )
+        self.assertEqual(response.status_code, 204)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/apps/api/tests/endpoints/test_document_versions.py
+++ b/apps/api/tests/endpoints/test_document_versions.py
@@ -1,0 +1,240 @@
+"""Tests for document version-history endpoints."""
+
+import datetime
+import typing
+import unittest
+from unittest import mock
+
+import fastapi.testclient
+
+from apps.api.tests import support
+from imbi.api import models
+from imbi.common import graph
+
+
+class DocumentVersionEndpointsTestCase(support.SharedAppTestCase):
+    """Version list/get/restore endpoints."""
+
+    def setUp(self) -> None:
+        from imbi.api.auth import permissions
+
+        self.admin_user = models.User(
+            email='admin@example.com',
+            display_name='Admin User',
+            password_hash='$argon2id$hashed',
+            is_active=True,
+            is_admin=True,
+            is_service_account=False,
+            created_at=datetime.datetime.now(datetime.UTC),
+        )
+        self.auth_context = permissions.AuthContext(
+            user=self.admin_user,
+            session_id='test-session',
+            auth_method='jwt',
+            permissions={
+                'document:read',
+                'document:write',
+            },
+        )
+
+        async def mock_get_current_user():
+            return self.auth_context
+
+        self.test_app.dependency_overrides[permissions.get_current_user] = (
+            mock_get_current_user
+        )
+
+        self.mock_db = mock.AsyncMock(spec=graph.Graph)
+        self.test_app.dependency_overrides[graph._inject_graph] = (
+            lambda: self.mock_db
+        )
+
+        self.ch_insert = mock.AsyncMock()
+        self.ch_query = mock.AsyncMock(return_value=[])
+        for target, replacement in (
+            ('imbi.common.clickhouse.insert', self.ch_insert),
+            ('imbi.common.clickhouse.query', self.ch_query),
+        ):
+            patcher = mock.patch(target, replacement)
+            patcher.start()
+            self.addCleanup(patcher.stop)
+
+        self.client = fastapi.testclient.TestClient(self.test_app)
+
+    def _document_data(self, **overrides: typing.Any) -> dict:
+        data: dict[str, typing.Any] = {
+            'id': 'document-1',
+            'title': 'DB lock runbook',
+            'content': 'Watch out for DB locks',
+            'created_by': 'admin@example.com',
+            'created_at': '2026-03-17T12:00:00Z',
+            'updated_by': None,
+            'updated_at': None,
+        }
+        data.update(overrides)
+        return data
+
+    def _project_row(self, n: dict | None = None, **kwargs) -> dict:
+        return {
+            'n': n if n is not None else self._document_data(),
+            'p': {'id': 'proj-abc', 'slug': 'billing', 'name': 'Billing'},
+            'team': {'name': 'Platform', 'slug': 'platform'},
+            'pt': None,
+            'u': None,
+            'ptype_names': [],
+            'tags': kwargs.get('tags', []),
+            'comment_count': 0,
+            'author': None,
+        }
+
+    def _version_row(self, **overrides: typing.Any) -> dict[str, typing.Any]:
+        row: dict[str, typing.Any] = {
+            'version': 1,
+            'title': 'DB lock runbook',
+            'change_kind': 'create',
+            'updated_by': 'admin@example.com',
+            'updated_at': datetime.datetime(2026, 3, 17, 12, 0, 0),
+        }
+        row.update(overrides)
+        return row
+
+    # -- List ------------------------------------------------------------
+
+    def test_list_versions(self) -> None:
+        self.mock_db.execute.return_value = [self._project_row()]
+        self.ch_query.return_value = [
+            self._version_row(version=2, change_kind='update'),
+            self._version_row(),
+        ]
+        with mock.patch(
+            'imbi.common.graph.parse_agtype', side_effect=lambda x: x
+        ):
+            response = self.client.get(
+                '/organizations/engineering/documents/document-1/versions'
+            )
+        self.assertEqual(response.status_code, 200)
+        data = response.json()['data']
+        self.assertEqual([v['version'] for v in data], [2, 1])
+        self.assertEqual(data[0]['change_kind'], 'update')
+        # Naive ClickHouse timestamps must serialize with a UTC offset.
+        self.assertTrue(data[0]['updated_at'].endswith('Z'))
+
+    def test_list_versions_document_not_found(self) -> None:
+        self.mock_db.execute.return_value = []
+        response = self.client.get(
+            '/organizations/engineering/documents/ghost/versions'
+        )
+        self.assertEqual(response.status_code, 404)
+        self.ch_query.assert_not_awaited()
+
+    # -- Get -------------------------------------------------------------
+
+    def test_get_version(self) -> None:
+        self.mock_db.execute.return_value = [self._project_row()]
+        self.ch_query.return_value = [
+            self._version_row(
+                content='Watch out for DB locks', tags=['runbook']
+            )
+        ]
+        with mock.patch(
+            'imbi.common.graph.parse_agtype', side_effect=lambda x: x
+        ):
+            response = self.client.get(
+                '/organizations/engineering/documents/document-1/versions/1'
+            )
+        self.assertEqual(response.status_code, 200)
+        body = response.json()
+        self.assertEqual(body['version'], 1)
+        self.assertEqual(body['content'], 'Watch out for DB locks')
+        self.assertEqual(body['tags'], ['runbook'])
+
+    def test_get_version_not_found(self) -> None:
+        self.mock_db.execute.return_value = [self._project_row()]
+        self.ch_query.return_value = []
+        with mock.patch(
+            'imbi.common.graph.parse_agtype', side_effect=lambda x: x
+        ):
+            response = self.client.get(
+                '/organizations/engineering/documents/document-1/versions/9'
+            )
+        self.assertEqual(response.status_code, 404)
+
+    # -- Restore ---------------------------------------------------------
+
+    def test_restore_version(self) -> None:
+        """Restore applies the snapshot as a new ``restore`` version."""
+        # ClickHouse calls: _require_document is graph-side; then
+        # 1: _fetch_version, 2: _max_recorded_version inside capture.
+        self.ch_query.side_effect = [
+            [self._version_row(content='Original text', tags=['runbook'])],
+            [{'v': 2, 'c': 2}],
+        ]
+        # Graph calls: 1: _require_document, 2: patch fetch-existing,
+        # 3: validate tags, 4: SET, 5: detach tags, 6: attach tags,
+        # 7: final fetch.
+        current = self._document_data(
+            content='Newer text', version=2, updated_by='admin@example.com'
+        )
+        restored = self._document_data(
+            content='Original text',
+            version=3,
+            updated_by='admin@example.com',
+        )
+        self.mock_db.execute.side_effect = [
+            [self._project_row(n=current)],
+            [self._project_row(n=current)],
+            [{'tag_slug': 'runbook', 'found': True}],
+            [{'id': 'document-1'}],
+            [{'removed': 0}],
+            [{'attached': 1}],
+            [
+                self._project_row(
+                    n=restored, tags=[{'name': 'Runbook', 'slug': 'runbook'}]
+                )
+            ],
+        ]
+        with mock.patch(
+            'imbi.common.graph.parse_agtype', side_effect=lambda x: x
+        ):
+            response = self.client.post(
+                '/organizations/engineering/documents/document-1'
+                '/versions/1/restore'
+            )
+        self.assertEqual(response.status_code, 200)
+        body = response.json()
+        self.assertEqual(body['content'], 'Original text')
+        self.assertEqual(body['version'], 3)
+        # The SET query carries the bumped version.
+        set_call = self.mock_db.execute.await_args_list[3]
+        self.assertEqual(set_call.args[1]['version'], 3)
+        self.assertEqual(set_call.args[1]['content'], 'Original text')
+        # The new snapshot is recorded as a restore.
+        self.ch_insert.assert_awaited_once()
+        _, rows = self.ch_insert.await_args.args
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0].version, 3)
+        self.assertEqual(rows[0].change_kind, 'restore')
+
+    def test_restore_version_not_found(self) -> None:
+        self.mock_db.execute.return_value = [self._project_row()]
+        self.ch_query.return_value = []
+        with mock.patch(
+            'imbi.common.graph.parse_agtype', side_effect=lambda x: x
+        ):
+            response = self.client.post(
+                '/organizations/engineering/documents/document-1'
+                '/versions/9/restore'
+            )
+        self.assertEqual(response.status_code, 404)
+
+    def test_restore_document_not_found(self) -> None:
+        self.mock_db.execute.return_value = []
+        response = self.client.post(
+            '/organizations/engineering/documents/ghost/versions/1/restore'
+        )
+        self.assertEqual(response.status_code, 404)
+        self.ch_query.assert_not_awaited()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/apps/api/tests/endpoints/test_document_versions.py
+++ b/apps/api/tests/endpoints/test_document_versions.py
@@ -163,15 +163,13 @@ class DocumentVersionEndpointsTestCase(support.SharedAppTestCase):
 
     def test_restore_version(self) -> None:
         """Restore applies the snapshot as a new ``restore`` version."""
-        # ClickHouse calls: _require_document is graph-side; then
-        # 1: _fetch_version, 2: _max_recorded_version inside capture.
+        # ClickHouse calls: 1: _fetch_version; the capture skips the
+        # history probe because the restored document is past v2.
         self.ch_query.side_effect = [
             [self._version_row(content='Original text', tags=['runbook'])],
-            [{'v': 2, 'c': 2}],
         ]
-        # Graph calls: 1: _require_document, 2: patch fetch-existing,
-        # 3: validate tags, 4: SET, 5: detach tags, 6: attach tags,
-        # 7: final fetch.
+        # Graph calls: 1: fetch document, 2: filter snapshot tags,
+        # 3: SET, 4: detach tags, 5: attach tags, 6: final fetch.
         current = self._document_data(
             content='Newer text', version=2, updated_by='admin@example.com'
         )
@@ -182,9 +180,8 @@ class DocumentVersionEndpointsTestCase(support.SharedAppTestCase):
         )
         self.mock_db.execute.side_effect = [
             [self._project_row(n=current)],
-            [self._project_row(n=current)],
             [{'tag_slug': 'runbook', 'found': True}],
-            [{'id': 'document-1'}],
+            [{'id': 'document-1', 'version': 3}],
             [{'removed': 0}],
             [{'attached': 1}],
             [
@@ -204,9 +201,9 @@ class DocumentVersionEndpointsTestCase(support.SharedAppTestCase):
         body = response.json()
         self.assertEqual(body['content'], 'Original text')
         self.assertEqual(body['version'], 3)
-        # The SET query carries the bumped version.
-        set_call = self.mock_db.execute.await_args_list[3]
-        self.assertEqual(set_call.args[1]['version'], 3)
+        # The SET query bumps the version atomically.
+        set_call = self.mock_db.execute.await_args_list[2]
+        self.assertEqual(set_call.args[1]['version_bump'], 1)
         self.assertEqual(set_call.args[1]['content'], 'Original text')
         # The new snapshot is recorded as a restore.
         self.ch_insert.assert_awaited_once()
@@ -214,6 +211,45 @@ class DocumentVersionEndpointsTestCase(support.SharedAppTestCase):
         self.assertEqual(len(rows), 1)
         self.assertEqual(rows[0].version, 3)
         self.assertEqual(rows[0].change_kind, 'restore')
+
+    def test_restore_drops_deleted_tags(self) -> None:
+        """Snapshot tags gone from the org are dropped, not fatal."""
+        self.ch_query.side_effect = [
+            [
+                self._version_row(
+                    content='Original text', tags=['runbook', 'gone']
+                )
+            ],
+        ]
+        current = self._document_data(
+            content='Newer text', version=2, updated_by='admin@example.com'
+        )
+        self.mock_db.execute.side_effect = [
+            [self._project_row(n=current)],
+            [
+                {'tag_slug': 'runbook', 'found': True},
+                {'tag_slug': 'gone', 'found': False},
+            ],
+            [{'id': 'document-1', 'version': 3}],
+            [{'removed': 0}],
+            [{'attached': 1}],
+            [
+                self._project_row(
+                    n=self._document_data(content='Original text', version=3),
+                    tags=[{'name': 'Runbook', 'slug': 'runbook'}],
+                )
+            ],
+        ]
+        with mock.patch(
+            'imbi.common.graph.parse_agtype', side_effect=lambda x: x
+        ):
+            response = self.client.post(
+                '/organizations/engineering/documents/document-1'
+                '/versions/1/restore'
+            )
+        self.assertEqual(response.status_code, 200)
+        _, rows = self.ch_insert.await_args.args
+        self.assertEqual(rows[0].tags, ['runbook'])
 
     def test_restore_version_not_found(self) -> None:
         self.mock_db.execute.return_value = [self._project_row()]

--- a/apps/api/tests/endpoints/test_document_versions.py
+++ b/apps/api/tests/endpoints/test_document_versions.py
@@ -93,7 +93,9 @@ class DocumentVersionEndpointsTestCase(support.SharedAppTestCase):
             'title': 'DB lock runbook',
             'change_kind': 'create',
             'updated_by': 'admin@example.com',
-            'updated_at': datetime.datetime(2026, 3, 17, 12, 0, 0),
+            # Naive on purpose: ClickHouse returns naive DateTime64
+            # values and the endpoint attaches UTC.
+            'updated_at': datetime.datetime(2026, 3, 17, 12, 0, 0),  # noqa: DTZ001
         }
         row.update(overrides)
         return row

--- a/apps/api/tests/endpoints/test_documents.py
+++ b/apps/api/tests/endpoints/test_documents.py
@@ -51,6 +51,18 @@ class DocumentEndpointsTestCase(support.SharedAppTestCase):
             lambda: self.mock_db
         )
 
+        # Version snapshots are written to ClickHouse best-effort on
+        # create/patch; keep these tests hermetic by mocking the client.
+        self.ch_insert = mock.AsyncMock()
+        self.ch_query = mock.AsyncMock(return_value=[{'v': 1, 'c': 1}])
+        for target, replacement in (
+            ('imbi.common.clickhouse.insert', self.ch_insert),
+            ('imbi.common.clickhouse.query', self.ch_query),
+        ):
+            patcher = mock.patch(target, replacement)
+            patcher.start()
+            self.addCleanup(patcher.stop)
+
         self.client = TestClient(self.test_app)
 
     def _document_data(self, **overrides: typing.Any) -> dict:
@@ -710,6 +722,154 @@ class DocumentEndpointsTestCase(support.SharedAppTestCase):
             json=[{'op': 'replace', 'path': '/content', 'value': 'x'}],
         )
         self.assertEqual(response.status_code, 404)
+
+    # -- Version history capture ----------------------------------------
+
+    def test_create_records_version_snapshot(self) -> None:
+        self.mock_db.execute.side_effect = [
+            [{'id': 'document-1'}],
+            [self._project_row()],
+        ]
+        with mock.patch(
+            'imbi.common.graph.parse_agtype', side_effect=lambda x: x
+        ):
+            response = self.client.post(
+                '/organizations/engineering/projects/proj-abc/documents/',
+                json={
+                    'title': 'DB lock runbook',
+                    'content': 'Watch out for DB locks',
+                },
+            )
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.json()['version'], 1)
+        self.ch_insert.assert_awaited_once()
+        table, rows = self.ch_insert.await_args.args
+        self.assertEqual(table, 'document_versions')
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0].version, 1)
+        self.assertEqual(rows[0].change_kind, 'create')
+        self.assertEqual(rows[0].content, 'Watch out for DB locks')
+
+    def test_patch_content_bumps_version_and_snapshots(self) -> None:
+        self.mock_db.execute.side_effect = [
+            [self._project_row()],
+            [{'id': 'document-1'}],
+            [
+                self._project_row(
+                    n=self._document_data(content='Updated text', version=2)
+                )
+            ],
+        ]
+        with mock.patch(
+            'imbi.common.graph.parse_agtype', side_effect=lambda x: x
+        ):
+            response = self.client.patch(
+                '/organizations/engineering/projects/proj-abc/documents/document-1',
+                json=[
+                    {
+                        'op': 'replace',
+                        'path': '/content',
+                        'value': 'Updated text',
+                    }
+                ],
+            )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()['version'], 2)
+        # The SET query (second call) writes the bumped version.
+        write_call = self.mock_db.execute.await_args_list[1]
+        self.assertEqual(write_call.args[1]['version'], 2)
+        self.ch_insert.assert_awaited_once()
+        _, rows = self.ch_insert.await_args.args
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0].version, 2)
+        self.assertEqual(rows[0].change_kind, 'update')
+
+    def test_patch_is_pinned_does_not_bump_version(self) -> None:
+        self.mock_db.execute.side_effect = [
+            [self._project_row()],
+            [{'id': 'document-1'}],
+            [self._project_row(n=self._document_data(is_pinned=True))],
+        ]
+        with mock.patch(
+            'imbi.common.graph.parse_agtype', side_effect=lambda x: x
+        ):
+            response = self.client.patch(
+                '/organizations/engineering/projects/proj-abc/documents/document-1',
+                json=[
+                    {'op': 'replace', 'path': '/is_pinned', 'value': True}
+                ],
+            )
+        self.assertEqual(response.status_code, 200)
+        write_call = self.mock_db.execute.await_args_list[1]
+        self.assertEqual(write_call.args[1]['version'], 1)
+        self.ch_insert.assert_not_awaited()
+
+    def test_patch_writes_baseline_for_document_without_history(self) -> None:
+        """First edit of a pre-versioning document retains its old state."""
+        self.ch_query.return_value = [{'v': 0, 'c': 0}]
+        self.mock_db.execute.side_effect = [
+            [self._project_row()],
+            [{'id': 'document-1'}],
+            [
+                self._project_row(
+                    n=self._document_data(content='Updated text', version=2)
+                )
+            ],
+        ]
+        with mock.patch(
+            'imbi.common.graph.parse_agtype', side_effect=lambda x: x
+        ):
+            response = self.client.patch(
+                '/organizations/engineering/projects/proj-abc/documents/document-1',
+                json=[
+                    {
+                        'op': 'replace',
+                        'path': '/content',
+                        'value': 'Updated text',
+                    }
+                ],
+            )
+        self.assertEqual(response.status_code, 200)
+        self.ch_insert.assert_awaited_once()
+        _, rows = self.ch_insert.await_args.args
+        self.assertEqual(len(rows), 2)
+        self.assertEqual(rows[0].version, 1)
+        self.assertEqual(rows[0].change_kind, 'baseline')
+        self.assertEqual(rows[0].content, 'Watch out for DB locks')
+        self.assertEqual(rows[1].version, 2)
+        self.assertEqual(rows[1].change_kind, 'update')
+
+    def test_patch_succeeds_when_clickhouse_insert_fails(self) -> None:
+        """Snapshot capture is best-effort; the graph write must land."""
+        self.ch_insert.side_effect = RuntimeError('clickhouse down')
+        self.mock_db.execute.side_effect = [
+            [self._project_row()],
+            [{'id': 'document-1'}],
+            [
+                self._project_row(
+                    n=self._document_data(content='Updated text', version=2)
+                )
+            ],
+        ]
+        with (
+            mock.patch(
+                'imbi.common.graph.parse_agtype', side_effect=lambda x: x
+            ),
+            self.assertLogs(
+                'imbi.api.endpoints.document_versions', level='ERROR'
+            ),
+        ):
+            response = self.client.patch(
+                '/organizations/engineering/projects/proj-abc/documents/document-1',
+                json=[
+                    {
+                        'op': 'replace',
+                        'path': '/content',
+                        'value': 'Updated text',
+                    }
+                ],
+            )
+        self.assertEqual(response.status_code, 200)
 
     # -- Delete --------------------------------------------------------
 

--- a/apps/api/tests/endpoints/test_documents.py
+++ b/apps/api/tests/endpoints/test_documents.py
@@ -121,7 +121,7 @@ class DocumentEndpointsTestCase(support.SharedAppTestCase):
 
     def test_create_success_no_tags(self) -> None:
         self.mock_db.execute.side_effect = [
-            [{'id': 'document-1'}],
+            [{'id': 'document-1', 'version': 2}],
             [self._project_row()],
         ]
         with mock.patch(
@@ -151,7 +151,7 @@ class DocumentEndpointsTestCase(support.SharedAppTestCase):
                 {'tag_slug': 'runbook', 'found': True},
                 {'tag_slug': 'alert', 'found': True},
             ],
-            [{'id': 'document-1'}],
+            [{'id': 'document-1', 'version': 2}],
             [{'attached': 2}],
             [
                 self._project_row(
@@ -234,7 +234,7 @@ class DocumentEndpointsTestCase(support.SharedAppTestCase):
 
     def test_create_user_document(self) -> None:
         self.mock_db.execute.side_effect = [
-            [{'id': 'document-1'}],
+            [{'id': 'document-1', 'version': 2}],
             [
                 self._row(
                     u={
@@ -275,7 +275,7 @@ class DocumentEndpointsTestCase(support.SharedAppTestCase):
 
     def test_create_project_type_document(self) -> None:
         self.mock_db.execute.side_effect = [
-            [{'id': 'document-1'}],
+            [{'id': 'document-1', 'version': 2}],
             [
                 self._row(
                     pt={'slug': 'http-api', 'name': 'HTTP API'},
@@ -490,7 +490,7 @@ class DocumentEndpointsTestCase(support.SharedAppTestCase):
         # 3: _fetch_document (final)
         self.mock_db.execute.side_effect = [
             [self._project_row()],
-            [{'id': 'document-1'}],
+            [{'id': 'document-1', 'version': 2}],
             [self._project_row(n=self._document_data(content='Updated text'))],
         ]
         with mock.patch(
@@ -517,7 +517,7 @@ class DocumentEndpointsTestCase(support.SharedAppTestCase):
         }
         self.mock_db.execute.side_effect = [
             [self._row(u=user)],
-            [{'id': 'document-1'}],
+            [{'id': 'document-1', 'version': 2}],
             [
                 self._row(
                     n=self._document_data(content='Updated text'),
@@ -546,7 +546,7 @@ class DocumentEndpointsTestCase(support.SharedAppTestCase):
         self.mock_db.execute.side_effect = [
             [self._project_row()],
             [{'tag_slug': 'runbook', 'found': True}],
-            [{'id': 'document-1'}],
+            [{'id': 'document-1', 'version': 2}],
             [{'removed': 0}],
             [{'attached': 1}],
             [
@@ -576,7 +576,7 @@ class DocumentEndpointsTestCase(support.SharedAppTestCase):
 
     def test_create_defaults_is_pinned_false(self) -> None:
         self.mock_db.execute.side_effect = [
-            [{'id': 'document-1'}],
+            [{'id': 'document-1', 'version': 2}],
             [self._project_row()],
         ]
         with mock.patch(
@@ -597,7 +597,7 @@ class DocumentEndpointsTestCase(support.SharedAppTestCase):
     def test_patch_title(self) -> None:
         self.mock_db.execute.side_effect = [
             [self._project_row()],
-            [{'id': 'document-1'}],
+            [{'id': 'document-1', 'version': 2}],
             [self._project_row(n=self._document_data(title='New title'))],
         ]
         with mock.patch(
@@ -622,7 +622,7 @@ class DocumentEndpointsTestCase(support.SharedAppTestCase):
     def test_patch_is_pinned(self) -> None:
         self.mock_db.execute.side_effect = [
             [self._project_row()],
-            [{'id': 'document-1'}],
+            [{'id': 'document-1', 'version': 2}],
             [self._project_row(n=self._document_data(is_pinned=True))],
         ]
         with mock.patch(
@@ -727,7 +727,7 @@ class DocumentEndpointsTestCase(support.SharedAppTestCase):
 
     def test_create_records_version_snapshot(self) -> None:
         self.mock_db.execute.side_effect = [
-            [{'id': 'document-1'}],
+            [{'id': 'document-1', 'version': 2}],
             [self._project_row()],
         ]
         with mock.patch(
@@ -753,7 +753,7 @@ class DocumentEndpointsTestCase(support.SharedAppTestCase):
     def test_patch_content_bumps_version_and_snapshots(self) -> None:
         self.mock_db.execute.side_effect = [
             [self._project_row()],
-            [{'id': 'document-1'}],
+            [{'id': 'document-1', 'version': 2}],
             [
                 self._project_row(
                     n=self._document_data(content='Updated text', version=2)
@@ -775,9 +775,9 @@ class DocumentEndpointsTestCase(support.SharedAppTestCase):
             )
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json()['version'], 2)
-        # The SET query (second call) writes the bumped version.
+        # The SET query (second call) bumps the version atomically.
         write_call = self.mock_db.execute.await_args_list[1]
-        self.assertEqual(write_call.args[1]['version'], 2)
+        self.assertEqual(write_call.args[1]['version_bump'], 1)
         self.ch_insert.assert_awaited_once()
         _, rows = self.ch_insert.await_args.args
         self.assertEqual(len(rows), 1)
@@ -787,7 +787,7 @@ class DocumentEndpointsTestCase(support.SharedAppTestCase):
     def test_patch_is_pinned_does_not_bump_version(self) -> None:
         self.mock_db.execute.side_effect = [
             [self._project_row()],
-            [{'id': 'document-1'}],
+            [{'id': 'document-1', 'version': 2}],
             [self._project_row(n=self._document_data(is_pinned=True))],
         ]
         with mock.patch(
@@ -795,13 +795,11 @@ class DocumentEndpointsTestCase(support.SharedAppTestCase):
         ):
             response = self.client.patch(
                 '/organizations/engineering/projects/proj-abc/documents/document-1',
-                json=[
-                    {'op': 'replace', 'path': '/is_pinned', 'value': True}
-                ],
+                json=[{'op': 'replace', 'path': '/is_pinned', 'value': True}],
             )
         self.assertEqual(response.status_code, 200)
         write_call = self.mock_db.execute.await_args_list[1]
-        self.assertEqual(write_call.args[1]['version'], 1)
+        self.assertEqual(write_call.args[1]['version_bump'], 0)
         self.ch_insert.assert_not_awaited()
 
     def test_patch_writes_baseline_for_document_without_history(self) -> None:
@@ -809,7 +807,7 @@ class DocumentEndpointsTestCase(support.SharedAppTestCase):
         self.ch_query.return_value = [{'v': 0, 'c': 0}]
         self.mock_db.execute.side_effect = [
             [self._project_row()],
-            [{'id': 'document-1'}],
+            [{'id': 'document-1', 'version': 2}],
             [
                 self._project_row(
                     n=self._document_data(content='Updated text', version=2)
@@ -844,7 +842,7 @@ class DocumentEndpointsTestCase(support.SharedAppTestCase):
         self.ch_insert.side_effect = RuntimeError('clickhouse down')
         self.mock_db.execute.side_effect = [
             [self._project_row()],
-            [{'id': 'document-1'}],
+            [{'id': 'document-1', 'version': 2}],
             [
                 self._project_row(
                     n=self._document_data(content='Updated text', version=2)
@@ -856,7 +854,7 @@ class DocumentEndpointsTestCase(support.SharedAppTestCase):
                 'imbi.common.graph.parse_agtype', side_effect=lambda x: x
             ),
             self.assertLogs(
-                'imbi.api.endpoints.document_versions', level='ERROR'
+                'imbi.api.endpoints._document_history', level='ERROR'
             ),
         ):
             response = self.client.patch(

--- a/libraries/common/src/imbi/common/clickhouse/schemata.toml
+++ b/libraries/common/src/imbi/common/clickhouse/schemata.toml
@@ -154,6 +154,24 @@ ORDER BY (project_id, sha);
 """
 enabled = true
 
+[document_versions]
+query = """
+CREATE TABLE IF NOT EXISTS imbi.document_versions {on_cluster}(
+  document_id   String,
+  version       UInt32,
+  title         String,
+  content       String,
+  tags          Array(String),
+  change_kind   LowCardinality(String),
+  updated_by    String,
+  updated_at    DateTime64(3, 'UTC'),
+  recorded_at   DateTime64(3, 'UTC')
+) ENGINE = {replicated}ReplacingMergeTree(recorded_at)
+PARTITION BY toYear(updated_at)
+ORDER BY (document_id, version);
+"""
+enabled = true
+
 [tags]
 query = """
 CREATE TABLE IF NOT EXISTS imbi.tags {on_cluster}(

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -46,6 +46,7 @@
         "cmdk": "^1.1.1",
         "date-fns": "^4.1.0",
         "devicon": "^2.17.0",
+        "diff": "^9.0.0",
         "js-yaml": "^4.1.1",
         "jwt-decode": "^4.0.0",
         "lucide-react": "^0.469.0",
@@ -8924,9 +8925,9 @@
       }
     },
     "node_modules/diff": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.2.tgz",
-      "integrity": "sha512-vtcDfH3TOjP8UekytvnHH1o1P4FcUdt4eQ1Y+Abap1tk/OB2MWQvcwS2ClCd1zuIhc3JKOx6p3kod8Vfys3E+A==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-9.0.0.tgz",
+      "integrity": "sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
@@ -15619,6 +15620,15 @@
         "diff": "^5.1.0"
       }
     },
+    "node_modules/unidiff/node_modules/diff": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.2.tgz",
+      "integrity": "sha512-vtcDfH3TOjP8UekytvnHH1o1P4FcUdt4eQ1Y+Abap1tk/OB2MWQvcwS2ClCd1zuIhc3JKOx6p3kod8Vfys3E+A==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
     "node_modules/unified": {
       "version": "11.0.5",
       "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
@@ -15879,6 +15889,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/uvu/node_modules/diff": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.2.tgz",
+      "integrity": "sha512-vtcDfH3TOjP8UekytvnHH1o1P4FcUdt4eQ1Y+Abap1tk/OB2MWQvcwS2ClCd1zuIhc3JKOx6p3kod8Vfys3E+A==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
       }
     },
     "node_modules/vfile": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -59,6 +59,7 @@
     "cmdk": "^1.1.1",
     "date-fns": "^4.1.0",
     "devicon": "^2.17.0",
+    "diff": "^9.0.0",
     "js-yaml": "^4.1.1",
     "jwt-decode": "^4.0.0",
     "lucide-react": "^0.469.0",

--- a/ui/src/api/endpoints.ts
+++ b/ui/src/api/endpoints.ts
@@ -33,9 +33,12 @@ import type {
   DeploymentTriggerResponse,
   Document,
   DocumentCreate,
+  DocumentEditorsResponse,
   DocumentListResponse,
   DocumentTemplate,
   DocumentTemplateCreate,
+  DocumentVersion,
+  DocumentVersionListResponse,
   DraftReleaseNotesRequest,
   DraftReleaseNotesResponse,
   Environment,
@@ -1776,6 +1779,72 @@ export const deleteOrgDocument = (orgSlug: string, documentId: string) =>
   apiClient.delete<void>(
     `/organizations/${encodeURIComponent(orgSlug)}/documents/${encodeURIComponent(documentId)}`,
   )
+
+// Document version history (attachment-agnostic). Full snapshots are
+// recorded server-side on every content-affecting change; restore
+// applies an old snapshot as a normal update (a new version).
+const documentVersionsPath = (orgSlug: string, documentId: string) =>
+  `/organizations/${encodeURIComponent(orgSlug)}/documents/${encodeURIComponent(documentId)}/versions`
+
+export const listDocumentVersions = async (
+  orgSlug: string,
+  documentId: string,
+  signal?: AbortSignal,
+) => {
+  const response = await apiClient.get<DocumentVersionListResponse>(
+    documentVersionsPath(orgSlug, documentId),
+    undefined,
+    signal,
+  )
+  return response?.data ?? []
+}
+
+export const getDocumentVersion = (
+  orgSlug: string,
+  documentId: string,
+  version: number,
+  signal?: AbortSignal,
+) =>
+  apiClient.get<DocumentVersion>(
+    `${documentVersionsPath(orgSlug, documentId)}/${version}`,
+    undefined,
+    signal,
+  )
+
+export const restoreDocumentVersion = (
+  orgSlug: string,
+  documentId: string,
+  version: number,
+) =>
+  apiClient.post<Document>(
+    `${documentVersionsPath(orgSlug, documentId)}/${version}/restore`,
+    undefined,
+  )
+
+// Advisory "currently editing" presence markers. The PUT heartbeat
+// registers/refreshes the caller and returns every active editor;
+// markers expire server-side after `ttl_seconds` without a heartbeat.
+const documentEditingPath = (orgSlug: string, documentId: string) =>
+  `/organizations/${encodeURIComponent(orgSlug)}/documents/${encodeURIComponent(documentId)}/editing`
+
+export const getDocumentEditors = (
+  orgSlug: string,
+  documentId: string,
+  signal?: AbortSignal,
+) =>
+  apiClient.get<DocumentEditorsResponse>(
+    documentEditingPath(orgSlug, documentId),
+    undefined,
+    signal,
+  )
+
+export const heartbeatDocumentEditing = (orgSlug: string, documentId: string) =>
+  apiClient.put<DocumentEditorsResponse>(
+    documentEditingPath(orgSlug, documentId),
+  )
+
+export const clearDocumentEditing = (orgSlug: string, documentId: string) =>
+  apiClient.delete<void>(documentEditingPath(orgSlug, documentId))
 
 // Documents attached to a user (org member).
 export const listUserDocuments = async (

--- a/ui/src/components/documents/DocumentVersionHistory.tsx
+++ b/ui/src/components/documents/DocumentVersionHistory.tsx
@@ -31,6 +31,7 @@ import {
 } from '@/components/ui/segmented-control'
 import { Sk, SkText } from '@/components/ui/skeleton'
 import { UserIdentity } from '@/components/ui/user-identity'
+import { queryKeys } from '@/lib/queryKeys'
 import { cn } from '@/lib/utils'
 import type { Document, DocumentVersionInfo } from '@/types'
 
@@ -78,7 +79,7 @@ export function DocumentVersionHistory({
   const versionsQuery = useQuery({
     enabled: open,
     queryFn: ({ signal }) => listDocumentVersions(orgSlug, document.id, signal),
-    queryKey: ['documentVersions', orgSlug, document.id],
+    queryKey: queryKeys.documentVersions(orgSlug, document.id),
   })
   const versions = versionsQuery.data ?? []
   const selectedVersion = selected ?? versions[0]?.version ?? null
@@ -89,13 +90,23 @@ export function DocumentVersionHistory({
     enabled: open && selectedVersion !== null,
     queryFn: ({ signal }) =>
       getDocumentVersion(orgSlug, document.id, selectedVersion ?? 0, signal),
-    queryKey: ['documentVersion', orgSlug, document.id, selectedVersion],
+    queryKey: queryKeys.documentVersion(
+      orgSlug,
+      document.id,
+      selectedVersion ?? 0,
+    ),
   })
   const snapshot = snapshotQuery.data
 
+  const currentVersion = document.version ?? 1
+  const isCurrent = selectedVersion === currentVersion
+
+  // diffLines is O(n·m) over the two contents — only pay for it when
+  // the Changes view is actually showing.
+  const showDiff = viewMode === 'diff' && !isCurrent && !!snapshot
   const diffParts = useMemo(
-    () => (snapshot ? diffLines(snapshot.content, document.content) : []),
-    [snapshot, document.content],
+    () => (showDiff ? diffLines(snapshot.content, document.content) : []),
+    [showDiff, snapshot, document.content],
   )
   const diffStats = useMemo(() => {
     let added = 0
@@ -107,10 +118,6 @@ export function DocumentVersionHistory({
     }
     return { added, removed }
   }, [diffParts])
-
-  const currentVersion = document.version ?? 1
-  const isCurrent =
-    selectedVersion !== null && selectedVersion === currentVersion
 
   return (
     <Dialog onOpenChange={onOpenChange} open={open}>
@@ -174,7 +181,7 @@ export function DocumentVersionHistory({
                 </div>
               )}
               <div className="ml-auto flex items-center gap-2">
-                {viewMode === 'diff' && snapshot && !isCurrent && (
+                {showDiff && (
                   <span className="font-mono text-[12.5px] tabular-nums">
                     <span className="text-success">+{diffStats.added}</span>{' '}
                     <span className="text-danger">−{diffStats.removed}</span>

--- a/ui/src/components/documents/DocumentVersionHistory.tsx
+++ b/ui/src/components/documents/DocumentVersionHistory.tsx
@@ -2,7 +2,15 @@ import { useMemo, useState } from 'react'
 
 import { useQuery } from '@tanstack/react-query'
 import { diffLines } from 'diff'
-import { FileText, GitCompare, RotateCcw } from 'lucide-react'
+import type { LucideIcon } from 'lucide-react'
+import {
+  CircleDashed,
+  FileText,
+  GitCompare,
+  Pencil,
+  Plus,
+  RotateCcw,
+} from 'lucide-react'
 import Markdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 
@@ -16,21 +24,26 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog'
+import { RelativeTime } from '@/components/ui/RelativeTime'
 import {
   SegmentedControl,
   SegmentedControlItem,
 } from '@/components/ui/segmented-control'
+import { Sk, SkText } from '@/components/ui/skeleton'
 import { UserIdentity } from '@/components/ui/user-identity'
 import { cn } from '@/lib/utils'
 import type { Document, DocumentVersionInfo } from '@/types'
 
-import { formatFull } from './documentsHelpers'
-
-const CHANGE_KIND_LABELS: Record<DocumentVersionInfo['change_kind'], string> = {
-  baseline: 'Original',
-  create: 'Created',
-  restore: 'Restored',
-  update: 'Edited',
+// Each change kind gets a glyph and tone so the timeline itself tells
+// the story: how a version came to be, at a glance.
+const CHANGE_KINDS: Record<
+  DocumentVersionInfo['change_kind'],
+  { icon: LucideIcon; label: string; tone: string }
+> = {
+  baseline: { icon: CircleDashed, label: 'Original', tone: 'text-tertiary' },
+  create: { icon: Plus, label: 'Created', tone: 'text-success' },
+  restore: { icon: RotateCcw, label: 'Restored', tone: 'text-warning' },
+  update: { icon: Pencil, label: 'Edited', tone: 'text-secondary' },
 }
 
 interface Props {
@@ -44,9 +57,10 @@ interface Props {
 }
 
 /**
- * Version-history dialog for one document: version list on the left,
- * the selected snapshot (rendered, or a line diff against the current
- * content) on the right, with a restore action.
+ * Version-history dialog for one document: a timeline of versions on
+ * the left (glyphs encode how each came to be), the selected snapshot
+ * on the right — rendered, or as a line diff against the current
+ * content — with a restore action scoped to the selected version.
  */
 export function DocumentVersionHistory({
   displayNames,
@@ -68,6 +82,8 @@ export function DocumentVersionHistory({
   })
   const versions = versionsQuery.data ?? []
   const selectedVersion = selected ?? versions[0]?.version ?? null
+  const selectedInfo =
+    versions.find((v) => v.version === selectedVersion) ?? null
 
   const snapshotQuery = useQuery({
     enabled: open && selectedVersion !== null,
@@ -77,102 +93,130 @@ export function DocumentVersionHistory({
   })
   const snapshot = snapshotQuery.data
 
+  const diffParts = useMemo(
+    () => (snapshot ? diffLines(snapshot.content, document.content) : []),
+    [snapshot, document.content],
+  )
+  const diffStats = useMemo(() => {
+    let added = 0
+    let removed = 0
+    for (const part of diffParts) {
+      const lines = part.value.replace(/\n$/, '').split('\n').length
+      if (part.added) added += lines
+      else if (part.removed) removed += lines
+    }
+    return { added, removed }
+  }, [diffParts])
+
+  const currentVersion = document.version ?? 1
   const isCurrent =
-    selectedVersion !== null && selectedVersion === (document.version ?? 1)
+    selectedVersion !== null && selectedVersion === currentVersion
 
   return (
     <Dialog onOpenChange={onOpenChange} open={open}>
-      <DialogContent className="flex max-h-[85vh] flex-col sm:max-w-4xl">
-        <DialogHeader>
+      <DialogContent className="flex h-[min(85vh,680px)] flex-col gap-0 overflow-hidden p-0 sm:max-w-4xl">
+        <DialogHeader className="border-tertiary border-b px-5 pt-5 pb-4">
           <DialogTitle>Version history</DialogTitle>
           <DialogDescription>
-            Every saved change to “{document.title}”. Restoring an older version
-            saves it as a new version — nothing is overwritten.
+            Every saved version of “{document.title}”.
           </DialogDescription>
         </DialogHeader>
 
-        <div className="grid min-h-0 flex-1 grid-cols-1 gap-4 sm:grid-cols-[220px_minmax(0,1fr)]">
-          {/* Version list */}
-          <div className="border-tertiary flex max-h-[60vh] flex-col gap-1 overflow-y-auto sm:border-r sm:pr-3">
-            {versionsQuery.isLoading && (
-              <div className="text-tertiary p-2 text-sm">Loading…</div>
-            )}
+        <div className="grid min-h-0 flex-1 grid-cols-1 sm:grid-cols-[248px_minmax(0,1fr)]">
+          {/* Timeline rail */}
+          <div className="border-tertiary overflow-y-auto border-b p-3 sm:border-r sm:border-b-0">
+            {versionsQuery.isLoading && <TimelineSkeleton />}
             {!versionsQuery.isLoading && versions.length === 0 && (
               <div className="text-tertiary p-2 text-sm">
-                No history recorded yet. Versions are captured from the next
-                edit onward.
+                No versions yet — the next edit records one.
               </div>
             )}
-            {versions.map((v) => (
-              <button
-                className={cn(
-                  'cursor-pointer rounded-md border p-2 text-left transition-colors',
-                  v.version === selectedVersion
-                    ? 'border-action bg-secondary'
-                    : 'border-transparent hover:bg-secondary',
-                )}
-                key={v.version}
-                onClick={() => setSelected(v.version)}
-                type="button"
-              >
-                <div className="text-primary flex items-center gap-1.5 text-[12.5px] font-medium">
-                  v{v.version}
-                  <span className="text-tertiary font-normal">
-                    {CHANGE_KIND_LABELS[v.change_kind]}
-                  </span>
-                  {v.version === (document.version ?? 1) && (
-                    <span className="text-action font-normal">· current</span>
-                  )}
+            {versions.length > 0 && (
+              <div className="relative">
+                {/* The spine: one continuous line through every node. */}
+                <div
+                  aria-hidden
+                  className="bg-tertiary absolute top-4 bottom-4 left-[22px] w-px"
+                />
+                <div className="relative flex flex-col gap-0.5">
+                  {versions.map((v) => (
+                    <TimelineEntry
+                      current={v.version === currentVersion}
+                      displayNames={displayNames}
+                      key={v.version}
+                      onSelect={() => setSelected(v.version)}
+                      selected={v.version === selectedVersion}
+                      version={v}
+                    />
+                  ))}
                 </div>
-                <div className="text-tertiary mt-0.5 text-[11.5px]">
-                  {formatFull(v.updated_at)}
-                </div>
-                <div className="mt-1">
-                  <UserIdentity
-                    displayNames={displayNames}
-                    email={v.updated_by}
-                    linkToProfile={false}
-                    size="small"
-                  />
-                </div>
-              </button>
-            ))}
+              </div>
+            )}
           </div>
 
           {/* Snapshot pane */}
           <div className="flex min-h-0 flex-col">
-            <div className="mb-2 flex items-center gap-2">
-              <SegmentedControl
-                ariaLabel="Version view"
-                onValueChange={(v) => setViewMode(v as 'content' | 'diff')}
-                value={viewMode}
-              >
-                <SegmentedControlItem value="content">
-                  <FileText className="size-3" />
-                  Content
-                </SegmentedControlItem>
-                <SegmentedControlItem value="diff">
-                  <GitCompare className="size-3" />
-                  Changes vs current
-                </SegmentedControlItem>
-              </SegmentedControl>
-              <Button
-                className="ml-auto gap-1.5"
-                disabled={
-                  !snapshot || isCurrent || restorePending || !selectedVersion
-                }
-                onClick={() => setConfirmRestore(true)}
-                size="sm"
-                variant="outline"
-              >
-                <RotateCcw className="size-3" />
-                {restorePending ? 'Restoring…' : 'Restore this version'}
-              </Button>
+            <div className="border-tertiary bg-secondary/50 flex flex-wrap items-center gap-x-3 gap-y-2 border-b px-4 py-2.5">
+              {selectedInfo && (
+                <div className="text-tertiary flex min-w-0 items-center gap-2 text-[12.5px]">
+                  <span className="text-primary font-mono font-medium">
+                    v{selectedInfo.version}
+                  </span>
+                  <span>{CHANGE_KINDS[selectedInfo.change_kind].label}</span>
+                  <span aria-hidden>·</span>
+                  <UserIdentity
+                    displayNames={displayNames}
+                    email={selectedInfo.updated_by}
+                    linkToProfile={false}
+                    size="small"
+                  />
+                  <RelativeTime value={selectedInfo.updated_at} />
+                </div>
+              )}
+              <div className="ml-auto flex items-center gap-2">
+                {viewMode === 'diff' && snapshot && !isCurrent && (
+                  <span className="font-mono text-[12.5px] tabular-nums">
+                    <span className="text-success">+{diffStats.added}</span>{' '}
+                    <span className="text-danger">−{diffStats.removed}</span>
+                  </span>
+                )}
+                <SegmentedControl
+                  ariaLabel="Version view"
+                  onValueChange={(v) => setViewMode(v as 'content' | 'diff')}
+                  value={viewMode}
+                >
+                  <SegmentedControlItem value="content">
+                    <FileText className="size-3" />
+                    Content
+                  </SegmentedControlItem>
+                  <SegmentedControlItem value="diff">
+                    <GitCompare className="size-3" />
+                    Changes
+                  </SegmentedControlItem>
+                </SegmentedControl>
+                {!isCurrent && selectedVersion !== null && (
+                  <Button
+                    className="gap-1.5"
+                    disabled={!snapshot || restorePending}
+                    onClick={() => setConfirmRestore(true)}
+                    size="sm"
+                    variant="outline"
+                  >
+                    <RotateCcw className="size-3" />
+                    {restorePending
+                      ? 'Restoring…'
+                      : `Restore v${selectedVersion}`}
+                  </Button>
+                )}
+              </div>
             </div>
 
-            <div className="border-tertiary min-h-0 flex-1 overflow-y-auto rounded-md border p-4">
+            <div className="min-h-0 flex-1 overflow-y-auto px-5 py-4">
               {snapshotQuery.isLoading && (
-                <div className="text-tertiary text-sm">Loading version…</div>
+                <div className="flex flex-col gap-3">
+                  <Sk h={22} w="33%" />
+                  <SkText widths={['100%', '83%', '66%']} />
+                </div>
               )}
               {snapshot && viewMode === 'content' && (
                 <>
@@ -186,9 +230,15 @@ export function DocumentVersionHistory({
                   </div>
                 </>
               )}
-              {snapshot && viewMode === 'diff' && (
-                <DiffView current={document.content} old={snapshot.content} />
-              )}
+              {snapshot &&
+                viewMode === 'diff' &&
+                (isCurrent ? (
+                  <div className="text-tertiary text-sm italic">
+                    This is the current version — nothing to compare.
+                  </div>
+                ) : (
+                  <DiffView parts={diffParts} />
+                ))}
             </div>
           </div>
         </div>
@@ -196,26 +246,25 @@ export function DocumentVersionHistory({
 
       <ConfirmDialog
         confirmLabel={restorePending ? 'Restoring…' : 'Restore'}
-        description={`The document will be reverted to version ${selectedVersion}. The current content stays in the history as its own version.`}
+        description={`“${document.title}” will be reverted to version ${selectedVersion}. The current content is kept in the history as its own version — nothing is overwritten.`}
         onCancel={() => setConfirmRestore(false)}
         onConfirm={() => {
           setConfirmRestore(false)
           if (selectedVersion !== null) onRestore(selectedVersion)
         }}
         open={confirmRestore}
-        title="Restore this version?"
+        title={`Restore version ${selectedVersion}?`}
       />
     </Dialog>
   )
 }
 
 /**
- * Line diff between the selected snapshot and the current content.
- * Additions are lines the current document has that the snapshot
- * doesn't; removals are lines only the snapshot has.
+ * Line diff from the selected snapshot to the current content:
+ * additions are lines the current document gained since that version,
+ * removals are lines only that version had.
  */
-function DiffView({ current, old }: { current: string; old: string }) {
-  const parts = useMemo(() => diffLines(old, current), [old, current])
+function DiffView({ parts }: { parts: ReturnType<typeof diffLines> }) {
   if (parts.length === 1 && !parts[0].added && !parts[0].removed) {
     return (
       <div className="text-tertiary text-sm italic">
@@ -230,10 +279,9 @@ function DiffView({ current, old }: { current: string; old: string }) {
         return lines.map((line, j) => (
           <div
             className={cn(
-              'px-2',
-              part.added &&
-                'bg-emerald-500/10 text-emerald-700 dark:text-emerald-400',
-              part.removed && 'bg-red-500/10 text-red-700 dark:text-red-400',
+              'rounded-sm px-2',
+              part.added && 'text-success bg-success/10',
+              part.removed && 'text-danger bg-danger/10',
             )}
             key={`${i}-${j}`}
           >
@@ -244,6 +292,83 @@ function DiffView({ current, old }: { current: string; old: string }) {
           </div>
         ))
       })}
+    </div>
+  )
+}
+
+function TimelineEntry({
+  current,
+  displayNames,
+  onSelect,
+  selected,
+  version,
+}: {
+  current: boolean
+  displayNames?: Map<string, string>
+  onSelect: () => void
+  selected: boolean
+  version: DocumentVersionInfo
+}) {
+  const kind = CHANGE_KINDS[version.change_kind]
+  const Icon = kind.icon
+  return (
+    <button
+      className={cn(
+        'focus-visible:ring-ring grid cursor-pointer grid-cols-[28px_minmax(0,1fr)] items-start gap-x-2.5 rounded-md p-2 text-left transition-colors focus-visible:ring-2 focus-visible:outline-none',
+        selected ? 'bg-secondary' : 'hover:bg-secondary/60',
+      )}
+      onClick={onSelect}
+      type="button"
+    >
+      {/* Node on the spine */}
+      <span
+        className={cn(
+          'bg-primary mt-0.5 flex size-[26px] items-center justify-center rounded-full border',
+          selected ? 'border-action' : 'border-secondary',
+          kind.tone,
+        )}
+      >
+        <Icon className="size-3" />
+      </span>
+      <span className="flex min-w-0 flex-col gap-0.5">
+        <span className="flex items-center gap-1.5 text-[12.5px]">
+          <span className="text-primary font-mono font-medium">
+            v{version.version}
+          </span>
+          <span className="text-tertiary">{kind.label}</span>
+          {current && (
+            <span className="border-action/40 text-action ml-auto rounded-full border px-1.5 text-[11px] leading-[1.6]">
+              Current
+            </span>
+          )}
+        </span>
+        <span className="text-tertiary flex items-center gap-1.5 text-[11.5px]">
+          <UserIdentity
+            displayNames={displayNames}
+            email={version.updated_by}
+            linkToProfile={false}
+            size="small"
+          />
+          <span aria-hidden>·</span>
+          <RelativeTime value={version.updated_at} />
+        </span>
+      </span>
+    </button>
+  )
+}
+
+function TimelineSkeleton() {
+  return (
+    <div className="flex flex-col gap-3 p-2">
+      {[0, 1, 2].map((i) => (
+        <div className="grid grid-cols-[28px_1fr] items-center gap-2.5" key={i}>
+          <Sk circle h={26} w={26} />
+          <div className="flex flex-col gap-1.5">
+            <Sk line w={96} />
+            <Sk line w={128} />
+          </div>
+        </div>
+      ))}
     </div>
   )
 }

--- a/ui/src/components/documents/DocumentVersionHistory.tsx
+++ b/ui/src/components/documents/DocumentVersionHistory.tsx
@@ -1,0 +1,249 @@
+import { useMemo, useState } from 'react'
+
+import { useQuery } from '@tanstack/react-query'
+import { diffLines } from 'diff'
+import { FileText, GitCompare, RotateCcw } from 'lucide-react'
+import Markdown from 'react-markdown'
+import remarkGfm from 'remark-gfm'
+
+import { getDocumentVersion, listDocumentVersions } from '@/api/endpoints'
+import { Button } from '@/components/ui/button'
+import { ConfirmDialog } from '@/components/ui/confirm-dialog'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import {
+  SegmentedControl,
+  SegmentedControlItem,
+} from '@/components/ui/segmented-control'
+import { UserIdentity } from '@/components/ui/user-identity'
+import { cn } from '@/lib/utils'
+import type { Document, DocumentVersionInfo } from '@/types'
+
+import { formatFull } from './documentsHelpers'
+
+const CHANGE_KIND_LABELS: Record<DocumentVersionInfo['change_kind'], string> = {
+  baseline: 'Original',
+  create: 'Created',
+  restore: 'Restored',
+  update: 'Edited',
+}
+
+interface Props {
+  displayNames?: Map<string, string>
+  document: Document
+  onOpenChange: (open: boolean) => void
+  onRestore: (version: number) => void
+  open: boolean
+  orgSlug: string
+  restorePending?: boolean
+}
+
+/**
+ * Version-history dialog for one document: version list on the left,
+ * the selected snapshot (rendered, or a line diff against the current
+ * content) on the right, with a restore action.
+ */
+export function DocumentVersionHistory({
+  displayNames,
+  document,
+  onOpenChange,
+  onRestore,
+  open,
+  orgSlug,
+  restorePending = false,
+}: Props) {
+  const [selected, setSelected] = useState<null | number>(null)
+  const [viewMode, setViewMode] = useState<'content' | 'diff'>('content')
+  const [confirmRestore, setConfirmRestore] = useState(false)
+
+  const versionsQuery = useQuery({
+    enabled: open,
+    queryFn: ({ signal }) => listDocumentVersions(orgSlug, document.id, signal),
+    queryKey: ['documentVersions', orgSlug, document.id],
+  })
+  const versions = versionsQuery.data ?? []
+  const selectedVersion = selected ?? versions[0]?.version ?? null
+
+  const snapshotQuery = useQuery({
+    enabled: open && selectedVersion !== null,
+    queryFn: ({ signal }) =>
+      getDocumentVersion(orgSlug, document.id, selectedVersion ?? 0, signal),
+    queryKey: ['documentVersion', orgSlug, document.id, selectedVersion],
+  })
+  const snapshot = snapshotQuery.data
+
+  const isCurrent =
+    selectedVersion !== null && selectedVersion === (document.version ?? 1)
+
+  return (
+    <Dialog onOpenChange={onOpenChange} open={open}>
+      <DialogContent className="flex max-h-[85vh] flex-col sm:max-w-4xl">
+        <DialogHeader>
+          <DialogTitle>Version history</DialogTitle>
+          <DialogDescription>
+            Every saved change to “{document.title}”. Restoring an older version
+            saves it as a new version — nothing is overwritten.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="grid min-h-0 flex-1 grid-cols-1 gap-4 sm:grid-cols-[220px_minmax(0,1fr)]">
+          {/* Version list */}
+          <div className="border-tertiary flex max-h-[60vh] flex-col gap-1 overflow-y-auto sm:border-r sm:pr-3">
+            {versionsQuery.isLoading && (
+              <div className="text-tertiary p-2 text-sm">Loading…</div>
+            )}
+            {!versionsQuery.isLoading && versions.length === 0 && (
+              <div className="text-tertiary p-2 text-sm">
+                No history recorded yet. Versions are captured from the next
+                edit onward.
+              </div>
+            )}
+            {versions.map((v) => (
+              <button
+                className={cn(
+                  'cursor-pointer rounded-md border p-2 text-left transition-colors',
+                  v.version === selectedVersion
+                    ? 'border-action bg-secondary'
+                    : 'border-transparent hover:bg-secondary',
+                )}
+                key={v.version}
+                onClick={() => setSelected(v.version)}
+                type="button"
+              >
+                <div className="text-primary flex items-center gap-1.5 text-[12.5px] font-medium">
+                  v{v.version}
+                  <span className="text-tertiary font-normal">
+                    {CHANGE_KIND_LABELS[v.change_kind]}
+                  </span>
+                  {v.version === (document.version ?? 1) && (
+                    <span className="text-action font-normal">· current</span>
+                  )}
+                </div>
+                <div className="text-tertiary mt-0.5 text-[11.5px]">
+                  {formatFull(v.updated_at)}
+                </div>
+                <div className="mt-1">
+                  <UserIdentity
+                    displayNames={displayNames}
+                    email={v.updated_by}
+                    linkToProfile={false}
+                    size="small"
+                  />
+                </div>
+              </button>
+            ))}
+          </div>
+
+          {/* Snapshot pane */}
+          <div className="flex min-h-0 flex-col">
+            <div className="mb-2 flex items-center gap-2">
+              <SegmentedControl
+                ariaLabel="Version view"
+                onValueChange={(v) => setViewMode(v as 'content' | 'diff')}
+                value={viewMode}
+              >
+                <SegmentedControlItem value="content">
+                  <FileText className="size-3" />
+                  Content
+                </SegmentedControlItem>
+                <SegmentedControlItem value="diff">
+                  <GitCompare className="size-3" />
+                  Changes vs current
+                </SegmentedControlItem>
+              </SegmentedControl>
+              <Button
+                className="ml-auto gap-1.5"
+                disabled={
+                  !snapshot || isCurrent || restorePending || !selectedVersion
+                }
+                onClick={() => setConfirmRestore(true)}
+                size="sm"
+                variant="outline"
+              >
+                <RotateCcw className="size-3" />
+                {restorePending ? 'Restoring…' : 'Restore this version'}
+              </Button>
+            </div>
+
+            <div className="border-tertiary min-h-0 flex-1 overflow-y-auto rounded-md border p-4">
+              {snapshotQuery.isLoading && (
+                <div className="text-tertiary text-sm">Loading version…</div>
+              )}
+              {snapshot && viewMode === 'content' && (
+                <>
+                  <h2 className="text-primary mt-0 mb-3 text-lg font-medium">
+                    {snapshot.title}
+                  </h2>
+                  <div className="document-markdown">
+                    <Markdown remarkPlugins={[remarkGfm]}>
+                      {snapshot.content}
+                    </Markdown>
+                  </div>
+                </>
+              )}
+              {snapshot && viewMode === 'diff' && (
+                <DiffView current={document.content} old={snapshot.content} />
+              )}
+            </div>
+          </div>
+        </div>
+      </DialogContent>
+
+      <ConfirmDialog
+        confirmLabel={restorePending ? 'Restoring…' : 'Restore'}
+        description={`The document will be reverted to version ${selectedVersion}. The current content stays in the history as its own version.`}
+        onCancel={() => setConfirmRestore(false)}
+        onConfirm={() => {
+          setConfirmRestore(false)
+          if (selectedVersion !== null) onRestore(selectedVersion)
+        }}
+        open={confirmRestore}
+        title="Restore this version?"
+      />
+    </Dialog>
+  )
+}
+
+/**
+ * Line diff between the selected snapshot and the current content.
+ * Additions are lines the current document has that the snapshot
+ * doesn't; removals are lines only the snapshot has.
+ */
+function DiffView({ current, old }: { current: string; old: string }) {
+  const parts = useMemo(() => diffLines(old, current), [old, current])
+  if (parts.length === 1 && !parts[0].added && !parts[0].removed) {
+    return (
+      <div className="text-tertiary text-sm italic">
+        This version's content is identical to the current document.
+      </div>
+    )
+  }
+  return (
+    <div className="font-mono text-[12.5px] leading-[1.6] whitespace-pre-wrap">
+      {parts.flatMap((part, i) => {
+        const lines = part.value.replace(/\n$/, '').split('\n')
+        return lines.map((line, j) => (
+          <div
+            className={cn(
+              'px-2',
+              part.added &&
+                'bg-emerald-500/10 text-emerald-700 dark:text-emerald-400',
+              part.removed && 'bg-red-500/10 text-red-700 dark:text-red-400',
+            )}
+            key={`${i}-${j}`}
+          >
+            <span className="inline-block w-4 select-none">
+              {part.added ? '+' : part.removed ? '−' : ' '}
+            </span>
+            {line}
+          </div>
+        ))
+      })}
+    </div>
+  )
+}

--- a/ui/src/components/documents/DocumentVersionHistory.tsx
+++ b/ui/src/components/documents/DocumentVersionHistory.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 
 import { useQuery } from '@tanstack/react-query'
 import { diffLines } from 'diff'
@@ -75,6 +75,14 @@ export function DocumentVersionHistory({
   const [selected, setSelected] = useState<null | number>(null)
   const [viewMode, setViewMode] = useState<'content' | 'diff'>('content')
   const [confirmRestore, setConfirmRestore] = useState(false)
+
+  // The dialog stays mounted while `document` can change underneath it
+  // (e.g. navigating via related documents), so the per-document
+  // selection must not carry over.
+  useEffect(() => {
+    setSelected(null)
+    setConfirmRestore(false)
+  }, [document.id])
 
   const versionsQuery = useQuery({
     enabled: open,

--- a/ui/src/components/documents/DocumentsPinboardNew.tsx
+++ b/ui/src/components/documents/DocumentsPinboardNew.tsx
@@ -1,6 +1,13 @@
 import { type ReactNode, useEffect, useMemo, useRef, useState } from 'react'
 
-import { ArrowLeft, Check, Columns2, Eye, PencilLine } from 'lucide-react'
+import {
+  ArrowLeft,
+  Check,
+  Columns2,
+  Eye,
+  PencilLine,
+  TriangleAlert,
+} from 'lucide-react'
 import Markdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 
@@ -20,10 +27,14 @@ type EditorMode = 'preview' | 'split' | 'write'
 
 interface Props {
   allDocuments?: Document[]
+  /** Resolve editor emails to display names for the presence banner. */
+  displayNames?: Map<string, string>
   initialDocument?: Document | null
   onDiscard: () => void
   onSave: (draft: { content: string; tags: string[]; title: string }) => void
   orgSlug: string
+  /** Emails of other people currently editing this document. */
+  otherEditors?: string[]
   saving?: boolean
   /**
    * When creating a new document, pre-seed the form (title, content, tags) from
@@ -36,10 +47,12 @@ const NOOP = () => {}
 
 export function DocumentsPinboardNew({
   allDocuments = [],
+  displayNames,
   initialDocument,
   onDiscard,
   onSave,
   orgSlug,
+  otherEditors = [],
   saving = false,
   template,
 }: Props) {
@@ -171,6 +184,17 @@ export function DocumentsPinboardNew({
           </Button>
         </div>
 
+        {otherEditors.length > 0 && (
+          <div className="mb-3.5 flex items-center gap-2 rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-[12.5px] text-amber-700 dark:text-amber-400">
+            <TriangleAlert className="size-3.5 shrink-0" />
+            <span>
+              {editorList(otherEditors, displayNames)}{' '}
+              {otherEditors.length === 1 ? 'is' : 'are'} also editing this
+              document — the last save wins.
+            </span>
+          </div>
+        )}
+
         <article className="border-tertiary bg-primary overflow-hidden rounded-lg border">
           {/* Title + tag picker */}
           <div className="px-7 pt-6">
@@ -233,6 +257,17 @@ export function DocumentsPinboardNew({
       </div>
     </div>
   )
+}
+
+/** "Alice", "Alice and Bob", or "Alice, Bob, and Carol". */
+function editorList(
+  emails: string[],
+  displayNames?: Map<string, string>,
+): string {
+  const names = emails.map((e) => displayNames?.get(e) ?? e)
+  if (names.length === 1) return names[0]
+  if (names.length === 2) return `${names[0]} and ${names[1]}`
+  return `${names.slice(0, -1).join(', ')}, and ${names[names.length - 1]}`
 }
 
 function ModeButton({

--- a/ui/src/components/documents/DocumentsPinboardNew.tsx
+++ b/ui/src/components/documents/DocumentsPinboardNew.tsx
@@ -1,16 +1,10 @@
 import { type ReactNode, useEffect, useMemo, useRef, useState } from 'react'
 
-import {
-  ArrowLeft,
-  Check,
-  Columns2,
-  Eye,
-  PencilLine,
-  TriangleAlert,
-} from 'lucide-react'
+import { ArrowLeft, Check, Columns2, Eye, PencilLine } from 'lucide-react'
 import Markdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 
+import { Alert } from '@/components/ui/alert'
 import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
 import type { Document, DocumentTemplate, TagRef } from '@/types'
@@ -185,14 +179,11 @@ export function DocumentsPinboardNew({
         </div>
 
         {otherEditors.length > 0 && (
-          <div className="mb-3.5 flex items-center gap-2 rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-[12.5px] text-amber-700 dark:text-amber-400">
-            <TriangleAlert className="size-3.5 shrink-0" />
-            <span>
-              {editorList(otherEditors, displayNames)}{' '}
-              {otherEditors.length === 1 ? 'is' : 'are'} also editing this
-              document — the last save wins.
-            </span>
-          </div>
+          <Alert className="mb-3.5" variant="warning">
+            {editorList(otherEditors, displayNames)}{' '}
+            {otherEditors.length === 1 ? 'is' : 'are'} also editing this
+            document — the last save wins.
+          </Alert>
         )}
 
         <article className="border-tertiary bg-primary overflow-hidden rounded-lg border">

--- a/ui/src/components/documents/DocumentsPinboardReader.tsx
+++ b/ui/src/components/documents/DocumentsPinboardReader.tsx
@@ -86,8 +86,6 @@ interface Props {
   onRestoreVersion?: (version: number) => void
   onTogglePin: () => void
   orgSlug: string
-  /** Emails of other people currently editing this document. */
-  otherEditors?: string[]
   projectId: null | string
   restorePending?: boolean
   /** Show the attachment eyebrow — only in the org-wide reader, where the
@@ -117,7 +115,6 @@ export function DocumentsPinboardReader({
   onRestoreVersion,
   onTogglePin,
   orgSlug,
-  otherEditors = [],
   projectId,
   restorePending = false,
   showAttachment = false,
@@ -407,13 +404,6 @@ export function DocumentsPinboardReader({
                 <span className="text-tertiary">·</span>
                 <span>Updated {formatUpdated(document)}</span>
               </div>
-              {otherEditors.length > 0 && (
-                <span className="inline-flex items-center gap-1.5 rounded-full bg-amber-500/10 px-2.5 py-0.5 text-[11.5px] text-amber-700 dark:text-amber-400">
-                  <Pencil className="size-3" />
-                  {editorNames(otherEditors, displayNames)}{' '}
-                  {otherEditors.length === 1 ? 'is' : 'are'} currently editing
-                </span>
-              )}
               <div className="bg-tertiary h-3.5 w-px" />
               <div className="flex flex-wrap gap-1">
                 {document.tags.map((t) => (
@@ -604,17 +594,6 @@ export function DocumentsPinboardReader({
       />
     </div>
   )
-}
-
-/** "Alice", "Alice and Bob", or "Alice, Bob, and Carol". */
-function editorNames(
-  emails: string[],
-  displayNames?: Map<string, string>,
-): string {
-  const names = emails.map((e) => displayNames?.get(e) ?? e)
-  if (names.length === 1) return names[0]
-  if (names.length === 2) return `${names[0]} and ${names[1]}`
-  return `${names.slice(0, -1).join(', ')}, and ${names[names.length - 1]}`
 }
 
 function extractHeadings(content: string): Heading[] {

--- a/ui/src/components/documents/DocumentsPinboardReader.tsx
+++ b/ui/src/components/documents/DocumentsPinboardReader.tsx
@@ -9,6 +9,7 @@ import {
   Clock,
   Eye,
   EyeOff,
+  History,
   List,
   Pencil,
   Pin,
@@ -47,6 +48,7 @@ import {
   uniqueTagsFromDocuments,
 } from './documentsHelpers'
 import { DocumentTagChip } from './DocumentTagChip'
+import { DocumentVersionHistory } from './DocumentVersionHistory'
 
 interface Heading {
   level: 2 | 3
@@ -81,9 +83,13 @@ interface Props {
   onOpen: (documentId: string) => void
   onReplyComment: (threadId: string, body: string, mentions: string[]) => void
   onResolveThread: (threadId: string, resolved: boolean) => void
+  onRestoreVersion?: (version: number) => void
   onTogglePin: () => void
   orgSlug: string
+  /** Emails of other people currently editing this document. */
+  otherEditors?: string[]
   projectId: null | string
+  restorePending?: boolean
   /** Show the attachment eyebrow — only in the org-wide reader, where the
    * container no longer implies what the document is bound to. */
   showAttachment?: boolean
@@ -108,12 +114,16 @@ export function DocumentsPinboardReader({
   onOpen,
   onReplyComment,
   onResolveThread,
+  onRestoreVersion,
   onTogglePin,
   orgSlug,
+  otherEditors = [],
   projectId,
+  restorePending = false,
   showAttachment = false,
 }: Props) {
   const [search, setSearch] = useState('')
+  const [showHistory, setShowHistory] = useState(false)
   const [commentFilter, setCommentFilter] = useState<CommentFilter>('open')
   const [showComments, setShowComments] = useState(false)
   const articleRef = useRef<HTMLDivElement>(null)
@@ -321,6 +331,15 @@ export function DocumentsPinboardReader({
               </div>
               <Button
                 className="gap-1.5"
+                onClick={() => setShowHistory(true)}
+                size="sm"
+                variant="ghost"
+              >
+                <History className="size-3" />
+                History
+              </Button>
+              <Button
+                className="gap-1.5"
                 onClick={onTogglePin}
                 size="sm"
                 variant="ghost"
@@ -388,6 +407,13 @@ export function DocumentsPinboardReader({
                 <span className="text-tertiary">·</span>
                 <span>Updated {formatUpdated(document)}</span>
               </div>
+              {otherEditors.length > 0 && (
+                <span className="inline-flex items-center gap-1.5 rounded-full bg-amber-500/10 px-2.5 py-0.5 text-[11.5px] text-amber-700 dark:text-amber-400">
+                  <Pencil className="size-3" />
+                  {editorNames(otherEditors, displayNames)}{' '}
+                  {otherEditors.length === 1 ? 'is' : 'are'} currently editing
+                </span>
+              )}
               <div className="bg-tertiary h-3.5 w-px" />
               <div className="flex flex-wrap gap-1">
                 {document.tags.map((t) => (
@@ -553,6 +579,18 @@ export function DocumentsPinboardReader({
         onComment={inline.onStartDraft}
         rect={inline.selectionRect}
       />
+      <DocumentVersionHistory
+        displayNames={displayNames}
+        document={document}
+        onOpenChange={setShowHistory}
+        onRestore={(version) => {
+          setShowHistory(false)
+          onRestoreVersion?.(version)
+        }}
+        open={showHistory}
+        orgSlug={orgSlug}
+        restorePending={restorePending}
+      />
       <ConfirmDialog
         confirmLabel={deleting ? 'Deleting…' : 'Delete'}
         description={`"${title}" will be permanently removed.`}
@@ -566,6 +604,17 @@ export function DocumentsPinboardReader({
       />
     </div>
   )
+}
+
+/** "Alice", "Alice and Bob", or "Alice, Bob, and Carol". */
+function editorNames(
+  emails: string[],
+  displayNames?: Map<string, string>,
+): string {
+  const names = emails.map((e) => displayNames?.get(e) ?? e)
+  if (names.length === 1) return names[0]
+  if (names.length === 2) return `${names[0]} and ${names[1]}`
+  return `${names.slice(0, -1).join(', ')}, and ${names[names.length - 1]}`
 }
 
 function extractHeadings(content: string): Heading[] {

--- a/ui/src/components/documents/DocumentsTab.tsx
+++ b/ui/src/components/documents/DocumentsTab.tsx
@@ -56,13 +56,12 @@ export function DocumentsTab({
     initialAction,
   )
 
-  // Advisory presence: heartbeat while editing an existing document,
-  // poll the editor list while reading.
-  const presenceDocumentId =
-    ctl.editingDocument?.id ?? ctl.selectedDocument?.id ?? null
+  // Advisory presence: heartbeat only while editing an existing
+  // document (the response carries the other editors). Readers
+  // generate no presence traffic.
   const { otherEditors } = useDocumentPresence(
     orgSlug,
-    presenceDocumentId,
+    ctl.editingDocument?.id ?? null,
     !!ctl.editingDocument,
     ctl.currentUserEmail,
   )
@@ -131,7 +130,6 @@ export function DocumentsTab({
         }
         onTogglePin={() => ctl.togglePin(document)}
         orgSlug={orgSlug}
-        otherEditors={otherEditors}
         projectId={scope.commentsProjectId}
         restorePending={ctl.restorePending}
         showAttachment={scope.templateContext === 'org'}

--- a/ui/src/components/documents/DocumentsTab.tsx
+++ b/ui/src/components/documents/DocumentsTab.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from 'react'
 
 import { ErrorBanner } from '@/components/ui/error-banner'
+import { useDocumentPresence } from '@/hooks/useDocumentPresence'
 import type { Document, DocumentTemplate } from '@/types'
 
 import { DocumentsPinboard } from './DocumentsPinboard'
@@ -55,6 +56,17 @@ export function DocumentsTab({
     initialAction,
   )
 
+  // Advisory presence: heartbeat while editing an existing document,
+  // poll the editor list while reading.
+  const presenceDocumentId =
+    ctl.editingDocument?.id ?? ctl.selectedDocument?.id ?? null
+  const { otherEditors } = useDocumentPresence(
+    orgSlug,
+    presenceDocumentId,
+    !!ctl.editingDocument,
+    ctl.currentUserEmail,
+  )
+
   if (ctl.isLoading) return <DocumentsTabSkeleton feed={!!renderList} />
   if (ctl.error)
     return <ErrorBanner error={ctl.error} title="Failed to load documents" />
@@ -79,11 +91,13 @@ export function DocumentsTab({
     return (
       <DocumentsPinboardNew
         allDocuments={ctl.documents}
+        displayNames={ctl.displayNames}
         initialDocument={ctl.editingDocument}
         key={ctl.editingDocument.id}
         onDiscard={ctl.handleDiscard}
         onSave={ctl.handleSave}
         orgSlug={orgSlug}
+        otherEditors={otherEditors}
         saving={ctl.updatePending}
       />
     )
@@ -112,9 +126,14 @@ export function DocumentsTab({
         onOpen={(id) => ctl.navigateToView({ documentId: id, kind: 'reading' })}
         onReplyComment={ctl.comments.onReply}
         onResolveThread={ctl.comments.onResolve}
+        onRestoreVersion={(version) =>
+          ctl.restoreVersion({ documentId: document.id, version })
+        }
         onTogglePin={() => ctl.togglePin(document)}
         orgSlug={orgSlug}
+        otherEditors={otherEditors}
         projectId={scope.commentsProjectId}
+        restorePending={ctl.restorePending}
         showAttachment={scope.templateContext === 'org'}
       />
     )

--- a/ui/src/components/documents/DocumentsTab.tsx
+++ b/ui/src/components/documents/DocumentsTab.tsx
@@ -62,7 +62,6 @@ export function DocumentsTab({
   const { otherEditors } = useDocumentPresence(
     orgSlug,
     ctl.editingDocument?.id ?? null,
-    !!ctl.editingDocument,
     ctl.currentUserEmail,
   )
 

--- a/ui/src/components/documents/useDocumentsController.ts
+++ b/ui/src/components/documents/useDocumentsController.ts
@@ -10,6 +10,7 @@ import { useAuth } from '@/hooks/useAuth'
 import { useDocumentComments } from '@/hooks/useDocumentComments'
 import { useUserDisplayNames } from '@/hooks/useUserDisplayNames'
 import { extractApiErrorDetail } from '@/lib/apiError'
+import { queryKeys } from '@/lib/queryKeys'
 import type { Document, DocumentTemplate, PatchOperation } from '@/types'
 
 export interface DocumentDraft {
@@ -229,7 +230,7 @@ export function useDocumentsController(
       )
       qc.invalidateQueries({ queryKey: documentsKey })
       qc.invalidateQueries({
-        queryKey: ['documentVersions', orgSlug, document.id],
+        queryKey: queryKeys.documentVersions(orgSlug, document.id),
       })
       toast.success('Document restored')
     },

--- a/ui/src/components/documents/useDocumentsController.ts
+++ b/ui/src/components/documents/useDocumentsController.ts
@@ -5,6 +5,7 @@ import { useNavigate } from 'react-router-dom'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
+import { restoreDocumentVersion } from '@/api/endpoints'
 import { useAuth } from '@/hooks/useAuth'
 import { useDocumentComments } from '@/hooks/useDocumentComments'
 import { useUserDisplayNames } from '@/hooks/useUserDisplayNames'
@@ -207,6 +208,33 @@ export function useDocumentsController(
     },
   })
 
+  // Restore is attachment-agnostic (org route) and lands as a normal
+  // update server-side, so the cache handling mirrors updateMutation.
+  const restoreMutation = useMutation({
+    mutationFn: ({
+      documentId,
+      version,
+    }: {
+      documentId: string
+      version: number
+    }) => restoreDocumentVersion(orgSlug, documentId, version),
+    onError: (err) => {
+      toast.error(`Restore failed: ${extractApiErrorDetail(err)}`)
+    },
+    onSuccess: (document) => {
+      qc.setQueryData<Document[]>(documentsKey, (prev) =>
+        prev
+          ? prev.map((n) => (n.id === document.id ? document : n))
+          : [document],
+      )
+      qc.invalidateQueries({ queryKey: documentsKey })
+      qc.invalidateQueries({
+        queryKey: ['documentVersions', orgSlug, document.id],
+      })
+      toast.success('Document restored')
+    },
+  })
+
   const deleteMutation = useMutation({
     mutationFn: (documentId: string) => scope.remove(documentId),
     onError: (err) => {
@@ -310,6 +338,8 @@ export function useDocumentsController(
     handleSave,
     isLoading,
     navigateToView,
+    restorePending: restoreMutation.isPending,
+    restoreVersion: restoreMutation.mutate,
     selectedDocument,
     togglePin,
     updatePending: updateMutation.isPending,

--- a/ui/src/hooks/__tests__/useDocumentPresence.test.tsx
+++ b/ui/src/hooks/__tests__/useDocumentPresence.test.tsx
@@ -24,31 +24,13 @@ describe('useDocumentPresence', () => {
     vi.restoreAllMocks()
   })
 
-  it('polls the editor list while reading and filters out self', async () => {
-    const get = vi.spyOn(endpoints, 'getDocumentEditors').mockResolvedValue({
-      editors: ['alice@example.com', 'me@example.com'],
-      ttl_seconds: 30,
-    })
-    const heartbeat = vi.spyOn(endpoints, 'heartbeatDocumentEditing')
-    const { result } = renderHook(
-      () => useDocumentPresence('acme', 'doc-1', false, 'me@example.com'),
-      { wrapper: wrapper(qc) },
-    )
-    await waitFor(() =>
-      expect(result.current.otherEditors).toEqual(['alice@example.com']),
-    )
-    expect(get).toHaveBeenCalledWith('acme', 'doc-1', expect.anything())
-    expect(heartbeat).not.toHaveBeenCalled()
-  })
-
-  it('heartbeats while editing and uses the PUT response', async () => {
+  it('heartbeats while editing and filters self from the response', async () => {
     const heartbeat = vi
       .spyOn(endpoints, 'heartbeatDocumentEditing')
       .mockResolvedValue({
         editors: ['bob@example.com', 'me@example.com'],
         ttl_seconds: 30,
       })
-    const get = vi.spyOn(endpoints, 'getDocumentEditors')
     const { result } = renderHook(
       () => useDocumentPresence('acme', 'doc-1', true, 'me@example.com'),
       { wrapper: wrapper(qc) },
@@ -57,7 +39,21 @@ describe('useDocumentPresence', () => {
       expect(result.current.otherEditors).toEqual(['bob@example.com']),
     )
     expect(heartbeat).toHaveBeenCalledWith('acme', 'doc-1')
+  })
+
+  it('is inert while not editing — no requests at all', () => {
+    const heartbeat = vi.spyOn(endpoints, 'heartbeatDocumentEditing')
+    const get = vi.spyOn(endpoints, 'getDocumentEditors')
+    const clear = vi.spyOn(endpoints, 'clearDocumentEditing')
+    const { result, unmount } = renderHook(
+      () => useDocumentPresence('acme', 'doc-1', false, 'me@example.com'),
+      { wrapper: wrapper(qc) },
+    )
+    expect(result.current.otherEditors).toEqual([])
+    unmount()
+    expect(heartbeat).not.toHaveBeenCalled()
     expect(get).not.toHaveBeenCalled()
+    expect(clear).not.toHaveBeenCalled()
   })
 
   it('clears the editing marker on unmount', async () => {
@@ -78,15 +74,15 @@ describe('useDocumentPresence', () => {
   })
 
   it('does nothing without a document id', () => {
-    const get = vi.spyOn(endpoints, 'getDocumentEditors')
+    const heartbeat = vi.spyOn(endpoints, 'heartbeatDocumentEditing')
     const clear = vi.spyOn(endpoints, 'clearDocumentEditing')
     const { result, unmount } = renderHook(
-      () => useDocumentPresence('acme', null, false, 'me@example.com'),
+      () => useDocumentPresence('acme', null, true, 'me@example.com'),
       { wrapper: wrapper(qc) },
     )
     expect(result.current.otherEditors).toEqual([])
     unmount()
-    expect(get).not.toHaveBeenCalled()
+    expect(heartbeat).not.toHaveBeenCalled()
     expect(clear).not.toHaveBeenCalled()
   })
 })

--- a/ui/src/hooks/__tests__/useDocumentPresence.test.tsx
+++ b/ui/src/hooks/__tests__/useDocumentPresence.test.tsx
@@ -32,28 +32,13 @@ describe('useDocumentPresence', () => {
         ttl_seconds: 30,
       })
     const { result } = renderHook(
-      () => useDocumentPresence('acme', 'doc-1', true, 'me@example.com'),
+      () => useDocumentPresence('acme', 'doc-1', 'me@example.com'),
       { wrapper: wrapper(qc) },
     )
     await waitFor(() =>
       expect(result.current.otherEditors).toEqual(['bob@example.com']),
     )
     expect(heartbeat).toHaveBeenCalledWith('acme', 'doc-1')
-  })
-
-  it('is inert while not editing — no requests at all', () => {
-    const heartbeat = vi.spyOn(endpoints, 'heartbeatDocumentEditing')
-    const get = vi.spyOn(endpoints, 'getDocumentEditors')
-    const clear = vi.spyOn(endpoints, 'clearDocumentEditing')
-    const { result, unmount } = renderHook(
-      () => useDocumentPresence('acme', 'doc-1', false, 'me@example.com'),
-      { wrapper: wrapper(qc) },
-    )
-    expect(result.current.otherEditors).toEqual([])
-    unmount()
-    expect(heartbeat).not.toHaveBeenCalled()
-    expect(get).not.toHaveBeenCalled()
-    expect(clear).not.toHaveBeenCalled()
   })
 
   it('clears the editing marker on unmount', async () => {
@@ -65,7 +50,7 @@ describe('useDocumentPresence', () => {
       .spyOn(endpoints, 'clearDocumentEditing')
       .mockResolvedValue(undefined)
     const { result, unmount } = renderHook(
-      () => useDocumentPresence('acme', 'doc-1', true, 'me@example.com'),
+      () => useDocumentPresence('acme', 'doc-1', 'me@example.com'),
       { wrapper: wrapper(qc) },
     )
     await waitFor(() => expect(result.current.otherEditors).toEqual([]))
@@ -73,11 +58,11 @@ describe('useDocumentPresence', () => {
     expect(clear).toHaveBeenCalledWith('acme', 'doc-1')
   })
 
-  it('does nothing without a document id', () => {
+  it('is inert without a document id — no requests at all', () => {
     const heartbeat = vi.spyOn(endpoints, 'heartbeatDocumentEditing')
     const clear = vi.spyOn(endpoints, 'clearDocumentEditing')
     const { result, unmount } = renderHook(
-      () => useDocumentPresence('acme', null, true, 'me@example.com'),
+      () => useDocumentPresence('acme', null, 'me@example.com'),
       { wrapper: wrapper(qc) },
     )
     expect(result.current.otherEditors).toEqual([])

--- a/ui/src/hooks/__tests__/useDocumentPresence.test.tsx
+++ b/ui/src/hooks/__tests__/useDocumentPresence.test.tsx
@@ -1,0 +1,92 @@
+import React from 'react'
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { renderHook, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import * as endpoints from '@/api/endpoints'
+
+import { useDocumentPresence } from '../useDocumentPresence'
+
+function wrapper(qc: QueryClient) {
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+  )
+}
+
+let qc: QueryClient
+
+describe('useDocumentPresence', () => {
+  beforeEach(() => {
+    qc = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    })
+    vi.restoreAllMocks()
+  })
+
+  it('polls the editor list while reading and filters out self', async () => {
+    const get = vi.spyOn(endpoints, 'getDocumentEditors').mockResolvedValue({
+      editors: ['alice@example.com', 'me@example.com'],
+      ttl_seconds: 30,
+    })
+    const heartbeat = vi.spyOn(endpoints, 'heartbeatDocumentEditing')
+    const { result } = renderHook(
+      () => useDocumentPresence('acme', 'doc-1', false, 'me@example.com'),
+      { wrapper: wrapper(qc) },
+    )
+    await waitFor(() =>
+      expect(result.current.otherEditors).toEqual(['alice@example.com']),
+    )
+    expect(get).toHaveBeenCalledWith('acme', 'doc-1', expect.anything())
+    expect(heartbeat).not.toHaveBeenCalled()
+  })
+
+  it('heartbeats while editing and uses the PUT response', async () => {
+    const heartbeat = vi
+      .spyOn(endpoints, 'heartbeatDocumentEditing')
+      .mockResolvedValue({
+        editors: ['bob@example.com', 'me@example.com'],
+        ttl_seconds: 30,
+      })
+    const get = vi.spyOn(endpoints, 'getDocumentEditors')
+    const { result } = renderHook(
+      () => useDocumentPresence('acme', 'doc-1', true, 'me@example.com'),
+      { wrapper: wrapper(qc) },
+    )
+    await waitFor(() =>
+      expect(result.current.otherEditors).toEqual(['bob@example.com']),
+    )
+    expect(heartbeat).toHaveBeenCalledWith('acme', 'doc-1')
+    expect(get).not.toHaveBeenCalled()
+  })
+
+  it('clears the editing marker on unmount', async () => {
+    vi.spyOn(endpoints, 'heartbeatDocumentEditing').mockResolvedValue({
+      editors: ['me@example.com'],
+      ttl_seconds: 30,
+    })
+    const clear = vi
+      .spyOn(endpoints, 'clearDocumentEditing')
+      .mockResolvedValue(undefined)
+    const { result, unmount } = renderHook(
+      () => useDocumentPresence('acme', 'doc-1', true, 'me@example.com'),
+      { wrapper: wrapper(qc) },
+    )
+    await waitFor(() => expect(result.current.otherEditors).toEqual([]))
+    unmount()
+    expect(clear).toHaveBeenCalledWith('acme', 'doc-1')
+  })
+
+  it('does nothing without a document id', () => {
+    const get = vi.spyOn(endpoints, 'getDocumentEditors')
+    const clear = vi.spyOn(endpoints, 'clearDocumentEditing')
+    const { result, unmount } = renderHook(
+      () => useDocumentPresence('acme', null, false, 'me@example.com'),
+      { wrapper: wrapper(qc) },
+    )
+    expect(result.current.otherEditors).toEqual([])
+    unmount()
+    expect(get).not.toHaveBeenCalled()
+    expect(clear).not.toHaveBeenCalled()
+  })
+})

--- a/ui/src/hooks/useDocumentPresence.ts
+++ b/ui/src/hooks/useDocumentPresence.ts
@@ -2,24 +2,20 @@ import { useEffect } from 'react'
 
 import { useQuery } from '@tanstack/react-query'
 
-import {
-  clearDocumentEditing,
-  getDocumentEditors,
-  heartbeatDocumentEditing,
-} from '@/api/endpoints'
+import { clearDocumentEditing, heartbeatDocumentEditing } from '@/api/endpoints'
 
 // The server expires markers after 30s; heartbeat well inside that.
 const HEARTBEAT_MS = 10_000
-const READER_POLL_MS = 5000
 
 /**
  * Advisory "currently editing" presence for one document.
  *
- * While `isEditing`, sends a PUT heartbeat on an interval (the response
- * carries the active editor list, so no separate poll is needed) and
- * clears the caller's marker on unmount / leaving edit mode. While just
- * reading, polls the editor list. Presence is best-effort: markers
- * expire server-side, so a missed DELETE only lingers for the TTL.
+ * Active only while `isEditing`: sends a PUT heartbeat on an interval
+ * (the response carries the active editor list, so no separate poll
+ * is needed) and clears the caller's marker on unmount / leaving edit
+ * mode. Idle readers generate no presence traffic. Presence is
+ * best-effort: markers expire server-side, so a missed DELETE only
+ * lingers for the TTL.
  */
 export function useDocumentPresence(
   orgSlug: string,
@@ -27,30 +23,27 @@ export function useDocumentPresence(
   isEditing: boolean,
   currentUserEmail: string,
 ) {
-  const enabled = !!orgSlug && !!documentId
+  const enabled = !!orgSlug && !!documentId && isEditing
 
   const { data } = useQuery({
     enabled,
     gcTime: 0,
-    queryFn: ({ signal }) =>
-      isEditing
-        ? heartbeatDocumentEditing(orgSlug, documentId ?? '')
-        : getDocumentEditors(orgSlug, documentId ?? '', signal),
-    queryKey: ['documentEditors', orgSlug, documentId, isEditing],
-    refetchInterval: isEditing ? HEARTBEAT_MS : READER_POLL_MS,
+    queryFn: () => heartbeatDocumentEditing(orgSlug, documentId ?? ''),
+    queryKey: ['documentEditors', orgSlug, documentId],
+    refetchInterval: HEARTBEAT_MS,
     retry: false,
     staleTime: 0,
   })
 
   // Best-effort release when the editor closes; the TTL covers the rest.
   useEffect(() => {
-    if (!enabled || !isEditing || !documentId) return
+    if (!enabled || !documentId) return
     return () => {
       clearDocumentEditing(orgSlug, documentId).catch(() => {})
     }
-  }, [enabled, isEditing, orgSlug, documentId])
+  }, [enabled, orgSlug, documentId])
 
-  const editors = data?.editors ?? []
+  const editors = enabled ? (data?.editors ?? []) : []
   return {
     otherEditors: editors.filter((email) => email !== currentUserEmail),
   }

--- a/ui/src/hooks/useDocumentPresence.ts
+++ b/ui/src/hooks/useDocumentPresence.ts
@@ -3,48 +3,54 @@ import { useEffect } from 'react'
 import { useQuery } from '@tanstack/react-query'
 
 import { clearDocumentEditing, heartbeatDocumentEditing } from '@/api/endpoints'
+import { queryKeys } from '@/lib/queryKeys'
 
-// The server expires markers after 30s; heartbeat well inside that.
-const HEARTBEAT_MS = 10_000
+// Bootstrap interval until the first heartbeat reports the server TTL;
+// thereafter the interval is derived as TTL/3 so the marker can miss
+// two beats before expiring.
+const DEFAULT_HEARTBEAT_MS = 10_000
 
 /**
  * Advisory "currently editing" presence for one document.
  *
- * Active only while `isEditing`: sends a PUT heartbeat on an interval
- * (the response carries the active editor list, so no separate poll
- * is needed) and clears the caller's marker on unmount / leaving edit
- * mode. Idle readers generate no presence traffic. Presence is
- * best-effort: markers expire server-side, so a missed DELETE only
- * lingers for the TTL.
+ * Active while `documentId` is set (null means "not editing"): sends a
+ * PUT heartbeat on an interval — including while the tab is
+ * backgrounded, so the marker survives the editor losing focus — and
+ * clears the caller's marker on unmount. The heartbeat response
+ * carries the active editor list, so no separate poll is needed, and
+ * idle readers generate no presence traffic. Presence is best-effort:
+ * markers expire server-side, so a missed DELETE only lingers for the
+ * TTL.
  */
 export function useDocumentPresence(
   orgSlug: string,
   documentId: null | string,
-  isEditing: boolean,
   currentUserEmail: string,
 ) {
-  const enabled = !!orgSlug && !!documentId && isEditing
-
   const { data } = useQuery({
-    enabled,
+    enabled: !!orgSlug && !!documentId,
     gcTime: 0,
     queryFn: () => heartbeatDocumentEditing(orgSlug, documentId ?? ''),
-    queryKey: ['documentEditors', orgSlug, documentId],
-    refetchInterval: HEARTBEAT_MS,
+    queryKey: queryKeys.documentEditors(orgSlug, documentId ?? ''),
+    refetchInterval: (query) => {
+      const ttl = query.state.data?.ttl_seconds
+      return ttl ? (ttl / 3) * 1000 : DEFAULT_HEARTBEAT_MS
+    },
+    refetchIntervalInBackground: true,
     retry: false,
     staleTime: 0,
   })
 
   // Best-effort release when the editor closes; the TTL covers the rest.
   useEffect(() => {
-    if (!enabled || !documentId) return
+    if (!orgSlug || !documentId) return
     return () => {
       clearDocumentEditing(orgSlug, documentId).catch(() => {})
     }
-  }, [enabled, orgSlug, documentId])
+  }, [orgSlug, documentId])
 
-  const editors = enabled ? (data?.editors ?? []) : []
   return {
-    otherEditors: editors.filter((email) => email !== currentUserEmail),
+    otherEditors:
+      data?.editors.filter((email) => email !== currentUserEmail) ?? [],
   }
 }

--- a/ui/src/hooks/useDocumentPresence.ts
+++ b/ui/src/hooks/useDocumentPresence.ts
@@ -1,0 +1,57 @@
+import { useEffect } from 'react'
+
+import { useQuery } from '@tanstack/react-query'
+
+import {
+  clearDocumentEditing,
+  getDocumentEditors,
+  heartbeatDocumentEditing,
+} from '@/api/endpoints'
+
+// The server expires markers after 30s; heartbeat well inside that.
+const HEARTBEAT_MS = 10_000
+const READER_POLL_MS = 5000
+
+/**
+ * Advisory "currently editing" presence for one document.
+ *
+ * While `isEditing`, sends a PUT heartbeat on an interval (the response
+ * carries the active editor list, so no separate poll is needed) and
+ * clears the caller's marker on unmount / leaving edit mode. While just
+ * reading, polls the editor list. Presence is best-effort: markers
+ * expire server-side, so a missed DELETE only lingers for the TTL.
+ */
+export function useDocumentPresence(
+  orgSlug: string,
+  documentId: null | string,
+  isEditing: boolean,
+  currentUserEmail: string,
+) {
+  const enabled = !!orgSlug && !!documentId
+
+  const { data } = useQuery({
+    enabled,
+    gcTime: 0,
+    queryFn: ({ signal }) =>
+      isEditing
+        ? heartbeatDocumentEditing(orgSlug, documentId ?? '')
+        : getDocumentEditors(orgSlug, documentId ?? '', signal),
+    queryKey: ['documentEditors', orgSlug, documentId, isEditing],
+    refetchInterval: isEditing ? HEARTBEAT_MS : READER_POLL_MS,
+    retry: false,
+    staleTime: 0,
+  })
+
+  // Best-effort release when the editor closes; the TTL covers the rest.
+  useEffect(() => {
+    if (!enabled || !isEditing || !documentId) return
+    return () => {
+      clearDocumentEditing(orgSlug, documentId).catch(() => {})
+    }
+  }, [enabled, isEditing, orgSlug, documentId])
+
+  const editors = data?.editors ?? []
+  return {
+    otherEditors: editors.filter((email) => email !== currentUserEmail),
+  }
+}

--- a/ui/src/lib/queryKeys.ts
+++ b/ui/src/lib/queryKeys.ts
@@ -15,6 +15,12 @@ export const queryKeys = {
     anchorSlug: string,
     relType: string,
   ) => ['anchor-edges', kind, orgSlug, anchorSlug, relType] as const,
+  documentEditors: (orgSlug: string, documentId: string) =>
+    ['documentEditors', orgSlug, documentId] as const,
+  documentVersion: (orgSlug: string, documentId: string, version: number) =>
+    ['documentVersion', orgSlug, documentId, version] as const,
+  documentVersions: (orgSlug: string, documentId: string) =>
+    ['documentVersions', orgSlug, documentId] as const,
   environments: (orgSlug: string) => ['environments', orgSlug] as const,
   identityPlugins: (orgSlug: string) => ['identity-plugins', orgSlug] as const,
   integration: (orgSlug: string, slug: string) =>

--- a/ui/src/types/api-generated.ts
+++ b/ui/src/types/api-generated.ts
@@ -558,7 +558,7 @@ export interface paths {
          *     Every login provider is now a login-capable ``Integration`` whose
          *     plugin implements the ``identity`` capability; the authorization
          *     URL and token exchange are owned entirely by that plugin's
-         *     handler via :mod:`imbi_api.identity.flows`.
+         *     handler via :mod:`imbi.api.identity.flows`.
          *
          *     Args:
          *         provider: Login-Integration slug
@@ -2548,7 +2548,7 @@ export interface paths {
          *
          *     Only ``USES`` edges of ``kind`` from *this* Integration are replaced;
          *     other integrations' assignments for the same capability are untouched
-         *     (unlike :func:`imbi_api.plugins.assignment_writer.replace_capability_
+         *     (unlike :func:`imbi.api.plugins.assignment_writer.replace_capability_
          *     assignments`, which is scoped per-parent and would wipe every
          *     integration bound to that project type).
          *
@@ -3001,6 +3001,105 @@ export interface paths {
          * @description Update a document via JSON Patch regardless of attachment kind.
          */
         patch: operations["patch_org_document_organizations__org_slug__documents__document_id__patch"];
+        trace?: never;
+    };
+    "/organizations/{org_slug}/documents/{document_id}/versions": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Document Versions
+         * @description List a document's version history, newest first.
+         */
+        get: operations["list_document_versions_organizations__org_slug__documents__document_id__versions_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/organizations/{org_slug}/documents/{document_id}/versions/{version}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Document Version
+         * @description Retrieve the full snapshot of a single document version.
+         */
+        get: operations["get_document_version_organizations__org_slug__documents__document_id__versions__version__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/organizations/{org_slug}/documents/{document_id}/versions/{version}/restore": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Restore Document Version
+         * @description Restore a document to a previous version.
+         *
+         *     Applies the old snapshot as a normal update, producing a new
+         *     version with ``change_kind='restore'`` — history is never
+         *     rewritten.
+         */
+        post: operations["restore_document_version_organizations__org_slug__documents__document_id__versions__version__restore_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/organizations/{org_slug}/documents/{document_id}/editing": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Document Editors
+         * @description List who is currently editing the document.
+         */
+        get: operations["get_document_editors_organizations__org_slug__documents__document_id__editing_get"];
+        /**
+         * Heartbeat Document Editing
+         * @description Start or refresh the caller's editing marker.
+         *
+         *     Idempotent; clients call this every few seconds while the editor
+         *     is open. The response includes every active editor (including the
+         *     caller) so the editing client needs no separate GET poll.
+         */
+        put: operations["heartbeat_document_editing_organizations__org_slug__documents__document_id__editing_put"];
+        post?: never;
+        /**
+         * Clear Document Editing
+         * @description Remove the caller's editing marker (done editing).
+         *
+         *     Best-effort — the marker expires on its own within
+         *     ``PRESENCE_TTL_SECONDS`` regardless.
+         */
+        delete: operations["clear_document_editing_organizations__org_slug__documents__document_id__editing_delete"];
+        options?: never;
+        head?: never;
+        patch?: never;
         trace?: never;
     };
     "/organizations/{org_slug}/projects/{project_id}/documents/": {
@@ -4432,7 +4531,7 @@ export interface paths {
          *     organization and have the targeted capability enabled. Rows are
          *     grouped by capability kind and each kind's assignments are replaced
          *     atomically via
-         *     :func:`imbi_api.plugins.assignment_writer.replace_capability_assignments`.
+         *     :func:`imbi.api.plugins.assignment_writer.replace_capability_assignments`.
          *
          *     Raises:
          *         404: Project not found, or an integration/identity-integration
@@ -7099,6 +7198,19 @@ export interface components {
              */
             tags?: string[];
         };
+        /**
+         * DocumentEditorsResponse
+         * @description Who currently holds an editing marker on the document.
+         */
+        DocumentEditorsResponse: {
+            /** Editors */
+            editors: string[];
+            /**
+             * Ttl Seconds
+             * @default 30
+             */
+            ttl_seconds: number;
+        };
         /** DocumentListResponse */
         DocumentListResponse: {
             /** Data */
@@ -7146,6 +7258,11 @@ export interface components {
              * @default []
              */
             tags: components["schemas"]["TagRef"][];
+            /**
+             * Version
+             * @default 1
+             */
+            version: number;
         };
         /** DocumentTemplateCreate */
         DocumentTemplateCreate: {
@@ -7259,6 +7376,59 @@ export interface components {
             project_type_slugs?: string[] | null;
             /** Sort Order */
             sort_order?: number | null;
+        };
+        /**
+         * DocumentVersionInfo
+         * @description Version metadata without the (potentially large) content.
+         */
+        DocumentVersionInfo: {
+            /** Version */
+            version: number;
+            /** Title */
+            title: string;
+            /**
+             * Change Kind
+             * @enum {string}
+             */
+            change_kind: "create" | "update" | "restore" | "baseline";
+            /** Updated By */
+            updated_by: string;
+            /**
+             * Updated At
+             * Format: date-time
+             */
+            updated_at: string;
+        };
+        /** DocumentVersionListResponse */
+        DocumentVersionListResponse: {
+            /** Data */
+            data: components["schemas"]["DocumentVersionInfo"][];
+        };
+        /** DocumentVersionResponse */
+        DocumentVersionResponse: {
+            /** Version */
+            version: number;
+            /** Title */
+            title: string;
+            /**
+             * Change Kind
+             * @enum {string}
+             */
+            change_kind: "create" | "update" | "restore" | "baseline";
+            /** Updated By */
+            updated_by: string;
+            /**
+             * Updated At
+             * Format: date-time
+             */
+            updated_at: string;
+            /** Content */
+            content: string;
+            /**
+             * Tags
+             * @default []
+             */
+            tags: string[];
         };
         /**
          * DraftReleaseNotesRequest
@@ -11075,7 +11245,7 @@ export interface components {
          *     ``label`` is the human-facing name shown in the UI (e.g. ``Semver``
          *     or ``CalVer``); ``pattern`` is a regular expression a tag must match.
          *     A tag is accepted when it matches *any* configured ``TagFormat`` --
-         *     see ``imbi_common.versioning.matches_tag_formats``.
+         *     see ``imbi.common.versioning.matches_tag_formats``.
          *
          *     Patterns are matched with :func:`re.fullmatch` and validated as
          *     compilable at assignment time so an invalid expression is rejected at
@@ -16858,6 +17028,198 @@ export interface operations {
                 content: {
                     "application/json": components["schemas"]["DocumentResponse"];
                 };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_document_versions_organizations__org_slug__documents__document_id__versions_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                org_slug: string;
+                document_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DocumentVersionListResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_document_version_organizations__org_slug__documents__document_id__versions__version__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                org_slug: string;
+                document_id: string;
+                version: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DocumentVersionResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    restore_document_version_organizations__org_slug__documents__document_id__versions__version__restore_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                org_slug: string;
+                document_id: string;
+                version: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DocumentResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_document_editors_organizations__org_slug__documents__document_id__editing_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                org_slug: string;
+                document_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DocumentEditorsResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    heartbeat_document_editing_organizations__org_slug__documents__document_id__editing_put: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                org_slug: string;
+                document_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DocumentEditorsResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    clear_document_editing_organizations__org_slug__documents__document_id__editing_delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                org_slug: string;
+                document_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
             };
             /** @description Validation Error */
             422: {

--- a/ui/src/types/index.ts
+++ b/ui/src/types/index.ts
@@ -729,6 +729,7 @@ export interface Document {
   title: string
   updated_at?: null | string
   updated_by?: null | string
+  version?: number
 }
 
 // The vertex a document is attached to. `id` is the project id, the
@@ -746,6 +747,12 @@ export interface DocumentCreate {
   content: string
   tags?: string[]
   title: string
+}
+
+// Who currently holds an advisory editing marker on a document.
+export interface DocumentEditorsResponse {
+  editors: string[]
+  ttl_seconds: number
 }
 
 export type DocumentListResponse = CollectionResponse<Document>
@@ -791,6 +798,24 @@ export type DocumentTemplateType =
   | 'project'
   | 'project_type'
   | 'user'
+
+// Full snapshot of a single document version.
+export interface DocumentVersion extends DocumentVersionInfo {
+  content: string
+  tags: string[]
+}
+
+// One entry in a document's version history (metadata only).
+export interface DocumentVersionInfo {
+  change_kind: 'baseline' | 'create' | 'restore' | 'update'
+  title: string
+  updated_at: string
+  updated_by: string
+  version: number
+}
+
+export type DocumentVersionListResponse =
+  CollectionResponse<DocumentVersionInfo>
 
 export interface DraftReleaseNotesRequest {
   base_sha: string


### PR DESCRIPTION
## Summary
Adds two features to Imbi documents: a full version history with restore, and an advisory "currently editing" presence indicator.

## Problem
Document edits overwrote the graph node in place — prior content was unrecoverable, with no record of who changed what or when. Two people editing the same document also had no way to know about each other; the last save silently clobbered the other's work with no trace.

## Solution
**Version history.** Every content-affecting change (title/content/tags — not pin toggles) bumps a `version` counter on the Document node and appends a full snapshot to a new `document_versions` ClickHouse table (ReplacingMergeTree keyed on `(document_id, version)`). The counter bumps atomically in the Cypher `SET`, so concurrent saves get distinct versions and every save survives in history. Documents that predate versioning get a `baseline` snapshot of their original state on first edit. Capture is best-effort via `BackgroundTasks` — the graph stays the source of truth and saves never wait on ClickHouse. New endpoints: `GET /documents/{id}/versions`, `GET …/versions/{n}`, `POST …/versions/{n}/restore` (applies the snapshot as a normal update producing a new `restore`-kind version; tags deleted since the snapshot are dropped rather than failing). The reader gains a History dialog: a timeline whose node glyphs encode how each version came to be, rendered snapshot view, line diff against current with `+N −N` stats, and confirm-guarded restore.

**Editing presence.** A Valkey sorted set per document (`imbi:document:editing:{org}:{id}`, members scored by expiry, 30s TTL) tracks active editors, with `GET`/`PUT`/`DELETE` at `…/documents/{id}/editing`. The editor heartbeats (PUT, pipelined to one round-trip) on a TTL-derived interval — including while the tab is backgrounded — and the response carries the other editors for an advisory "X is also editing — the last save wins" banner. Idle readers generate no presence traffic, and everything degrades to "nobody editing" if Valkey is down. Advisory only; saving is never blocked.

## Impact
- New ClickHouse table `document_versions`, created idempotently at startup from `schemata.toml` — no migration needed.
- `DocumentResponse` gains a `version` field; existing documents read as version 1 until first edited.
- History rows are retained in ClickHouse when a document is deleted (audit trail), though unreachable via the API once the document is gone.
- New `diff` dependency in the UI for the version diff view.
- Presence adds one pipelined Valkey round-trip per open editor per ~10s; no impact on readers.

## Testing
- Full Python suite green via `moon run root:coverage` (79 document-related endpoint tests, including version capture, baseline, restore, tag-filtering, presence, and Valkey/ClickHouse failure paths); the atomic version-bump Cypher was verified against a live Apache AGE instance.
- UI: 575 vitest tests green (presence hook and controller covered); oxlint/tsc clean.
- Manually exercised the editor, history dialog, and presence banner against the dev environment.