### PR TITLE
Fix release image build and test its config in CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          file: ./Dockerfile
+          file: ./container/Dockerfile
           platforms: ${{ matrix.platform }}
           build-args: |
             VITE_GIT_REF=${{ steps.ref.outputs.tag }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: "Pipeline"
 on:
   push:
     branches:
-      - "master"
+      - "main"
   pull_request:
 jobs:
   ci:
@@ -25,3 +25,24 @@ jobs:
           version: "0.11.13"
       - uses: "moonrepo/setup-toolchain@v0"
       - run: "moon ci"
+  image:
+    # Exercises the same docker/build-push-action configuration as
+    # release.yml (single arch, no push) so drift in the build context,
+    # Dockerfile path, or build args fails here instead of on a release tag.
+    name: "Image"
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: "actions/checkout@v4"
+        with:
+          persist-credentials: false
+      - uses: "docker/setup-buildx-action@v3"
+      - uses: "docker/build-push-action@v6"
+        with:
+          context: .
+          file: ./container/Dockerfile
+          platforms: linux/amd64
+          push: false
+          build-args: |
+            VITE_GIT_REF=${{ github.sha }}
+          cache-from: type=gha,scope=linux-amd64
+          cache-to: type=gha,mode=max,scope=linux-amd64

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,7 @@ to see everything.
 
 ```bash
 moon ci                    # full pipeline (lint/format/typecheck, ui, docs,
-                           #   single-session coverage, docker image test build)
+                           #   single-session coverage)
 moon run <proj>:<task>     # one task, e.g. `moon run api:test`, `moon run ui:build`
 moon run :lint             # a task across every project
 

--- a/moon.yml
+++ b/moon.yml
@@ -126,10 +126,10 @@ tasks:
     outputs:
       - 'build/coverage.xml'
 
-  # Build the production Docker image (Dockerfile lives in container/). Runs in
-  # `moon ci` as a build test only: `docker build` never pushes, and publishing
-  # remains release.yml's job. `always` so the image is validated on every CI
-  # run regardless of which project moon marks affected.
+  # Build the production Docker image (Dockerfile lives in container/) for
+  # local use. CI validates the image via test.yml's Image job instead, which
+  # exercises release.yml's docker/build-push-action configuration and writes
+  # the GHA build cache that release-tag runs reuse.
   image:
     command: 'docker'
     args:
@@ -143,7 +143,7 @@ tasks:
       - '.'
     options:
       cache: false
-      runInCI: 'always'
+      runInCI: false
 
   # Tear down the backing services and volumes.
   teardown:


### PR DESCRIPTION
## Summary
Fixes the Dockerfile path in `release.yml` that broke both v2.17.0 image builds, and moves CI's image validation to a single-arch `docker/build-push-action` build in the test pipeline so the release build configuration is exercised on every PR.

## Problem
The v2.17.0 release run failed in both `build` jobs with `failed to read dockerfile: open Dockerfile: no such file or directory`. The Dockerfile moved to `container/` (#152), and while `moon ci`'s `root:image` task and `compose.yaml` were updated, `release.yml`'s `docker/build-push-action` still pointed at `./Dockerfile` — a configuration no CI run exercises, so the drift only surfaced on the release tag. Additionally, `test.yml`'s push trigger still referenced `master` (stale since the consolidation), so the pipeline never runs on the default branch.

## Solution
- Point `release.yml`'s `docker/build-push-action` at `container/Dockerfile`.
- Add an `Image` job to `test.yml` that runs the same `build-push-action` configuration as `release.yml` (linux/amd64 only, `push: false`, same GHA cache scope), so drift in the build context, Dockerfile path, or build args fails on PRs instead of on release tags.
- Drop `root:image` from `moon ci` (`runInCI: false`) — the moon build used its own correct `-f` flag, so it could never catch release-config drift, and keeping both meant building the image twice per CI run. The task remains for local `moon run root:image`.
- Fix the push trigger `master` → `main` so the pipeline (and the Image job's build cache, which release-tag runs can only reuse from the default branch) runs on merges.

## Notes
- The v2.17.0 `publish-pypi` job succeeded (all 14 distributions published); only the image jobs failed. Recovering the v2.17.0 image is handled separately from this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)