### PR TITLE
Fix per-environment deployer attribution

### DIFF
--- a/apps/api/src/imbi/api/endpoints/_helpers.py
+++ b/apps/api/src/imbi/api/endpoints/_helpers.py
@@ -2,15 +2,18 @@
 
 import collections.abc
 import contextlib
+import datetime
 import json
 import logging
 import typing
+import urllib.parse
 
 import fastapi
 import psycopg
 
 from imbi.api import patch as json_patch
 from imbi.common import graph
+from imbi.common import models as common_models
 from imbi.common.plugins.base import PluginContext, ServiceConnection
 
 LOGGER = logging.getLogger(__name__)
@@ -141,6 +144,91 @@ async def update_membership_role(
                 f' of organization {org_slug!r}'
             ),
         )
+
+
+_SAFE_AUDIT_URL_SCHEMES: frozenset[str] = frozenset({'http', 'https'})
+
+
+def safe_audit_url(value: str | None) -> str | None:
+    """Drop plugin-supplied URLs that aren't plain http(s).
+
+    Both ``run_url`` and ``release_url`` are surfaced by deployment
+    plugins and rendered as ``<a href>`` in the operations-log UI.
+    A malicious or buggy plugin could return a ``javascript:`` or
+    ``data:`` URL that, if echoed verbatim into the DOM, would land
+    as XSS. The UI already escapes attribute values, but defense in
+    depth: drop anything that isn't ``http(s)://`` server-side so
+    every consumer of the audit row sees a known-safe scheme.
+    """
+    if value is None:
+        return None
+    parsed = urllib.parse.urlsplit(value)
+    if parsed.scheme.lower() not in _SAFE_AUDIT_URL_SCHEMES:
+        LOGGER.warning(
+            'Dropping audit URL with unsupported scheme %r', parsed.scheme
+        )
+        return None
+    return value
+
+
+def deployed_operation_log(
+    *,
+    project_id: str,
+    project_slug: str,
+    environment_slug: str,
+    recorded_by: str,
+    performed_by: str | None,
+    action: str,
+    version: str | None,
+    plugin_slug: str = '',
+    run_url: str | None = None,
+    release_url: str | None = None,
+    from_environment: str | None = None,
+    external_run_id: str | None = None,
+    occurred_at: datetime.datetime | None = None,
+) -> common_models.OperationLog:
+    """Build a ``Deployed`` ``operations_log`` row.
+
+    Shared by the in-product deploy/promote audit writer and the
+    maintenance ops-log backfill so the history pane renders every
+    deploy identically. Plugin-supplied URLs (``run_url`` /
+    ``release_url``) are filtered through :func:`safe_audit_url` so
+    non-http(s) schemes never reach the audit JSON or the ``link``.
+
+    ``occurred_at`` is only overridden when supplied; callers that
+    backfill historical deploys pin it to the real deploy time because
+    ``lookup_ops_log_performed_by`` ranks with
+    ``argMax(performed_by, occurred_at)`` -- the row must sort by when
+    the deploy actually happened, not when it was recorded. Omitting it
+    keeps the model default (now).
+    """
+    safe_run_url = safe_audit_url(run_url)
+    description = json.dumps(
+        {
+            'action': action,
+            'plugin_slug': plugin_slug,
+            'run_url': safe_run_url,
+            'release_url': safe_audit_url(release_url),
+            'from_environment': from_environment,
+        },
+        sort_keys=True,
+    )
+    fields: dict[str, typing.Any] = {
+        'recorded_by': recorded_by,
+        'performed_by': performed_by,
+        'project_id': project_id,
+        'project_slug': project_slug,
+        'environment_slug': environment_slug,
+        'entry_type': 'Deployed',
+        'description': description,
+        'link': safe_run_url,
+        'version': version,
+        'plugin_slug': plugin_slug,
+        'external_run_id': external_run_id,
+    }
+    if occurred_at is not None:
+        fields['occurred_at'] = occurred_at
+    return common_models.OperationLog(**fields)
 
 
 async def lookup_project_slugs(

--- a/apps/api/src/imbi/api/endpoints/project_deployments.py
+++ b/apps/api/src/imbi/api/endpoints/project_deployments.py
@@ -19,7 +19,6 @@ import json
 import logging
 import re
 import typing
-import urllib.parse
 
 import fastapi
 import httpx
@@ -30,6 +29,7 @@ from imbi.api.auth import permissions
 from imbi.api.deployment_sync import queue as deployment_sync_queue
 from imbi.api.deployment_sync import service as deployment_sync_service
 from imbi.api.endpoints._helpers import (
+    deployed_operation_log,
     lookup_project_links,
     lookup_project_slugs,
     lookup_project_type_slugs,
@@ -638,31 +638,6 @@ def _resolve_credentials(
     return fallback
 
 
-_SAFE_AUDIT_URL_SCHEMES: frozenset[str] = frozenset({'http', 'https'})
-
-
-def _safe_audit_url(value: str | None) -> str | None:
-    """Drop plugin-supplied URLs that aren't plain http(s).
-
-    Both ``run_url`` and ``release_url`` are surfaced by deployment
-    plugins and rendered as ``<a href>`` in the operations-log UI.
-    A malicious or buggy plugin could return a ``javascript:`` or
-    ``data:`` URL that, if echoed verbatim into the DOM, would land
-    as XSS. The UI already escapes attribute values, but defense in
-    depth: drop anything that isn't ``http(s)://`` server-side so
-    every consumer of the audit row sees a known-safe scheme.
-    """
-    if value is None:
-        return None
-    parsed = urllib.parse.urlsplit(value)
-    if parsed.scheme.lower() not in _SAFE_AUDIT_URL_SCHEMES:
-        LOGGER.warning(
-            'Dropping audit URL with unsupported scheme %r', parsed.scheme
-        )
-        return None
-    return value
-
-
 async def _record_deployment_audit(
     *,
     project_id: str,
@@ -689,36 +664,19 @@ async def _record_deployment_audit(
     ``OperationLog.version`` is populated with ``tag if tag else
     committish`` — a single human-friendly display string that the
     operations-log UI can render directly.
-
-    Plugin-supplied URLs (``run_url`` / ``release_url``) are filtered
-    through ``_safe_audit_url`` so non-http(s) schemes never reach the
-    audit JSON — see L22.
     """
-    safe_run_url = _safe_audit_url(run_url)
-    safe_release_url = _safe_audit_url(release_url)
-    description = json.dumps(
-        {
-            'action': action,
-            'plugin_slug': plugin_slug,
-            'run_url': safe_run_url,
-            'release_url': safe_release_url,
-            'from_environment': from_environment,
-        },
-        sort_keys=True,
-    )
-    entry = common_models.OperationLog(
-        id=nanoid.generate(),
-        recorded_at=datetime.datetime.now(datetime.UTC),
-        recorded_by=recorded_by,
-        performed_by=recorded_by,
+    entry = deployed_operation_log(
         project_id=project_id,
         project_slug=project_slug,
         environment_slug=environment_slug,
-        entry_type='Deployed',
-        description=description,
-        link=safe_run_url,
+        recorded_by=recorded_by,
+        performed_by=recorded_by,
+        action=action,
         version=tag or committish,
         plugin_slug=plugin_slug,
+        run_url=run_url,
+        release_url=release_url,
+        from_environment=from_environment,
         external_run_id=external_run_id,
     )
     row = entry.model_dump(by_alias=True, mode='python')
@@ -1171,7 +1129,7 @@ async def _apply_remote_deployment(
         timestamp=observed.created_at,
         performed_by=performed_by,
     )
-    if result is None:
+    if isinstance(result, str):
         # Either the Release upsert didn't take or the env slug isn't
         # wired up in this org -- record as an error so the operator
         # has a thread to pull rather than a silently swallowed row.
@@ -1600,7 +1558,7 @@ async def _handle_deploy(
         )
         if release_id is None:
             continue
-        result = await append_deployment_event(
+        appended = await append_deployment_event(
             db,
             org_slug=org_slug,
             project_id=project_id,
@@ -1611,7 +1569,8 @@ async def _handle_deploy(
             external_run_id=str(run.run_id) if run.run_id else None,
             external_run_url=run.run_url,
         )
-        if result is not None:
+        if not isinstance(appended, str):
+            result = appended
             matched_tag = try_tag
             break
     if result is None:
@@ -1990,7 +1949,7 @@ async def _handle_promote(
         run=run,
         plugin_id=resolved.integration_id,
         plugin_slug=resolved.plugin_slug,
-        recorded=promote_result is not None,
+        recorded=not isinstance(promote_result, str),
         release_url=release_url,
         tag=body.tag,
         warning='; '.join(warnings) if warnings else None,

--- a/apps/api/src/imbi/api/endpoints/projects.py
+++ b/apps/api/src/imbi/api/endpoints/projects.py
@@ -690,9 +690,16 @@ def ops_log_version_candidates(
 
 
 async def lookup_ops_log_performed_by(
-    targets: list[tuple[str, str, str]],
-) -> dict[tuple[str, str, str], str]:
-    """Map ``(project_id, environment_slug, version)`` → ``performed_by``.
+    targets: list[tuple[str, str, str | None, str | None]],
+) -> dict[tuple[str, str], str]:
+    """Map ``(project_id, environment_slug)`` → ``performed_by``.
+
+    Each target is ``(project_id, environment_slug, tag, committish)``.
+    The audit writer records ``version = tag or committish``, so each
+    target's version candidates are probed tag-first, committish-second
+    (via :func:`ops_log_version_candidates`) and the first match wins —
+    folding the dual-key rule in here so callers don't expand and then
+    collapse it themselves.
 
     Backfills the deployer for releases whose
     ``DeploymentEvent.performed_by`` on the AGE edge is null.
@@ -711,6 +718,7 @@ async def lookup_ops_log_performed_by(
         ' argMax(performed_by, occurred_at) AS performed_by'
         ' FROM operations_log FINAL'
         " WHERE entry_type = 'Deployed'"
+        ' AND is_deleted = 0'
         ' AND project_id IN {project_ids:Array(String)}'
         ' GROUP BY project_id, environment_slug, version'
     )
@@ -724,17 +732,24 @@ async def lookup_ops_log_performed_by(
             exc_info=True,
         )
         return {}
-    target_keys = set(targets)
-    result: dict[tuple[str, str, str], str] = {}
+    by_version: dict[tuple[str, str, str], str] = {}
     for row in rows:
+        performed_by = row.get('performed_by')
+        if not performed_by:
+            continue
         key = (
             str(row.get('project_id') or ''),
             str(row.get('environment_slug') or ''),
             str(row.get('version') or ''),
         )
-        performed_by = row.get('performed_by')
-        if performed_by and key in target_keys:
-            result[key] = str(performed_by)
+        by_version[key] = str(performed_by)
+    result: dict[tuple[str, str], str] = {}
+    for project_id, env_slug, tag, committish in targets:
+        for version in ops_log_version_candidates(tag, committish):
+            looked_up = by_version.get((project_id, env_slug, version))
+            if looked_up:
+                result[(project_id, env_slug)] = looked_up
+                break
     return result
 
 
@@ -814,7 +829,7 @@ async def _fetch_current_releases(
     # Backfill performed_by from operations_log for events whose
     # AGE edge left it null (in-product deploy/promote path).
     enrich_targets = [
-        (pid, env_slug, version)
+        (pid, env_slug, tag, committish)
         for (pid, env_slug), (
             tag,
             committish,
@@ -822,18 +837,15 @@ async def _fetch_current_releases(
             performed_by,
         ) in latest.items()
         if performed_by is None
-        for version in ops_log_version_candidates(tag, committish)
     ]
     performed_by_by_key = await lookup_ops_log_performed_by(enrich_targets)
     if performed_by_by_key:
         for key, (tag, committish, ts, performed_by) in list(latest.items()):
             if performed_by is not None:
                 continue
-            for version in ops_log_version_candidates(tag, committish):
-                looked_up = performed_by_by_key.get((key[0], key[1], version))
-                if looked_up:
-                    latest[key] = (tag, committish, ts, looked_up)
-                    break
+            looked_up = performed_by_by_key.get(key)
+            if looked_up:
+                latest[key] = (tag, committish, ts, looked_up)
 
     result: dict[str, dict[str, ReleaseInfo]] = {}
     for (pid, env_slug), (tag, committish, ts, performed_by) in latest.items():

--- a/apps/api/src/imbi/api/endpoints/projects.py
+++ b/apps/api/src/imbi/api/endpoints/projects.py
@@ -671,6 +671,24 @@ def _latest_deployment_event(
     return latest_ts, latest_by
 
 
+def ops_log_version_candidates(
+    tag: str | None, committish: str | None
+) -> list[str]:
+    """Ordered, distinct version keys to probe in ``operations_log``.
+
+    The audit writer records ``version = matched_tag or committish_short``
+    (see ``project_deployments``), so a deploy from a branch/SHA stores the
+    short committish while the release still carries a tag. Probe the tag
+    first, then the committish, so the backfill join resolves the deployer
+    regardless of which the audit row captured.
+    """
+    candidates: list[str] = []
+    for value in (tag, committish):
+        if value and value not in candidates:
+            candidates.append(value)
+    return candidates
+
+
 async def lookup_ops_log_performed_by(
     targets: list[tuple[str, str, str]],
 ) -> dict[tuple[str, str, str], str]:
@@ -796,24 +814,26 @@ async def _fetch_current_releases(
     # Backfill performed_by from operations_log for events whose
     # AGE edge left it null (in-product deploy/promote path).
     enrich_targets = [
-        (pid, env_slug, str(tag or committish or ''))
+        (pid, env_slug, version)
         for (pid, env_slug), (
             tag,
             committish,
             _ts,
             performed_by,
         ) in latest.items()
-        if performed_by is None and (tag or committish)
+        if performed_by is None
+        for version in ops_log_version_candidates(tag, committish)
     ]
     performed_by_by_key = await lookup_ops_log_performed_by(enrich_targets)
     if performed_by_by_key:
         for key, (tag, committish, ts, performed_by) in list(latest.items()):
             if performed_by is not None:
                 continue
-            version = str(tag or committish or '')
-            looked_up = performed_by_by_key.get((key[0], key[1], version))
-            if looked_up:
-                latest[key] = (tag, committish, ts, looked_up)
+            for version in ops_log_version_candidates(tag, committish):
+                looked_up = performed_by_by_key.get((key[0], key[1], version))
+                if looked_up:
+                    latest[key] = (tag, committish, ts, looked_up)
+                    break
 
     result: dict[str, dict[str, ReleaseInfo]] = {}
     for (pid, env_slug), (tag, committish, ts, performed_by) in latest.items():

--- a/apps/api/src/imbi/api/endpoints/releases.py
+++ b/apps/api/src/imbi/api/endpoints/releases.py
@@ -1126,11 +1126,15 @@ async def append_deployment_event(
         for idx in range(len(existing) - 1, -1, -1):
             candidate = existing[idx]
             if candidate.external_run_id == external_run_id:
+                # A caller passing ``performed_by=None`` means "unknown",
+                # not "clear" -- keep the stored deployer so a webhook
+                # refresh can't blank attribution a resync backfilled.
+                effective_performed_by = performed_by or candidate.performed_by
                 if (
                     candidate.status == status
                     and candidate.note == note
                     and candidate.external_run_url == external_run_url
-                    and candidate.performed_by == performed_by
+                    and candidate.performed_by == effective_performed_by
                 ):
                     return _edge_to_response(env, existing), 'noop'
                 refreshed = candidate.model_copy(
@@ -1140,7 +1144,7 @@ async def append_deployment_event(
                         'external_run_url': external_run_url,
                         'timestamp': timestamp
                         or datetime.datetime.now(datetime.UTC),
-                        'performed_by': performed_by,
+                        'performed_by': effective_performed_by,
                     }
                 )
                 updated_list = [

--- a/apps/api/src/imbi/api/endpoints/releases.py
+++ b/apps/api/src/imbi/api/endpoints/releases.py
@@ -26,7 +26,10 @@ from imbi.api.auth import permissions
 from imbi.api.domain.models import User
 from imbi.api.endpoints._helpers import fetch_or_404
 from imbi.api.endpoints.operations_log import complete_opslog_entry
-from imbi.api.endpoints.projects import lookup_ops_log_performed_by
+from imbi.api.endpoints.projects import (
+    lookup_ops_log_performed_by,
+    ops_log_version_candidates,
+)
 from imbi.api.plugins import call_with_timeout
 from imbi.api.scoring import OptionalValkeyClient
 from imbi.api.scoring import queue as score_queue
@@ -130,6 +133,7 @@ class DeploymentEventInput(pydantic.BaseModel):
     status: _DEPLOYMENT_STATUS
     note: str | None = None
     external_run_id: str | None = None
+    external_run_url: str | None = None
 
 
 class ReleaseEnvironmentRef(pydantic.BaseModel):
@@ -672,6 +676,54 @@ async def _users_by_email(
     return out
 
 
+async def _backfill_performed_by(
+    project_id: str,
+    by_env: dict[
+        str,
+        tuple[
+            dict[str, typing.Any],
+            dict[str, typing.Any] | None,
+            models.DeploymentEvent | None,
+        ],
+    ],
+) -> dict[str, str]:
+    """Resolve the deployer per env slug from ``operations_log``.
+
+    Only covers events whose AGE edge left ``performed_by`` null (the
+    in-product deploy/promote path). Each env offers both its release tag
+    and committish as candidate version keys — the audit writer records
+    whichever matched — and the tag is probed before the committish.
+    """
+    enrich_targets: list[tuple[str, str, str]] = []
+    for env, release_raw, event in by_env.values():
+        if event is None or event.performed_by is not None:
+            continue
+        if release_raw is None:
+            continue
+        for version in ops_log_version_candidates(
+            release_raw.get('tag'), release_raw.get('committish')
+        ):
+            enrich_targets.append((project_id, env['slug'], version))
+    performed_by_by_key = await lookup_ops_log_performed_by(enrich_targets)
+
+    out: dict[str, str] = {}
+    for env, release_raw, event in by_env.values():
+        if event is None or event.performed_by is not None:
+            continue
+        if release_raw is None:
+            continue
+        for version in ops_log_version_candidates(
+            release_raw.get('tag'), release_raw.get('committish')
+        ):
+            looked_up = performed_by_by_key.get(
+                (project_id, env['slug'], version)
+            )
+            if looked_up:
+                out[env['slug']] = looked_up
+                break
+    return out
+
+
 @releases_router.get(
     '/current',
     response_model=list[CurrentReleaseEnvironment],
@@ -764,18 +816,7 @@ async def list_current_releases(
     # Backfill performed_by from operations_log for events whose AGE edge
     # left it null (in-product deploy/promote path), mirroring the
     # project-detail current-releases view so both agree.
-    enrich_targets: list[tuple[str, str, str]] = []
-    for env, release_raw, event in by_env.values():
-        if event is None or event.performed_by is not None:
-            continue
-        if release_raw is None:
-            continue
-        version = str(
-            release_raw.get('tag') or release_raw.get('committish') or ''
-        )
-        if version:
-            enrich_targets.append((project_id, env['slug'], version))
-    performed_by_by_key = await lookup_ops_log_performed_by(enrich_targets)
+    performed_by_by_slug = await _backfill_performed_by(project_id, by_env)
 
     # Resolve deployer emails to Imbi users so the UI can show a display
     # name + profile link + Gravatar. ``performed_by`` may be an email
@@ -787,17 +828,8 @@ async def list_current_releases(
     ] = []
     for env, release_raw, event in by_env.values():
         performed_by = event.performed_by if event else None
-        if (
-            performed_by is None
-            and event is not None
-            and release_raw is not None
-        ):
-            version = str(
-                release_raw.get('tag') or release_raw.get('committish') or ''
-            )
-            performed_by = performed_by_by_key.get(
-                (project_id, env['slug'], version)
-            )
+        if performed_by is None:
+            performed_by = performed_by_by_slug.get(env['slug'])
         computed.append((env, release_raw, event, performed_by))
 
     users_by_email = await _users_by_email(
@@ -1361,7 +1393,16 @@ async def record_deployment(
         ),
     ],
 ) -> ReleaseEnvironmentEdgeResponse:
-    """Record a deployment event for a release in an environment."""
+    """Record a deployment event for a release in an environment.
+
+    Delegates persistence to :func:`append_deployment_event` so a webhook
+    status update for a run the in-product deploy flow already recorded
+    deduplicates on ``external_run_id`` (refreshing the existing event in
+    place) instead of appending a second, anonymous event that would blank
+    "Deployed by". The explicit pre-checks preserve the endpoint's
+    distinct 404 (missing release) / 422 (missing environment) semantics,
+    which the delegate collapses into a single ``None``.
+    """
     release = await _fetch_release(db, org_slug, project_id, release_id)
     if release is None:
         raise fastapi.HTTPException(
@@ -1371,7 +1412,7 @@ async def record_deployment(
             ),
         )
 
-    env, existing = await _fetch_deployment_edge(
+    env, _existing = await _fetch_deployment_edge(
         db, org_slug, project_id, release_id, env_slug
     )
     if env is None:
@@ -1383,66 +1424,28 @@ async def record_deployment(
             ),
         )
 
-    event = models.DeploymentEvent(
-        timestamp=datetime.datetime.now(datetime.UTC),
+    # The gateway supplies no actor, so leave performed_by None — the
+    # in-product deploy flow already attributes the operator via
+    # operations_log, which the current-release enrichment backfills from.
+    result = await append_deployment_event(
+        db,
+        org_slug=org_slug,
+        project_id=project_id,
+        release_id=release_id,
+        env_slug=env_slug,
         status=data.status,
         note=data.note,
+        external_run_id=data.external_run_id,
+        external_run_url=data.external_run_url,
     )
-    deployments = [*existing, event]
-    serialized = json.dumps(
-        [e.model_dump(mode='json') for e in deployments],
-    )
-
-    if existing:
-        set_query: typing.LiteralString = """
-        MATCH (:Project {{id: {project_id}}})
-              -[:HAS_RELEASE]->(r:Release {{id: {release_id}}})
-        MATCH (r)-[d:DEPLOYED_TO]->(:Environment {{slug: {env_slug}}})
-        SET d.deployments = {deployments}
-        RETURN d.deployments AS deployments
-        """
-        await db.execute(
-            set_query,
-            {
-                'project_id': project_id,
-                'release_id': release_id,
-                'env_slug': env_slug,
-                'deployments': serialized,
-            },
-            ['deployments'],
+    if result is None:  # unreachable: pre-checks validated release + env
+        raise fastapi.HTTPException(
+            status_code=404,
+            detail=(
+                f'Release {release_id!r} for project {project_id!r} not found'
+            ),
         )
-    else:
-        create_query: typing.LiteralString = """
-        MATCH (:Project {{id: {project_id}}})
-              -[:HAS_RELEASE]->(r:Release {{id: {release_id}}})
-        MATCH (e:Environment {{slug: {env_slug}}})
-              -[:BELONGS_TO]->(:Organization {{slug: {org_slug}}})
-        CREATE (r)-[d:DEPLOYED_TO {{deployments: {deployments}}}]->(e)
-        RETURN d.deployments AS deployments
-        """
-        await db.execute(
-            create_query,
-            {
-                'project_id': project_id,
-                'release_id': release_id,
-                'env_slug': env_slug,
-                'org_slug': org_slug,
-                'deployments': serialized,
-            },
-            ['deployments'],
-        )
-
-    if data.status == 'success':
-        # A successful deployment makes this release the current one for
-        # the environment; record it on the DEPLOYED_IN edge.
-        await _set_current_release(
-            db,
-            org_slug=org_slug,
-            project_id=project_id,
-            env_slug=env_slug,
-            release_id=release_id,
-            timestamp=event.timestamp,
-        )
+    edge, _outcome = result
 
     if data.external_run_id and data.status in {
         'success',
@@ -1460,7 +1463,7 @@ async def record_deployment(
         valkey_client, project_id, 'deployment_status_change'
     )
 
-    return _edge_to_response(env, deployments)
+    return edge
 
 
 @releases_router.get(

--- a/apps/api/src/imbi/api/endpoints/releases.py
+++ b/apps/api/src/imbi/api/endpoints/releases.py
@@ -26,10 +26,7 @@ from imbi.api.auth import permissions
 from imbi.api.domain.models import User
 from imbi.api.endpoints._helpers import fetch_or_404
 from imbi.api.endpoints.operations_log import complete_opslog_entry
-from imbi.api.endpoints.projects import (
-    lookup_ops_log_performed_by,
-    ops_log_version_candidates,
-)
+from imbi.api.endpoints.projects import lookup_ops_log_performed_by
 from imbi.api.plugins import call_with_timeout
 from imbi.api.scoring import OptionalValkeyClient
 from imbi.api.scoring import queue as score_queue
@@ -208,19 +205,6 @@ def _serialize_links(
         else:
             out.append(models.ReleaseLink(**link).model_dump(mode='json'))
     return json.dumps(out)
-
-
-def _parse_deployments(
-    raw: typing.Any,
-) -> list[models.DeploymentEvent]:
-    """Parse the JSON-encoded ``deployments`` edge property."""
-    if not raw:
-        return []
-    data = json.loads(raw) if isinstance(raw, str) else raw
-    if not isinstance(data, list):
-        return []
-    items: list[typing.Any] = data  # type: ignore[assignment]
-    return [models.DeploymentEvent.model_validate(e) for e in items]
 
 
 def _release_to_response(
@@ -692,36 +676,28 @@ async def _backfill_performed_by(
     Only covers events whose AGE edge left ``performed_by`` null (the
     in-product deploy/promote path). Each env offers both its release tag
     and committish as candidate version keys — the audit writer records
-    whichever matched — and the tag is probed before the committish.
+    whichever matched, and ``lookup_ops_log_performed_by`` probes the tag
+    before the committish.
     """
-    enrich_targets: list[tuple[str, str, str]] = []
+    targets: list[tuple[str, str, str | None, str | None]] = []
     for env, release_raw, event in by_env.values():
         if event is None or event.performed_by is not None:
             continue
         if release_raw is None:
             continue
-        for version in ops_log_version_candidates(
-            release_raw.get('tag'), release_raw.get('committish')
-        ):
-            enrich_targets.append((project_id, env['slug'], version))
-    performed_by_by_key = await lookup_ops_log_performed_by(enrich_targets)
-
-    out: dict[str, str] = {}
-    for env, release_raw, event in by_env.values():
-        if event is None or event.performed_by is not None:
-            continue
-        if release_raw is None:
-            continue
-        for version in ops_log_version_candidates(
-            release_raw.get('tag'), release_raw.get('committish')
-        ):
-            looked_up = performed_by_by_key.get(
-                (project_id, env['slug'], version)
+        targets.append(
+            (
+                project_id,
+                env['slug'],
+                release_raw.get('tag'),
+                release_raw.get('committish'),
             )
-            if looked_up:
-                out[env['slug']] = looked_up
-                break
-    return out
+        )
+    performed_by_by_key = await lookup_ops_log_performed_by(targets)
+    return {
+        env_slug: name
+        for (_pid, env_slug), name in performed_by_by_key.items()
+    }
 
 
 @releases_router.get(
@@ -794,7 +770,9 @@ async def list_current_releases(
             continue
         slug = env['slug']
         release_raw = graph.parse_agtype(row['release'])
-        events = _parse_deployments(graph.parse_agtype(row['deployments']))
+        events = models.parse_deployment_events(
+            graph.parse_agtype(row['deployments'])
+        )
 
         if release_raw is None or not events:
             by_env.setdefault(slug, (env, None, None))
@@ -1054,7 +1032,7 @@ async def _fetch_deployment_edge(
     if not rows:
         return None, []
     env = graph.parse_agtype(rows[0]['env'])
-    deployments = _parse_deployments(
+    deployments = models.parse_deployment_events(
         graph.parse_agtype(rows[0]['deployments'])
     )
     return env, deployments
@@ -1095,13 +1073,18 @@ async def append_deployment_event(
     external_run_url: str | None = None,
     timestamp: datetime.datetime | None = None,
     performed_by: str | None = None,
-) -> tuple[ReleaseEnvironmentEdgeResponse, AppendOutcome] | None:
+) -> (
+    tuple[ReleaseEnvironmentEdgeResponse, AppendOutcome]
+    | typing.Literal['no_release', 'no_env']
+):
     """Append a ``DeploymentEvent`` to ``Release -[:DEPLOYED_TO]-> Env``.
 
-    Returns a ``(edge, outcome)`` tuple, or ``None`` when the named
-    ``Release`` or ``Environment`` cannot be found — callers that
-    auto-record from a deploy of a SHA (which has no ``Release`` node)
-    treat ``None`` as "skip persistence, deploy still succeeded".
+    Returns a ``(edge, outcome)`` tuple, or a string discriminant when
+    the target can't be found: ``'no_release'`` when the named
+    ``Release`` doesn't exist, ``'no_env'`` when the ``Environment``
+    lookup fails. Callers that auto-record from a deploy of a SHA
+    (which has no ``Release`` node) treat a string result as "skip
+    persistence, deploy still succeeded".
 
     ``outcome`` is one of ``'appended'`` (new row), ``'updated'``
     (dedupe path refreshed an existing row in place), or ``'noop'``
@@ -1128,12 +1111,12 @@ async def append_deployment_event(
     """
     release = await _fetch_release(db, org_slug, project_id, release_id)
     if release is None:
-        return None
+        return 'no_release'
     env, existing = await _fetch_deployment_edge(
         db, org_slug, project_id, release_id, env_slug
     )
     if env is None:
-        return None
+        return 'no_env'
     if external_run_id and existing:
         # Walk newest-first so the "most recent event for this run"
         # wins when older entries with the same id exist (rare; only
@@ -1399,31 +1382,9 @@ async def record_deployment(
     status update for a run the in-product deploy flow already recorded
     deduplicates on ``external_run_id`` (refreshing the existing event in
     place) instead of appending a second, anonymous event that would blank
-    "Deployed by". The explicit pre-checks preserve the endpoint's
-    distinct 404 (missing release) / 422 (missing environment) semantics,
-    which the delegate collapses into a single ``None``.
+    "Deployed by". The delegate's ``'no_release'`` / ``'no_env'``
+    discriminants map to the endpoint's distinct 404 / 422 responses.
     """
-    release = await _fetch_release(db, org_slug, project_id, release_id)
-    if release is None:
-        raise fastapi.HTTPException(
-            status_code=404,
-            detail=(
-                f'Release {release_id!r} for project {project_id!r} not found'
-            ),
-        )
-
-    env, _existing = await _fetch_deployment_edge(
-        db, org_slug, project_id, release_id, env_slug
-    )
-    if env is None:
-        raise fastapi.HTTPException(
-            status_code=422,
-            detail=(
-                f'Environment {env_slug!r} not found in'
-                f' organization {org_slug!r}'
-            ),
-        )
-
     # The gateway supplies no actor, so leave performed_by None — the
     # in-product deploy flow already attributes the operator via
     # operations_log, which the current-release enrichment backfills from.
@@ -1438,11 +1399,19 @@ async def record_deployment(
         external_run_id=data.external_run_id,
         external_run_url=data.external_run_url,
     )
-    if result is None:  # unreachable: pre-checks validated release + env
+    if result == 'no_release':
         raise fastapi.HTTPException(
             status_code=404,
             detail=(
                 f'Release {release_id!r} for project {project_id!r} not found'
+            ),
+        )
+    if result == 'no_env':
+        raise fastapi.HTTPException(
+            status_code=422,
+            detail=(
+                f'Environment {env_slug!r} not found in'
+                f' organization {org_slug!r}'
             ),
         )
     edge, _outcome = result
@@ -1515,7 +1484,7 @@ async def list_deployment_edges(
         env = graph.parse_agtype(row['env'])
         if not env:
             continue
-        deployments = _parse_deployments(
+        deployments = models.parse_deployment_events(
             graph.parse_agtype(row['deployments'])
         )
         results.append(_edge_to_response(env, deployments))

--- a/apps/api/src/imbi/api/maintenance/operations.py
+++ b/apps/api/src/imbi/api/maintenance/operations.py
@@ -375,7 +375,7 @@ async def execute_opslog_backfill(
             continue
         candidates = ops_log_version_candidates(tag, committish)
         events = common_models.parse_deployment_events(
-            graph.parse_agtype(row.get('deployments'))
+            graph.parse_agtype(row.get('deployments')), on_error='skip'
         )
         for event in sorted(events, key=lambda e: e.timestamp, reverse=True):
             if event.status != 'success' or not event.performed_by:

--- a/apps/api/src/imbi/api/maintenance/operations.py
+++ b/apps/api/src/imbi/api/maintenance/operations.py
@@ -18,6 +18,7 @@ endpoints package at import time.
 from __future__ import annotations
 
 import functools
+import json
 import logging
 import typing
 
@@ -27,13 +28,18 @@ from valkey import asyncio as valkey
 from imbi.api import models
 from imbi.api.auth import permissions
 from imbi.api.scoring import queue as score_queue
-from imbi.common import graph
+from imbi.common import clickhouse, graph
+from imbi.common import models as common_models
 from imbi.common.plugins.errors import PluginRateLimited
 
 LOGGER = logging.getLogger(__name__)
 
 #: ``requested_by`` / ``principal_name`` recorded on work this runs.
 REQUESTED_BY = 'maintenance'
+
+#: ``recorded_by`` stamped on ops-log rows the backfill writes, so they
+#: are distinguishable from rows the in-product deploy/promote flows write.
+OPSLOG_BACKFILL_RECORDED_BY = 'maintenance-opslog-backfill'
 
 ExecuteOutcome = typing.Literal['succeeded', 'skipped']
 
@@ -269,3 +275,196 @@ async def execute_rescore(
         client, project_id, 'bulk_rescore', REQUESTED_BY
     )
     return 'succeeded' if enqueued else 'skipped'
+
+
+_DEPLOYMENT_EDGES_QUERY: typing.LiteralString = """
+MATCH (:Project {{id: {project_id}}})-[:HAS_RELEASE]->(r:Release)
+      -[d:DEPLOYED_TO]->(e:Environment)
+RETURN e.slug AS env_slug,
+       r.tag AS tag,
+       r.committish AS committish,
+       d.deployments AS deployments
+"""
+
+
+def _parse_deployments(raw: object) -> list[common_models.DeploymentEvent]:
+    """Parse the JSON-encoded ``deployments`` edge property.
+
+    Mirrors ``endpoints.releases._parse_deployments`` -- inlined here so
+    this module doesn't reach into an endpoint's private helper.
+    """
+    if not raw:
+        return []
+    data = json.loads(raw) if isinstance(raw, str) else raw
+    if not isinstance(data, list):
+        return []
+    return [
+        common_models.DeploymentEvent.model_validate(entry)
+        for entry in typing.cast('list[object]', data)
+    ]
+
+
+async def _existing_opslog_rows(
+    project_id: str,
+) -> tuple[set[str], set[tuple[str, str]]]:
+    """Return the ``operations_log`` 'Deployed' rows already on file.
+
+    Two dedupe indexes for one project: the set of ``external_run_id``
+    values, and the set of ``(environment_slug, version)`` pairs.  Read
+    ``FINAL`` so the ``ReplacingMergeTree`` collapse is applied and
+    superseded rows don't resurrect a stale key.
+    """
+    sql = (
+        'SELECT environment_slug, version, external_run_id'
+        ' FROM operations_log FINAL'
+        " WHERE entry_type = 'Deployed'"
+        ' AND project_id = {project_id:String}'
+    )
+    rows = await clickhouse.client.Clickhouse.get_instance().query(
+        sql, {'project_id': project_id}
+    )
+    run_ids: set[str] = set()
+    env_versions: set[tuple[str, str]] = set()
+    for row in rows:
+        run_id = row.get('external_run_id')
+        if run_id:
+            run_ids.add(str(run_id))
+        env = str(row.get('environment_slug') or '')
+        version = str(row.get('version') or '')
+        if env and version:
+            env_versions.add((env, version))
+    return run_ids, env_versions
+
+
+def _backfill_row(
+    *,
+    project_id: str,
+    project_slug: str,
+    env_slug: str,
+    version: str,
+    event: common_models.DeploymentEvent,
+) -> common_models.OperationLog:
+    """Build the ops-log row for one attributed deployment event.
+
+    Mirrors ``project_deployments._record_deployment_audit``'s shape so
+    the history pane renders backfilled deploys identically, but stamps
+    ``recorded_by`` with the backfill marker and pins ``occurred_at`` to
+    the deployment event's own timestamp -- ``lookup_ops_log_performed_by``
+    ranks with ``argMax(performed_by, occurred_at)``, so the row must sort
+    by when the deploy actually happened, not when the backfill ran.
+    """
+    description = json.dumps(
+        {
+            'action': 'opslog-backfill',
+            'plugin_slug': '',
+            'run_url': event.external_run_url,
+            'release_url': None,
+            'from_environment': None,
+        },
+        sort_keys=True,
+    )
+    return common_models.OperationLog(
+        occurred_at=event.timestamp,
+        recorded_by=OPSLOG_BACKFILL_RECORDED_BY,
+        performed_by=event.performed_by,
+        project_id=project_id,
+        project_slug=project_slug,
+        environment_slug=env_slug,
+        entry_type='Deployed',
+        description=description,
+        link=event.external_run_url,
+        version=version,
+        plugin_slug='',
+        external_run_id=event.external_run_id,
+    )
+
+
+async def execute_opslog_backfill(
+    db: graph.Graph, client: valkey.Valkey, project_id: str
+) -> ExecuteOutcome:
+    """Backfill ``operations_log`` 'Deployed' rows from the graph edges.
+
+    Deployments recorded outside Imbi carry their deployer only on
+    ``DeploymentEvent.performed_by`` on the ``DEPLOYED_TO`` edge; the
+    ops-log 'Deployed' rows that ``lookup_ops_log_performed_by`` reads to
+    resolve "Deployed by" are written solely by the in-product
+    deploy/promote flows.  This walks every deployment edge, and for each
+    ``success`` event that carries a ``performed_by`` writes a matching
+    ops-log row when one does not already exist, closing the attribution
+    gap for those releases.
+
+    Events with an empty ``performed_by`` are skipped entirely -- never
+    insert one, because ``argMax(performed_by, occurred_at)`` would let a
+    newer empty row mask a real deployer.  Events are processed
+    newest-first per edge so the most recent attributed deployer is the
+    one that survives dedupe for a given ``(environment, version)``.
+
+    Skipped when the project has no deployment edges or every attributed
+    event already has a matching ops-log row.
+    """
+    from imbi.api.endpoints._helpers import lookup_project_slugs
+    from imbi.api.endpoints.projects import ops_log_version_candidates
+
+    rows = await db.execute(
+        _DEPLOYMENT_EDGES_QUERY,
+        {'project_id': project_id},
+        ['env_slug', 'tag', 'committish', 'deployments'],
+    )
+    if not rows:
+        return 'skipped'
+
+    existing_run_ids, existing_env_versions = await _existing_opslog_rows(
+        project_id
+    )
+    project_slug, _team_slug = await lookup_project_slugs(db, project_id)
+
+    pending: list[common_models.OperationLog] = []
+    for row in rows:
+        env_slug = graph.parse_agtype(row.get('env_slug'))
+        if not isinstance(env_slug, str) or not env_slug:
+            continue
+        tag_val = graph.parse_agtype(row.get('tag'))
+        committish_val = graph.parse_agtype(row.get('committish'))
+        tag = str(tag_val) if tag_val else None
+        committish = str(committish_val) if committish_val else None
+        version = tag or committish
+        if not version:
+            continue
+        candidates = ops_log_version_candidates(tag, committish)
+        events = _parse_deployments(graph.parse_agtype(row.get('deployments')))
+        for event in sorted(events, key=lambda e: e.timestamp, reverse=True):
+            if event.status != 'success' or not event.performed_by:
+                continue
+            run_id = event.external_run_id
+            if run_id and run_id in existing_run_ids:
+                continue
+            if any((env_slug, v) in existing_env_versions for v in candidates):
+                continue
+            pending.append(
+                _backfill_row(
+                    project_id=project_id,
+                    project_slug=project_slug,
+                    env_slug=env_slug,
+                    version=version,
+                    event=event,
+                )
+            )
+            if run_id:
+                existing_run_ids.add(run_id)
+            existing_env_versions.add((env_slug, version))
+
+    if not pending:
+        return 'skipped'
+
+    columns: list[str] = []
+    values: list[list[typing.Any]] = []
+    for entry in pending:
+        dumped = entry.model_dump(by_alias=True, mode='python')
+        dumped['is_deleted'] = 1 if entry.is_deleted else 0
+        if not columns:
+            columns = list(dumped.keys())
+        values.append(list(dumped.values()))
+    await clickhouse.client.Clickhouse.get_instance().insert(
+        'operations_log', values, columns
+    )
+    return 'succeeded'

--- a/apps/api/src/imbi/api/maintenance/operations.py
+++ b/apps/api/src/imbi/api/maintenance/operations.py
@@ -18,7 +18,6 @@ endpoints package at import time.
 from __future__ import annotations
 
 import functools
-import json
 import logging
 import typing
 
@@ -287,23 +286,6 @@ RETURN e.slug AS env_slug,
 """
 
 
-def _parse_deployments(raw: object) -> list[common_models.DeploymentEvent]:
-    """Parse the JSON-encoded ``deployments`` edge property.
-
-    Mirrors ``endpoints.releases._parse_deployments`` -- inlined here so
-    this module doesn't reach into an endpoint's private helper.
-    """
-    if not raw:
-        return []
-    data = json.loads(raw) if isinstance(raw, str) else raw
-    if not isinstance(data, list):
-        return []
-    return [
-        common_models.DeploymentEvent.model_validate(entry)
-        for entry in typing.cast('list[object]', data)
-    ]
-
-
 async def _existing_opslog_rows(
     project_id: str,
 ) -> tuple[set[str], set[tuple[str, str]]]:
@@ -318,6 +300,7 @@ async def _existing_opslog_rows(
         'SELECT environment_slug, version, external_run_id'
         ' FROM operations_log FINAL'
         " WHERE entry_type = 'Deployed'"
+        ' AND is_deleted = 0'
         ' AND project_id = {project_id:String}'
     )
     rows = await clickhouse.client.Clickhouse.get_instance().query(
@@ -334,49 +317,6 @@ async def _existing_opslog_rows(
         if env and version:
             env_versions.add((env, version))
     return run_ids, env_versions
-
-
-def _backfill_row(
-    *,
-    project_id: str,
-    project_slug: str,
-    env_slug: str,
-    version: str,
-    event: common_models.DeploymentEvent,
-) -> common_models.OperationLog:
-    """Build the ops-log row for one attributed deployment event.
-
-    Mirrors ``project_deployments._record_deployment_audit``'s shape so
-    the history pane renders backfilled deploys identically, but stamps
-    ``recorded_by`` with the backfill marker and pins ``occurred_at`` to
-    the deployment event's own timestamp -- ``lookup_ops_log_performed_by``
-    ranks with ``argMax(performed_by, occurred_at)``, so the row must sort
-    by when the deploy actually happened, not when the backfill ran.
-    """
-    description = json.dumps(
-        {
-            'action': 'opslog-backfill',
-            'plugin_slug': '',
-            'run_url': event.external_run_url,
-            'release_url': None,
-            'from_environment': None,
-        },
-        sort_keys=True,
-    )
-    return common_models.OperationLog(
-        occurred_at=event.timestamp,
-        recorded_by=OPSLOG_BACKFILL_RECORDED_BY,
-        performed_by=event.performed_by,
-        project_id=project_id,
-        project_slug=project_slug,
-        environment_slug=env_slug,
-        entry_type='Deployed',
-        description=description,
-        link=event.external_run_url,
-        version=version,
-        plugin_slug='',
-        external_run_id=event.external_run_id,
-    )
 
 
 async def execute_opslog_backfill(
@@ -402,7 +342,10 @@ async def execute_opslog_backfill(
     Skipped when the project has no deployment edges or every attributed
     event already has a matching ops-log row.
     """
-    from imbi.api.endpoints._helpers import lookup_project_slugs
+    from imbi.api.endpoints._helpers import (
+        deployed_operation_log,
+        lookup_project_slugs,
+    )
     from imbi.api.endpoints.projects import ops_log_version_candidates
 
     rows = await db.execute(
@@ -431,7 +374,9 @@ async def execute_opslog_backfill(
         if not version:
             continue
         candidates = ops_log_version_candidates(tag, committish)
-        events = _parse_deployments(graph.parse_agtype(row.get('deployments')))
+        events = common_models.parse_deployment_events(
+            graph.parse_agtype(row.get('deployments'))
+        )
         for event in sorted(events, key=lambda e: e.timestamp, reverse=True):
             if event.status != 'success' or not event.performed_by:
                 continue
@@ -441,12 +386,17 @@ async def execute_opslog_backfill(
             if any((env_slug, v) in existing_env_versions for v in candidates):
                 continue
             pending.append(
-                _backfill_row(
+                deployed_operation_log(
                     project_id=project_id,
                     project_slug=project_slug,
-                    env_slug=env_slug,
+                    environment_slug=env_slug,
+                    recorded_by=OPSLOG_BACKFILL_RECORDED_BY,
+                    performed_by=event.performed_by,
+                    action='opslog-backfill',
                     version=version,
-                    event=event,
+                    run_url=event.external_run_url,
+                    external_run_id=event.external_run_id,
+                    occurred_at=event.timestamp,
                 )
             )
             if run_id:

--- a/apps/api/src/imbi/api/maintenance/registry.py
+++ b/apps/api/src/imbi/api/maintenance/registry.py
@@ -24,6 +24,7 @@ MaintenanceSlug = typing.Literal[
     'remediate',
     'rescore',
     'deployment-resync',
+    'opslog-backfill',
     'commit-sync',
     'pr-sync',
 ]
@@ -94,6 +95,19 @@ OPERATIONS: dict[MaintenanceSlug, OperationDefinition] = {
             pause_key=None,
             enumerate=operations.enumerate_all_projects,
             execute=operations.execute_deployment_resync,
+        ),
+        OperationDefinition(
+            slug='opslog-backfill',
+            label='Backfill Deployment Log',
+            description=(
+                'Ensure operations_log has Deployed entries for every '
+                'attributed deployment event on each release, so deployer '
+                'attribution resolves for deployments recorded outside '
+                'Imbi.'
+            ),
+            pause_key=None,
+            enumerate=operations.enumerate_all_projects,
+            execute=operations.execute_opslog_backfill,
         ),
         OperationDefinition(
             slug='commit-sync',

--- a/apps/api/tests/endpoints/test_project_deployments.py
+++ b/apps/api/tests/endpoints/test_project_deployments.py
@@ -1763,37 +1763,37 @@ class LatestDeploymentTimestampTestCase(unittest.TestCase):
 
 
 class SafeAuditUrlTestCase(unittest.TestCase):
-    """Direct tests for ``_safe_audit_url`` (L22)."""
+    """Direct tests for ``safe_audit_url`` (L22)."""
 
     def test_returns_none_for_none(self) -> None:
-        from imbi.api.endpoints.project_deployments import _safe_audit_url
+        from imbi.api.endpoints._helpers import safe_audit_url
 
-        self.assertIsNone(_safe_audit_url(None))
+        self.assertIsNone(safe_audit_url(None))
 
     def test_allows_http_and_https(self) -> None:
-        from imbi.api.endpoints.project_deployments import _safe_audit_url
+        from imbi.api.endpoints._helpers import safe_audit_url
 
         for url in (
             'http://example.com/run/42',
             'https://github.com/o/r/actions/runs/1',
         ):
-            self.assertEqual(_safe_audit_url(url), url)
+            self.assertEqual(safe_audit_url(url), url)
 
     def test_strips_javascript_scheme(self) -> None:
-        from imbi.api.endpoints.project_deployments import _safe_audit_url
+        from imbi.api.endpoints._helpers import safe_audit_url
 
-        self.assertIsNone(_safe_audit_url('javascript:alert(1)'))
-        self.assertIsNone(_safe_audit_url('JavaScript:alert(1)'))
+        self.assertIsNone(safe_audit_url('javascript:alert(1)'))
+        self.assertIsNone(safe_audit_url('JavaScript:alert(1)'))
 
     def test_strips_data_scheme(self) -> None:
-        from imbi.api.endpoints.project_deployments import _safe_audit_url
+        from imbi.api.endpoints._helpers import safe_audit_url
 
-        self.assertIsNone(_safe_audit_url('data:text/html,<script>x</script>'))
+        self.assertIsNone(safe_audit_url('data:text/html,<script>x</script>'))
 
     def test_strips_file_scheme(self) -> None:
-        from imbi.api.endpoints.project_deployments import _safe_audit_url
+        from imbi.api.endpoints._helpers import safe_audit_url
 
-        self.assertIsNone(_safe_audit_url('file:///etc/passwd'))
+        self.assertIsNone(safe_audit_url('file:///etc/passwd'))
 
 
 def _relocating_resolved() -> ResolvedCapability:

--- a/apps/api/tests/endpoints/test_projects_helpers.py
+++ b/apps/api/tests/endpoints/test_projects_helpers.py
@@ -263,6 +263,52 @@ class FetchCurrentReleasesTestCase(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(result['p1']['prod'].performed_by, 'bob@example.com')
 
+    async def test_enriches_performed_by_from_committish_when_tag_set(
+        self,
+    ) -> None:
+        # A branch/SHA deploy records version = committish in the ops log
+        # even though the release carries a tag; the backfill must probe
+        # the committish key too, not just the tag.
+        deployed = datetime.datetime(2026, 4, 1, 12, 0, 0, tzinfo=datetime.UTC)
+        db = mock.AsyncMock()
+        db.execute.return_value = [
+            _row(
+                project_id='p1',
+                env_slug='prod',
+                tag='1.0.0',
+                committish='abcdef0',
+                events=[_event(deployed)],
+            ),
+        ]
+        ch = mock.MagicMock()
+        ch.query = mock.AsyncMock(
+            return_value=[
+                {
+                    'project_id': 'p1',
+                    'environment_slug': 'prod',
+                    'version': 'abcdef0',
+                    'performed_by': 'carol@example.com',
+                },
+            ]
+        )
+
+        with (
+            mock.patch(
+                'imbi.api.endpoints.projects.ch_client.Clickhouse.'
+                'get_instance',
+                return_value=ch,
+            ),
+            mock.patch(
+                'imbi.api.endpoints.projects.graph.parse_agtype',
+                side_effect=lambda v: v,
+            ),
+        ):
+            result = await projects._fetch_current_releases(db, ['p1'])
+
+        self.assertEqual(
+            result['p1']['prod'].performed_by, 'carol@example.com'
+        )
+
     async def test_skips_environments_with_no_events(self) -> None:
         db = mock.AsyncMock()
         db.execute.return_value = [

--- a/apps/api/tests/endpoints/test_projects_helpers.py
+++ b/apps/api/tests/endpoints/test_projects_helpers.py
@@ -378,11 +378,9 @@ class LookupOpsLogPerformedByTestCase(unittest.IsolatedAsyncioTestCase):
             return_value=ch,
         ):
             result = await projects.lookup_ops_log_performed_by(
-                [('p1', 'prod', '1.0.0')]
+                [('p1', 'prod', '1.0.0', None)]
             )
-        self.assertEqual(
-            result, {('p1', 'prod', '1.0.0'): 'alice@example.com'}
-        )
+        self.assertEqual(result, {('p1', 'prod'): 'alice@example.com'})
 
     async def test_swallows_clickhouse_errors(self) -> None:
         ch = mock.MagicMock()
@@ -392,6 +390,6 @@ class LookupOpsLogPerformedByTestCase(unittest.IsolatedAsyncioTestCase):
             return_value=ch,
         ):
             result = await projects.lookup_ops_log_performed_by(
-                [('p1', 'prod', '1.0.0')]
+                [('p1', 'prod', '1.0.0', None)]
             )
         self.assertEqual(result, {})

--- a/apps/api/tests/endpoints/test_releases.py
+++ b/apps/api/tests/endpoints/test_releases.py
@@ -649,11 +649,8 @@ class DeploymentEdgeTestCase(_ReleasesTestBase):
 
     def test_record_deployment_creates_edge(self) -> None:
         self.mock_db.execute.side_effect = [
-            [{'release': _release_row()}],  # pre-check _fetch_release
-            # pre-check _fetch_deployment_edge: env exists, no edge
-            [{'env': self._env(), 'deployments': None}],
-            [{'release': _release_row()}],  # append _fetch_release
-            # append _fetch_deployment_edge
+            [{'release': _release_row()}],  # _fetch_release
+            # _fetch_deployment_edge: env exists, no edge
             [{'env': self._env(), 'deployments': None}],
             [{'deployments': None}],  # create_query
         ]
@@ -687,10 +684,8 @@ class DeploymentEdgeTestCase(_ReleasesTestBase):
             }
         ]
         self.mock_db.execute.side_effect = [
-            [{'release': _release_row()}],  # pre-check _fetch_release
-            edge_row,  # pre-check _fetch_deployment_edge
-            [{'release': _release_row()}],  # append _fetch_release
-            edge_row,  # append _fetch_deployment_edge
+            [{'release': _release_row()}],  # _fetch_release
+            edge_row,  # _fetch_deployment_edge
             [{'deployments': None}],
             [{'current_release': RELEASE_ID}],  # current_release write
         ]
@@ -711,8 +706,6 @@ class DeploymentEdgeTestCase(_ReleasesTestBase):
         # Recording an event must trigger a score recompute, since a
         # DeploymentStatusPolicy can score the project on its status.
         self.mock_db.execute.side_effect = [
-            [{'release': _release_row()}],
-            [{'env': self._env(), 'deployments': None}],
             [{'release': _release_row()}],
             [{'env': self._env(), 'deployments': None}],
             [{'deployments': None}],
@@ -857,10 +850,8 @@ class DeploymentEdgeTestCase(_ReleasesTestBase):
         ]
         edge_row = [{'env': self._env(), 'deployments': json.dumps(existing)}]
         self.mock_db.execute.side_effect = [
-            [{'release': _release_row()}],  # pre-check _fetch_release
-            edge_row,  # pre-check _fetch_deployment_edge
-            [{'release': _release_row()}],  # append _fetch_release
-            edge_row,  # append _fetch_deployment_edge
+            [{'release': _release_row()}],  # _fetch_release
+            edge_row,  # _fetch_deployment_edge
             [{'deployments': None}],  # _set_deployments (in-place refresh)
             [{'current_release': RELEASE_ID}],  # current_release write
         ]
@@ -907,8 +898,6 @@ class DeploymentEdgeTestCase(_ReleasesTestBase):
         ]
         edge_row = [{'env': self._env(), 'deployments': json.dumps(existing)}]
         self.mock_db.execute.side_effect = [
-            [{'release': _release_row()}],
-            edge_row,
             [{'release': _release_row()}],
             edge_row,
             [{'deployments': None}],  # _set_deployments (append)
@@ -1067,10 +1056,8 @@ class DeploymentEdgeTestCase(_ReleasesTestBase):
         self,
     ) -> None:
         self.mock_db.execute.side_effect = [
-            [{'release': _release_row()}],
-            [{'env': self._env(), 'deployments': None}],
-            [{'release': _release_row()}],
-            [{'env': self._env(), 'deployments': None}],
+            [{'release': _release_row()}],  # _fetch_release
+            [{'env': self._env(), 'deployments': None}],  # _fetch_edge
             [{'deployments': None}],  # create edge
             [],  # current_release write matched nothing
         ]
@@ -1480,7 +1467,7 @@ class CurrentReleasesTestCase(_ReleasesTestBase):
             ],
         ]
         lookup = mock.AsyncMock(
-            return_value={(PROJECT_ID, 'production', 'abc1234'): 'deployer'}
+            return_value={(PROJECT_ID, 'production'): 'deployer'}
         )
         with (
             mock.patch(
@@ -1496,10 +1483,10 @@ class CurrentReleasesTestCase(_ReleasesTestBase):
         self.assertEqual(response.status_code, 200, response.text)
         row = response.json()[0]
         self.assertEqual(row['performed_by'], 'deployer')
-        # Both the tag and the committish were offered as candidate keys.
+        # The target carries both the tag and the committish; the lookup
+        # probes them in order (tag first, committish second).
         targets = lookup.await_args.args[0]
-        self.assertIn((PROJECT_ID, 'production', '1.2.3'), targets)
-        self.assertIn((PROJECT_ID, 'production', 'abc1234'), targets)
+        self.assertIn((PROJECT_ID, 'production', '1.2.3', 'abc1234'), targets)
 
     def test_performed_by_email_resolves_to_display_name(self) -> None:
         """An email ``performed_by`` that matches an Imbi user surfaces

--- a/apps/api/tests/endpoints/test_releases.py
+++ b/apps/api/tests/endpoints/test_releases.py
@@ -649,8 +649,11 @@ class DeploymentEdgeTestCase(_ReleasesTestBase):
 
     def test_record_deployment_creates_edge(self) -> None:
         self.mock_db.execute.side_effect = [
-            [{'release': _release_row()}],  # _fetch_release
-            # _fetch_deployment_edge: env exists, no edge
+            [{'release': _release_row()}],  # pre-check _fetch_release
+            # pre-check _fetch_deployment_edge: env exists, no edge
+            [{'env': self._env(), 'deployments': None}],
+            [{'release': _release_row()}],  # append _fetch_release
+            # append _fetch_deployment_edge
             [{'env': self._env(), 'deployments': None}],
             [{'deployments': None}],  # create_query
         ]
@@ -677,14 +680,17 @@ class DeploymentEdgeTestCase(_ReleasesTestBase):
                 'note': None,
             }
         ]
+        edge_row = [
+            {
+                'env': self._env(),
+                'deployments': json.dumps(existing),
+            }
+        ]
         self.mock_db.execute.side_effect = [
-            [{'release': _release_row()}],
-            [
-                {
-                    'env': self._env(),
-                    'deployments': json.dumps(existing),
-                }
-            ],
+            [{'release': _release_row()}],  # pre-check _fetch_release
+            edge_row,  # pre-check _fetch_deployment_edge
+            [{'release': _release_row()}],  # append _fetch_release
+            edge_row,  # append _fetch_deployment_edge
             [{'deployments': None}],
             [{'current_release': RELEASE_ID}],  # current_release write
         ]
@@ -705,6 +711,8 @@ class DeploymentEdgeTestCase(_ReleasesTestBase):
         # Recording an event must trigger a score recompute, since a
         # DeploymentStatusPolicy can score the project on its status.
         self.mock_db.execute.side_effect = [
+            [{'release': _release_row()}],
+            [{'env': self._env(), 'deployments': None}],
             [{'release': _release_row()}],
             [{'env': self._env(), 'deployments': None}],
             [{'deployments': None}],
@@ -769,14 +777,17 @@ class DeploymentEdgeTestCase(_ReleasesTestBase):
                 'note': None,
             }
         ]
+        edge_row = [
+            {
+                'env': self._env(),
+                'deployments': json.dumps(existing),
+            }
+        ]
         self.mock_db.execute.side_effect = [
             [{'release': _release_row()}],
-            [
-                {
-                    'env': self._env(),
-                    'deployments': json.dumps(existing),
-                }
-            ],
+            edge_row,
+            [{'release': _release_row()}],
+            edge_row,
             [{'deployments': None}],
             [{'current_release': RELEASE_ID}],  # current_release write
         ]
@@ -808,6 +819,8 @@ class DeploymentEdgeTestCase(_ReleasesTestBase):
         self.mock_db.execute.side_effect = [
             [{'release': _release_row()}],
             [{'env': self._env(), 'deployments': None}],
+            [{'release': _release_row()}],
+            [{'env': self._env(), 'deployments': None}],
             [{'deployments': None}],
         ]
         with (
@@ -827,6 +840,91 @@ class DeploymentEdgeTestCase(_ReleasesTestBase):
             )
         self.assertEqual(response.status_code, 200)
         mock_close.assert_not_called()
+
+    def test_record_deployment_dedupes_on_external_run_id(self) -> None:
+        # A webhook status update for a run the in-product deploy flow
+        # already recorded must refresh that event in place (not append a
+        # second, anonymous one) and persist the external_run_url — the
+        # duplicate anonymous event is what used to blank "Deployed by".
+        existing = [
+            {
+                'timestamp': '2026-04-20T10:00:00+00:00',
+                'status': 'in_progress',
+                'note': None,
+                'external_run_id': 'run-99',
+                'performed_by': 'deployer',
+            }
+        ]
+        edge_row = [{'env': self._env(), 'deployments': json.dumps(existing)}]
+        self.mock_db.execute.side_effect = [
+            [{'release': _release_row()}],  # pre-check _fetch_release
+            edge_row,  # pre-check _fetch_deployment_edge
+            [{'release': _release_row()}],  # append _fetch_release
+            edge_row,  # append _fetch_deployment_edge
+            [{'deployments': None}],  # _set_deployments (in-place refresh)
+            [{'current_release': RELEASE_ID}],  # current_release write
+        ]
+        with (
+            mock.patch(
+                'imbi.common.graph.parse_agtype',
+                side_effect=lambda x: x,
+            ),
+            mock.patch(
+                'imbi.api.endpoints.releases.complete_opslog_entry',
+                new_callable=mock.AsyncMock,
+                return_value=True,
+            ),
+        ):
+            response = self.client.post(
+                self._url(f'/{RELEASE_ID}/environments/production'),
+                json={
+                    'status': 'success',
+                    'external_run_id': 'run-99',
+                    'external_run_url': 'https://gh/runs/99',
+                },
+            )
+        self.assertEqual(response.status_code, 200, response.text)
+        body = response.json()
+        # Refreshed in place: still a single event, now success, with the
+        # run URL stored.
+        self.assertEqual(len(body['deployments']), 1)
+        self.assertEqual(body['deployments'][0]['status'], 'success')
+        self.assertEqual(body['deployments'][0]['external_run_id'], 'run-99')
+        self.assertEqual(
+            body['deployments'][0]['external_run_url'], 'https://gh/runs/99'
+        )
+
+    def test_record_deployment_without_run_id_stays_append_only(self) -> None:
+        # Without an external_run_id the endpoint keeps append-only
+        # semantics, so a new event is added alongside the existing one.
+        existing = [
+            {
+                'timestamp': '2026-04-20T10:00:00+00:00',
+                'status': 'in_progress',
+                'note': None,
+                'external_run_id': 'run-99',
+            }
+        ]
+        edge_row = [{'env': self._env(), 'deployments': json.dumps(existing)}]
+        self.mock_db.execute.side_effect = [
+            [{'release': _release_row()}],
+            edge_row,
+            [{'release': _release_row()}],
+            edge_row,
+            [{'deployments': None}],  # _set_deployments (append)
+        ]
+        with mock.patch(
+            'imbi.common.graph.parse_agtype',
+            side_effect=lambda x: x,
+        ):
+            response = self.client.post(
+                self._url(f'/{RELEASE_ID}/environments/production'),
+                json={'status': 'failed'},
+            )
+        self.assertEqual(response.status_code, 200, response.text)
+        body = response.json()
+        self.assertEqual(len(body['deployments']), 2)
+        self.assertEqual(body['current_status'], 'failed')
 
     def test_list_deployment_edges(self) -> None:
         deployments = json.dumps(
@@ -917,6 +1015,8 @@ class DeploymentEdgeTestCase(_ReleasesTestBase):
         self.mock_db.execute.side_effect = [
             [{'release': _release_row()}],
             [{'env': self._env(), 'deployments': None}],
+            [{'release': _release_row()}],
+            [{'env': self._env(), 'deployments': None}],
             [{'deployments': None}],  # create edge
             [{'current_release': RELEASE_ID}],  # current_release write
         ]
@@ -948,6 +1048,8 @@ class DeploymentEdgeTestCase(_ReleasesTestBase):
         self.mock_db.execute.side_effect = [
             [{'release': _release_row()}],
             [{'env': self._env(), 'deployments': None}],
+            [{'release': _release_row()}],
+            [{'env': self._env(), 'deployments': None}],
             [{'deployments': None}],
         ]
         with mock.patch(
@@ -965,6 +1067,8 @@ class DeploymentEdgeTestCase(_ReleasesTestBase):
         self,
     ) -> None:
         self.mock_db.execute.side_effect = [
+            [{'release': _release_row()}],
+            [{'env': self._env(), 'deployments': None}],
             [{'release': _release_row()}],
             [{'env': self._env(), 'deployments': None}],
             [{'deployments': None}],  # create edge
@@ -1358,6 +1462,44 @@ class CurrentReleasesTestCase(_ReleasesTestBase):
         by_slug = {row['environment']['slug']: row for row in data}
         self.assertIsNone(by_slug['testing']['release'])
         self.assertEqual(by_slug['production']['release']['tag'], '1.0.0')
+
+    def test_backfill_matches_committish_when_release_has_tag(self) -> None:
+        # A branch/SHA deploy records version = committish in the ops log,
+        # while the release still carries a tag; the backfill must probe
+        # both keys so "Deployed by" resolves from the committish-keyed
+        # ops-log row instead of showing blank.
+        deployments = self._events(('2026-04-22T10:00:00+00:00', 'success'))
+        self.mock_db.execute.side_effect = [
+            [{'id': PROJECT_ID}],
+            [
+                {
+                    'env': self._env('production'),
+                    'release': _release_row(tag='1.2.3', committish='abc1234'),
+                    'deployments': deployments,
+                }
+            ],
+        ]
+        lookup = mock.AsyncMock(
+            return_value={(PROJECT_ID, 'production', 'abc1234'): 'deployer'}
+        )
+        with (
+            mock.patch(
+                'imbi.api.endpoints.releases.lookup_ops_log_performed_by',
+                new=lookup,
+            ),
+            mock.patch(
+                'imbi.common.graph.parse_agtype',
+                side_effect=lambda x: x,
+            ),
+        ):
+            response = self.client.get(self._url('/current'))
+        self.assertEqual(response.status_code, 200, response.text)
+        row = response.json()[0]
+        self.assertEqual(row['performed_by'], 'deployer')
+        # Both the tag and the committish were offered as candidate keys.
+        targets = lookup.await_args.args[0]
+        self.assertIn((PROJECT_ID, 'production', '1.2.3'), targets)
+        self.assertIn((PROJECT_ID, 'production', 'abc1234'), targets)
 
     def test_performed_by_email_resolves_to_display_name(self) -> None:
         """An email ``performed_by`` that matches an Imbi user surfaces

--- a/apps/api/tests/endpoints/test_releases.py
+++ b/apps/api/tests/endpoints/test_releases.py
@@ -884,6 +884,9 @@ class DeploymentEdgeTestCase(_ReleasesTestBase):
         self.assertEqual(
             body['deployments'][0]['external_run_url'], 'https://gh/runs/99'
         )
+        # The webhook sends no performed_by; the refresh must keep the
+        # stored deployer rather than blanking it.
+        self.assertEqual(body['deployments'][0]['performed_by'], 'deployer')
 
     def test_record_deployment_without_run_id_stays_append_only(self) -> None:
         # Without an external_run_id the endpoint keeps append-only

--- a/apps/api/tests/test_maintenance_operations.py
+++ b/apps/api/tests/test_maintenance_operations.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import contextlib
+import datetime
+import json
 import time
 import unittest
 from unittest import mock
@@ -278,6 +280,186 @@ class ExecuteDeploymentResyncTests(unittest.IsolatedAsyncioTestCase):
                     mock.AsyncMock(), mock.AsyncMock(), 'p1'
                 )
         self.assertIn('no credentials', str(ctx.exception))
+
+
+def _edge_row(
+    *,
+    env_slug: str = 'production',
+    tag: str | None = 'v1.2.3',
+    committish: str | None = 'abc1234',
+    deployments: list[dict[str, object]],
+) -> dict[str, object]:
+    """A graph row as ``execute_opslog_backfill`` reads it.
+
+    ``parse_agtype`` passes plain strings through and JSON-decodes the
+    ``deployments`` payload, so encoding it as JSON mirrors the AGE
+    edge-property shape.
+    """
+    return {
+        'env_slug': env_slug,
+        'tag': tag,
+        'committish': committish,
+        'deployments': json.dumps(deployments),
+    }
+
+
+def _event(
+    *,
+    status: str = 'success',
+    performed_by: str | None = 'alice@example.com',
+    external_run_id: str | None = 'run-1',
+    timestamp: str = '2026-01-01T00:00:00+00:00',
+    external_run_url: str | None = 'https://ci.example.com/run-1',
+) -> dict[str, object]:
+    return {
+        'status': status,
+        'performed_by': performed_by,
+        'external_run_id': external_run_id,
+        'external_run_url': external_run_url,
+        'timestamp': timestamp,
+    }
+
+
+class ExecuteOpslogBackfillTests(unittest.IsolatedAsyncioTestCase):
+    async def _run(
+        self,
+        *,
+        edge_rows: list[dict[str, object]],
+        existing_ch_rows: list[dict[str, object]] | None = None,
+    ) -> tuple[operations.ExecuteOutcome, mock.Mock]:
+        db = mock.AsyncMock()
+        db.execute = mock.AsyncMock(return_value=edge_rows)
+        instance = mock.Mock()
+        instance.query = mock.AsyncMock(return_value=existing_ch_rows or [])
+        instance.insert = mock.AsyncMock()
+        with (
+            mock.patch.object(
+                operations.clickhouse.client.Clickhouse,
+                'get_instance',
+                return_value=instance,
+            ),
+            mock.patch(
+                'imbi.api.endpoints._helpers.lookup_project_slugs',
+                mock.AsyncMock(return_value=('proj', 'team')),
+            ),
+        ):
+            outcome = await operations.execute_opslog_backfill(
+                db, mock.AsyncMock(), 'p1'
+            )
+        return outcome, instance
+
+    @staticmethod
+    def _inserted_row(instance: mock.Mock) -> dict[str, object]:
+        _table, values, columns = instance.insert.await_args.args
+        assert len(values) == 1
+        return dict(zip(columns, values[0], strict=True))
+
+    async def test_skipped_without_edges(self) -> None:
+        outcome, instance = await self._run(edge_rows=[])
+        self.assertEqual('skipped', outcome)
+        instance.insert.assert_not_awaited()
+
+    async def test_inserts_row_for_attributed_success(self) -> None:
+        outcome, instance = await self._run(
+            edge_rows=[_edge_row(deployments=[_event()])]
+        )
+        self.assertEqual('succeeded', outcome)
+        instance.insert.assert_awaited_once()
+        table = instance.insert.await_args.args[0]
+        self.assertEqual('operations_log', table)
+        row = self._inserted_row(instance)
+        self.assertEqual('Deployed', row['entry_type'])
+        self.assertEqual('alice@example.com', row['performed_by'])
+        self.assertEqual('maintenance-opslog-backfill', row['recorded_by'])
+        self.assertEqual('production', row['environment_slug'])
+        self.assertEqual('v1.2.3', row['version'])
+        self.assertEqual('run-1', row['external_run_id'])
+
+    async def test_occurred_at_matches_event_timestamp(self) -> None:
+        _outcome, instance = await self._run(
+            edge_rows=[
+                _edge_row(
+                    deployments=[_event(timestamp='2025-06-15T12:34:56+00:00')]
+                )
+            ]
+        )
+        row = self._inserted_row(instance)
+        self.assertEqual(
+            datetime.datetime(2025, 6, 15, 12, 34, 56, tzinfo=datetime.UTC),
+            row['occurred_at'],
+        )
+
+    async def test_skips_events_without_performed_by(self) -> None:
+        outcome, instance = await self._run(
+            edge_rows=[_edge_row(deployments=[_event(performed_by=None)])]
+        )
+        self.assertEqual('skipped', outcome)
+        instance.insert.assert_not_awaited()
+
+    async def test_skips_non_success_events(self) -> None:
+        outcome, instance = await self._run(
+            edge_rows=[_edge_row(deployments=[_event(status='in_progress')])]
+        )
+        self.assertEqual('skipped', outcome)
+        instance.insert.assert_not_awaited()
+
+    async def test_dedupes_by_external_run_id(self) -> None:
+        # The env/version differ from the event's, so only the run-id
+        # match can suppress the insert.
+        outcome, instance = await self._run(
+            edge_rows=[_edge_row(deployments=[_event()])],
+            existing_ch_rows=[
+                {
+                    'environment_slug': 'staging',
+                    'version': 'v9.9.9',
+                    'external_run_id': 'run-1',
+                }
+            ],
+        )
+        self.assertEqual('skipped', outcome)
+        instance.insert.assert_not_awaited()
+
+    async def test_dedupes_by_env_and_version(self) -> None:
+        # No run id on the event, but the committish candidate matches an
+        # existing (env, version) row -> nothing to insert.
+        outcome, instance = await self._run(
+            edge_rows=[_edge_row(deployments=[_event(external_run_id=None)])],
+            existing_ch_rows=[
+                {
+                    'environment_slug': 'production',
+                    'version': 'abc1234',
+                    'external_run_id': None,
+                }
+            ],
+        )
+        self.assertEqual('skipped', outcome)
+        instance.insert.assert_not_awaited()
+
+    async def test_newest_attributed_event_wins_dedupe(self) -> None:
+        # Two success events on one edge, same (env, version), no run ids.
+        # Only the newer one is inserted so argMax reflects the latest
+        # deployer.
+        outcome, instance = await self._run(
+            edge_rows=[
+                _edge_row(
+                    deployments=[
+                        _event(
+                            performed_by='old@example.com',
+                            external_run_id=None,
+                            timestamp='2025-01-01T00:00:00+00:00',
+                        ),
+                        _event(
+                            performed_by='new@example.com',
+                            external_run_id=None,
+                            timestamp='2026-01-01T00:00:00+00:00',
+                        ),
+                    ]
+                )
+            ]
+        )
+        self.assertEqual('succeeded', outcome)
+        row = self._inserted_row(instance)
+        self.assertEqual('new@example.com', row['performed_by'])
 
 
 class ExecuteRescoreTests(unittest.IsolatedAsyncioTestCase):

--- a/apps/api/tests/test_maintenance_operations.py
+++ b/apps/api/tests/test_maintenance_operations.py
@@ -461,6 +461,33 @@ class ExecuteOpslogBackfillTests(unittest.IsolatedAsyncioTestCase):
         row = self._inserted_row(instance)
         self.assertEqual('new@example.com', row['performed_by'])
 
+    async def test_unsafe_run_url_is_dropped(self) -> None:
+        # A plugin-supplied external_run_url with a non-http(s) scheme
+        # must not reach the audit link or description JSON (XSS defense
+        # in depth), even on the backfill path.
+        _outcome, instance = await self._run(
+            edge_rows=[
+                _edge_row(
+                    deployments=[
+                        _event(external_run_url='javascript:alert(1)')
+                    ]
+                )
+            ]
+        )
+        row = self._inserted_row(instance)
+        self.assertIsNone(row['link'])
+        description = json.loads(str(row['description']))
+        self.assertIsNone(description['run_url'])
+
+    async def test_existing_rows_query_filters_soft_deleted(self) -> None:
+        # A tombstoned (is_deleted=1) ops-log row must not dedupe-suppress
+        # a backfill insert, so the existing-rows read filters them out.
+        _outcome, instance = await self._run(
+            edge_rows=[_edge_row(deployments=[_event()])]
+        )
+        sql = instance.query.await_args.args[0]
+        self.assertIn('is_deleted = 0', sql)
+
 
 class ExecuteRescoreTests(unittest.IsolatedAsyncioTestCase):
     async def test_enqueued_is_succeeded(self) -> None:

--- a/libraries/common/src/imbi/common/models.py
+++ b/libraries/common/src/imbi/common/models.py
@@ -758,6 +758,50 @@ class DeploymentEvent(pydantic.BaseModel):
     performed_by: str | None = None
 
 
+def parse_deployment_events(
+    raw: object,
+    *,
+    on_error: typing.Literal['raise', 'skip'] = 'raise',
+) -> list[DeploymentEvent]:
+    """Parse the JSON-encoded ``deployments`` edge property.
+
+    A release's ``DEPLOYED_TO`` edge stores its event history as a
+    JSON-encoded string (or, once decoded by the graph layer, a list).
+    Falsy input and anything that isn't a list yield ``[]``; every list
+    entry is validated into a :class:`DeploymentEvent`.
+
+    ``on_error`` controls how malformed data is handled. ``'raise'``
+    (the default) lets a JSON decode error or an invalid entry
+    propagate, so a bad edge fails loudly. ``'skip'`` is tolerant:
+    undecodable JSON yields ``[]`` and each entry that fails validation
+    is dropped, keeping the good ones — for callers (e.g. score
+    computation) that must not fail the whole operation over one bad
+    row.
+    """
+    if not raw:
+        return []
+    if isinstance(raw, str):
+        try:
+            data: object = json.loads(raw)
+        except json.JSONDecodeError:
+            if on_error == 'raise':
+                raise
+            return []
+    else:
+        data = raw
+    if not isinstance(data, list):
+        return []
+    events: list[DeploymentEvent] = []
+    for entry in typing.cast('list[object]', data):
+        try:
+            events.append(DeploymentEvent.model_validate(entry))
+        except pydantic.ValidationError:
+            if on_error == 'raise':
+                raise
+            continue
+    return events
+
+
 class ReleaseLink(pydantic.BaseModel):
     """A typed external link attached to a ``Release``.
 

--- a/libraries/common/src/imbi/common/scoring/engine.py
+++ b/libraries/common/src/imbi/common/scoring/engine.py
@@ -2,10 +2,7 @@
 
 from __future__ import annotations
 
-import json
 import typing
-
-import pydantic
 
 from imbi.common import graph, models
 from imbi.common.scoring import attribute, policies
@@ -188,18 +185,6 @@ def _parse_deployment_events(
     AGE round-trips the list as a JSON string; malformed entries are
     skipped rather than failing the whole score computation.
     """
-    parsed: typing.Any = graph.parse_agtype(raw)
-    if isinstance(parsed, str):
-        try:
-            parsed = json.loads(parsed)
-        except json.JSONDecodeError:
-            return []
-    if not isinstance(parsed, list):
-        return []
-    events: list[models.DeploymentEvent] = []
-    for item in parsed:  # pyright: ignore[reportUnknownVariableType]
-        try:
-            events.append(models.DeploymentEvent.model_validate(item))
-        except pydantic.ValidationError:
-            continue
-    return events
+    return models.parse_deployment_events(
+        graph.parse_agtype(raw), on_error='skip'
+    )

--- a/libraries/common/tests/test_models.py
+++ b/libraries/common/tests/test_models.py
@@ -1230,6 +1230,65 @@ class DeploymentEventTestCase(unittest.TestCase):
         )
 
 
+class ParseDeploymentEventsTestCase(unittest.TestCase):
+    """Tests for the ``parse_deployment_events`` helper."""
+
+    def test_falsy_returns_empty(self) -> None:
+        for raw in (None, '', [], 0):
+            self.assertEqual(models.parse_deployment_events(raw), [])
+
+    def test_non_list_returns_empty(self) -> None:
+        self.assertEqual(models.parse_deployment_events('{"a": 1}'), [])
+        self.assertEqual(models.parse_deployment_events({'a': 1}), [])
+
+    def test_parses_json_string(self) -> None:
+        raw = json.dumps(
+            [
+                {
+                    'timestamp': '2026-04-20T10:00:00+00:00',
+                    'status': 'success',
+                }
+            ]
+        )
+        events = models.parse_deployment_events(raw)
+        self.assertEqual(len(events), 1)
+        self.assertIsInstance(events[0], models.DeploymentEvent)
+        self.assertEqual(events[0].status, 'success')
+
+    def test_parses_already_decoded_list(self) -> None:
+        events = models.parse_deployment_events(
+            [{'status': 'pending'}, {'status': 'failed'}]
+        )
+        self.assertEqual([e.status for e in events], ['pending', 'failed'])
+
+    def test_strict_mode_raises_on_corrupt_json(self) -> None:
+        with self.assertRaises(json.JSONDecodeError):
+            models.parse_deployment_events('not json')
+
+    def test_strict_mode_raises_on_invalid_entry(self) -> None:
+        raw = json.dumps([{'status': 'success'}, {'nope': True}])
+        with self.assertRaises(pydantic.ValidationError):
+            models.parse_deployment_events(raw)
+
+    def test_skip_mode_returns_empty_on_corrupt_json(self) -> None:
+        self.assertEqual(
+            models.parse_deployment_events('not json', on_error='skip'), []
+        )
+
+    def test_skip_mode_drops_bad_entry_keeps_good(self) -> None:
+        raw = json.dumps(
+            [
+                {
+                    'status': 'success',
+                    'timestamp': '2026-06-01T00:00:00+00:00',
+                },
+                {'nope': True},
+            ]
+        )
+        events = models.parse_deployment_events(raw, on_error='skip')
+        self.assertEqual([e.status for e in events], ['success'])
+
+
 class ReleaseLinkTestCase(unittest.TestCase):
     """Tests for the ReleaseLink model."""
 

--- a/plugins/github/src/imbi/plugins/github/deployment.py
+++ b/plugins/github/src/imbi/plugins/github/deployment.py
@@ -26,6 +26,7 @@ import contextlib
 import datetime
 import hashlib
 import logging
+import re
 import time
 import typing
 import urllib.parse
@@ -1002,10 +1003,16 @@ class GitHubDeployment(DeploymentCapability):
         with explicit pagination if it ever needs to.
         """
         page_size = max(1, min(limit, 100))
+        # One run commonly backs several deployments in a sweep; cache
+        # the triggering-actor lookup by run id so we resolve each run
+        # at most once. Shared across the parallel per-env fan-out.
+        run_cache: dict[str, tuple[str, str] | None] = {}
         async with self._client(ctx, credentials) as client:
             per_env = await asyncio.gather(
                 *(
-                    self._list_deployments_for_env(client, env, page_size)
+                    self._list_deployments_for_env(
+                        client, env, page_size, run_cache
+                    )
                     for env in environments
                 )
             )
@@ -1035,6 +1042,7 @@ class GitHubDeployment(DeploymentCapability):
         client: httpx.AsyncClient,
         environment: str,
         page_size: int,
+        run_cache: dict[str, tuple[str, str] | None],
     ) -> list[RemoteDeployment]:
         try:
             resp = await client.get(
@@ -1067,7 +1075,7 @@ class GitHubDeployment(DeploymentCapability):
         observed: list[RemoteDeployment] = []
         for deployment in deployments:
             run = await self._observe_deployment(
-                client, environment, deployment
+                client, environment, deployment, run_cache
             )
             if run is not None:
                 observed.append(run)
@@ -1078,6 +1086,7 @@ class GitHubDeployment(DeploymentCapability):
         client: httpx.AsyncClient,
         environment: str,
         deployment: dict[str, typing.Any],
+        run_cache: dict[str, tuple[str, str] | None],
     ) -> RemoteDeployment | None:
         deployment_id = deployment.get('id')
         sha = deployment.get('sha')
@@ -1113,6 +1122,18 @@ class GitHubDeployment(DeploymentCapability):
             creator_id = creator_dict.get('id')
             if isinstance(creator_id, int):
                 creator_subject = str(creator_id)
+            # Deployments made by an Actions workflow carry the app bot
+            # as creator (``deployer[bot]``), never the human who
+            # triggered the run. Re-attribute to the run's triggering
+            # actor so the host can resolve the deploy to a real user.
+            if _is_bot(creator_dict):
+                run_id = _run_id_from_status_url(status_url)
+                if run_id is not None:
+                    actor = await self._resolve_triggering_actor(
+                        client, run_id, run_cache
+                    )
+                    if actor is not None:
+                        creator_login, creator_subject = actor
         return RemoteDeployment(
             environment=environment,
             sha=str(sha),
@@ -1127,6 +1148,53 @@ class GitHubDeployment(DeploymentCapability):
             creator=creator_login,
             creator_subject=creator_subject,
         )
+
+    async def _resolve_triggering_actor(
+        self,
+        client: httpx.AsyncClient,
+        run_id: str,
+        run_cache: dict[str, tuple[str, str] | None],
+    ) -> tuple[str, str] | None:
+        """Resolve a workflow run's human trigger to ``(login, subject)``.
+
+        Attributes a bot-created deployment to the person who started
+        the Actions run via ``GET /actions/runs/{run_id}``, preferring
+        ``triggering_actor`` (the account that re-ran or dispatched the
+        run) and falling back to ``actor``. Best-effort: a fetch/parse
+        error, a missing actor, or an actor that is itself a bot yields
+        ``None`` so the caller keeps the bot creator -- attribution must
+        never fail the resync. Results (including ``None``) are cached
+        per sweep because one run backs several deployments.
+        """
+        if run_id in run_cache:
+            return run_cache[run_id]
+        result: tuple[str, str] | None = None
+        try:
+            resp = await client.get(f'/actions/runs/{run_id}')
+            resp.raise_for_status()
+            run = typing.cast(dict[str, typing.Any], resp.json())
+        except (httpx.HTTPError, PluginAuthenticationFailed, ValueError):
+            LOGGER.warning(
+                'Failed to fetch workflow run %s for deploy attribution',
+                run_id,
+                exc_info=True,
+            )
+            run_cache[run_id] = None
+            return None
+        actor_raw = run.get('triggering_actor') or run.get('actor')
+        if isinstance(actor_raw, dict):
+            actor = typing.cast(dict[str, typing.Any], actor_raw)
+            login = actor.get('login')
+            actor_id = actor.get('id')
+            if (
+                isinstance(login, str)
+                and login
+                and isinstance(actor_id, int)
+                and not _is_bot(actor)
+            ):
+                result = (login, str(actor_id))
+        run_cache[run_id] = result
+        return result
 
     async def _release_notes_for_ref(
         self, client: httpx.AsyncClient, ref: str
@@ -1193,6 +1261,38 @@ class GitHubDeployment(DeploymentCapability):
         state = str(latest.get('state') or '').lower()
         log_url = latest.get('log_url') or latest.get('target_url')
         return _to_event_status(state), str(log_url) if log_url else None
+
+
+_RUN_ID_RE = re.compile(r'/actions/runs/(\d+)')
+
+
+def _is_bot(user: dict[str, typing.Any]) -> bool:
+    """Return ``True`` when a GitHub user object denotes an app/bot.
+
+    GitHub marks app identities with ``type == 'Bot'`` on the user
+    object and gives them a ``login`` suffixed ``[bot]``
+    (``github-actions[bot]``, ``deployer[bot]``). Either signal alone is
+    sufficient; both comparisons are case-insensitive.
+    """
+    if str(user.get('type') or '').lower() == 'bot':
+        return True
+    login = user.get('login')
+    return isinstance(login, str) and login.lower().endswith('[bot]')
+
+
+def _run_id_from_status_url(url: str | None) -> str | None:
+    """Extract the Actions run id from a deployment status URL.
+
+    A GitHub Actions deploy posts its status ``log_url``/``target_url``
+    pointing at the workflow run
+    (``.../actions/runs/{run_id}`` optionally followed by
+    ``/job/{job_id}``). Any URL that is not an Actions run link yields
+    ``None``.
+    """
+    if not url:
+        return None
+    match = _RUN_ID_RE.search(url)
+    return match.group(1) if match else None
 
 
 def _to_event_status(github_state: str) -> DeploymentEventStatus:

--- a/plugins/github/tests/test_deployment.py
+++ b/plugins/github/tests/test_deployment.py
@@ -1297,6 +1297,222 @@ class ListRecentDeploymentsTestCase(unittest.IsolatedAsyncioTestCase):
         self.assertTrue(all(e.release_notes is None for e in events))
         self.assertEqual(first.call_count, 1)
 
+    @respx.mock
+    async def test_bot_creator_attributed_to_triggering_actor(self) -> None:
+        # A workflow-created deployment lists the app bot as creator; the
+        # status URL points at the Actions run, so attribution follows to
+        # the run's triggering actor (the human who started it).
+        respx.get('https://api.github.com/repos/octo/demo/deployments').mock(
+            return_value=httpx.Response(
+                200,
+                json=[
+                    {
+                        'id': 123,
+                        'sha': 'botsha',
+                        'ref': 'main',
+                        'created_at': '2026-05-13T14:00:00Z',
+                        'creator': {
+                            'login': 'deployer[bot]',
+                            'id': 111,
+                            'type': 'Bot',
+                        },
+                    }
+                ],
+            )
+        )
+        respx.get(
+            'https://api.github.com/repos/octo/demo/deployments/123/statuses'
+        ).mock(
+            return_value=httpx.Response(
+                200,
+                json=[
+                    {
+                        'state': 'success',
+                        'log_url': 'https://github.com/octo/demo/actions/runs/9001/job/55',
+                        'created_at': '2026-05-13T14:01:00Z',
+                    }
+                ],
+            )
+        )
+        run = respx.get(
+            'https://api.github.com/repos/octo/demo/actions/runs/9001'
+        ).mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    'triggering_actor': {'login': 'octocat', 'id': 583231},
+                    'actor': {'login': 'someone-else', 'id': 42},
+                },
+            )
+        )
+        respx.get(
+            'https://api.github.com/repos/octo/demo/releases/tags/main'
+        ).mock(return_value=httpx.Response(404, json={'message': 'Not Found'}))
+        plugin = GitHubDeployment()
+        events = await plugin.list_recent_deployments(
+            _ctx(), _CREDS, ['production']
+        )
+        self.assertEqual(len(events), 1)
+        self.assertTrue(run.called)
+        self.assertEqual(events[0].creator, 'octocat')
+        self.assertEqual(events[0].creator_subject, '583231')
+
+    @respx.mock
+    async def test_bot_detection_is_case_insensitive(self) -> None:
+        # Bot detection must not depend on GitHub's casing: a creator
+        # with type 'bot' and a mixed-case '[Bot]' login suffix is still
+        # re-attributed to the run's triggering actor.
+        respx.get('https://api.github.com/repos/octo/demo/deployments').mock(
+            return_value=httpx.Response(
+                200,
+                json=[
+                    {
+                        'id': 123,
+                        'sha': 'botsha',
+                        'ref': 'main',
+                        'created_at': '2026-05-13T14:00:00Z',
+                        'creator': {
+                            'login': 'Deployer[Bot]',
+                            'id': 111,
+                            'type': 'bot',
+                        },
+                    }
+                ],
+            )
+        )
+        respx.get(
+            'https://api.github.com/repos/octo/demo/deployments/123/statuses'
+        ).mock(
+            return_value=httpx.Response(
+                200,
+                json=[
+                    {
+                        'state': 'success',
+                        'log_url': 'https://github.com/octo/demo/actions/runs/9001/job/55',
+                        'created_at': '2026-05-13T14:01:00Z',
+                    }
+                ],
+            )
+        )
+        run = respx.get(
+            'https://api.github.com/repos/octo/demo/actions/runs/9001'
+        ).mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    'triggering_actor': {'login': 'octocat', 'id': 583231},
+                },
+            )
+        )
+        respx.get(
+            'https://api.github.com/repos/octo/demo/releases/tags/main'
+        ).mock(return_value=httpx.Response(404, json={'message': 'Not Found'}))
+        plugin = GitHubDeployment()
+        events = await plugin.list_recent_deployments(
+            _ctx(), _CREDS, ['production']
+        )
+        self.assertEqual(len(events), 1)
+        self.assertTrue(run.called)
+        self.assertEqual(events[0].creator, 'octocat')
+        self.assertEqual(events[0].creator_subject, '583231')
+
+    @respx.mock
+    async def test_bot_creator_kept_when_run_fetch_fails(self) -> None:
+        # The run lookup 500s; attribution degrades gracefully to the bot
+        # creator rather than raising and failing the resync.
+        respx.get('https://api.github.com/repos/octo/demo/deployments').mock(
+            return_value=httpx.Response(
+                200,
+                json=[
+                    {
+                        'id': 123,
+                        'sha': 'botsha',
+                        'ref': 'main',
+                        'created_at': '2026-05-13T14:00:00Z',
+                        'creator': {
+                            'login': 'github-actions[bot]',
+                            'id': 111,
+                        },
+                    }
+                ],
+            )
+        )
+        respx.get(
+            'https://api.github.com/repos/octo/demo/deployments/123/statuses'
+        ).mock(
+            return_value=httpx.Response(
+                200,
+                json=[
+                    {
+                        'state': 'success',
+                        'target_url': 'https://github.com/octo/demo/actions/runs/9001',
+                        'created_at': '2026-05-13T14:01:00Z',
+                    }
+                ],
+            )
+        )
+        run = respx.get(
+            'https://api.github.com/repos/octo/demo/actions/runs/9001'
+        ).mock(return_value=httpx.Response(500, json={'message': 'oops'}))
+        respx.get(
+            'https://api.github.com/repos/octo/demo/releases/tags/main'
+        ).mock(return_value=httpx.Response(404, json={'message': 'Not Found'}))
+        plugin = GitHubDeployment()
+        events = await plugin.list_recent_deployments(
+            _ctx(), _CREDS, ['production']
+        )
+        self.assertEqual(len(events), 1)
+        self.assertTrue(run.called)
+        self.assertEqual(events[0].creator, 'github-actions[bot]')
+        self.assertEqual(events[0].creator_subject, '111')
+
+    @respx.mock
+    async def test_human_creator_skips_run_lookup(self) -> None:
+        # A human-created deployment must never issue the extra run
+        # fetch; the creator is used as-is.
+        respx.get('https://api.github.com/repos/octo/demo/deployments').mock(
+            return_value=httpx.Response(
+                200,
+                json=[
+                    {
+                        'id': 123,
+                        'sha': 'humansha',
+                        'ref': 'main',
+                        'created_at': '2026-05-13T14:00:00Z',
+                        'creator': {'login': 'octocat', 'id': 583231},
+                    }
+                ],
+            )
+        )
+        respx.get(
+            'https://api.github.com/repos/octo/demo/deployments/123/statuses'
+        ).mock(
+            return_value=httpx.Response(
+                200,
+                json=[
+                    {
+                        'state': 'success',
+                        'log_url': 'https://github.com/octo/demo/actions/runs/9001',
+                        'created_at': '2026-05-13T14:01:00Z',
+                    }
+                ],
+            )
+        )
+        run = respx.get(
+            'https://api.github.com/repos/octo/demo/actions/runs/9001'
+        ).mock(return_value=httpx.Response(200, json={}))
+        respx.get(
+            'https://api.github.com/repos/octo/demo/releases/tags/main'
+        ).mock(return_value=httpx.Response(404, json={'message': 'Not Found'}))
+        plugin = GitHubDeployment()
+        events = await plugin.list_recent_deployments(
+            _ctx(), _CREDS, ['production']
+        )
+        self.assertEqual(len(events), 1)
+        self.assertFalse(run.called)
+        self.assertEqual(events[0].creator, 'octocat')
+        self.assertEqual(events[0].creator_subject, '583231')
+
 
 class GetReleaseNotesTestCase(unittest.IsolatedAsyncioTestCase):
     @respx.mock

--- a/plugins/github/tests/test_deployment.py
+++ b/plugins/github/tests/test_deployment.py
@@ -1328,7 +1328,10 @@ class ListRecentDeploymentsTestCase(unittest.IsolatedAsyncioTestCase):
                 json=[
                     {
                         'state': 'success',
-                        'log_url': 'https://github.com/octo/demo/actions/runs/9001/job/55',
+                        'log_url': (
+                            'https://github.com/octo/demo'
+                            '/actions/runs/9001/job/55'
+                        ),
                         'created_at': '2026-05-13T14:01:00Z',
                     }
                 ],
@@ -1388,7 +1391,10 @@ class ListRecentDeploymentsTestCase(unittest.IsolatedAsyncioTestCase):
                 json=[
                     {
                         'state': 'success',
-                        'log_url': 'https://github.com/octo/demo/actions/runs/9001/job/55',
+                        'log_url': (
+                            'https://github.com/octo/demo'
+                            '/actions/runs/9001/job/55'
+                        ),
                         'created_at': '2026-05-13T14:01:00Z',
                     }
                 ],
@@ -1445,7 +1451,9 @@ class ListRecentDeploymentsTestCase(unittest.IsolatedAsyncioTestCase):
                 json=[
                     {
                         'state': 'success',
-                        'target_url': 'https://github.com/octo/demo/actions/runs/9001',
+                        'target_url': (
+                            'https://github.com/octo/demo/actions/runs/9001'
+                        ),
                         'created_at': '2026-05-13T14:01:00Z',
                     }
                 ],
@@ -1492,7 +1500,9 @@ class ListRecentDeploymentsTestCase(unittest.IsolatedAsyncioTestCase):
                 json=[
                     {
                         'state': 'success',
-                        'log_url': 'https://github.com/octo/demo/actions/runs/9001',
+                        'log_url': (
+                            'https://github.com/octo/demo/actions/runs/9001'
+                        ),
                         'created_at': '2026-05-13T14:01:00Z',
                     }
                 ],


### PR DESCRIPTION
## Summary
Make "Deployed by" on the project Environments card resolve consistently regardless of which path recorded the deployment (in-product deploy/promote, gateway webhook, or resync), attribute GitHub Actions-created deployments to the human who triggered the run, and add a Backfill Deployment Log admin maintenance operation to heal historical data.

## Problem
The per-environment deployer is stitched together from three sources, each with a gap, so the same release showed a deployer on some environments and not others (e.g. the account project showing Kevin on production but not testing/staging):

- The webhook `record_deployment` endpoint stored events without `external_run_id`/`external_run_url` and appended unconditionally, so a status update for a run the deploy flow had already recorded stacked a second, anonymous event that became the environment's latest and blanked "Deployed by".
- The operations_log backfill joined on `(project, environment, version)` where the audit row records `matched_tag or committish` but the current-release views keyed only on the tag — a deploy triggered from a branch/SHA never joined.
- Deployment resync attributed to the GitHub deployment `creator`, which for Actions-created deployments is the app bot (`deployer[bot]`), never the human who triggered the workflow.

## Solution
- `record_deployment` now delegates to `append_deployment_event`, persisting the run id/URL and deduplicating in place; 404/422 semantics, ops-log completion, and score recompute are preserved.
- The performed_by backfill probes both the tag and the short committish via a shared `ops_log_version_candidates` helper used by both the project-detail and projects-list views.
- The GitHub plugin detects bot creators (case-insensitive `type == 'bot'` or `[bot]` login suffix), parses the Actions run id from the deployment-status URL it already fetched, and attributes to the run's `triggering_actor` (fallback `actor`), best-effort with a per-sweep cache; human creators skip the extra call.
- New registry-driven maintenance operation `opslog-backfill` ("Backfill Deployment Log") inserts missing operations_log `Deployed` rows from successful, attributed deployment events — real event timestamps, never unattributed rows, deduped by run id and (environment, version).

## Impact
After deploying, run **Sync Deployments** then **Backfill Deployment Log** from the admin Maintenance page: the first stamps the deployer on each environment's newest event, the second writes the ops-log rows so environments whose latest event is a legacy anonymous duplicate also resolve. Deployers resolve to named Imbi users where their GitHub identity is linked; otherwise the raw GitHub login is shown. Workflows triggered by schedules or another bot keep the bot attribution. No schema changes; no UI codegen needed (the Maintenance page renders operations from the registry at runtime).

## Testing
- Full `apps/api` and `plugins/github` suites: 2,784 passed.
- New unit tests: webhook dedupe + run-URL persistence, append-only without a run id, committish-keyed backfill resolution in both views, bot/human/failure/case-insensitivity attribution paths, and 8 tests for the backfill operation (insert, skip-unattributed, dedupe rules, timestamp fidelity).
- Pre-commit (ruff, mypy) and basedpyright clean on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)