### PR TITLE
Fix ClickHouse schema setup on clustered deployments

### DIFF
--- a/apps/api/src/imbi/api/auth/seed.py
+++ b/apps/api/src/imbi/api/auth/seed.py
@@ -822,6 +822,37 @@ async def seed_default_organization(
     return is_new
 
 
+async def seed_permissions_and_roles(db: graph.Graph) -> dict[str, int]:
+    """Prune retired permissions, then seed permissions and default roles.
+
+    Organization-independent half of :func:`bootstrap_auth_system`, so a
+    deployment that only needs to pick up newly declared permissions can
+    run it without re-seeding an organization or touching users. The
+    call order is load-bearing: ``seed_default_roles`` MATCHes the
+    ``Permission`` nodes it grants, so ``seed_permissions`` must run
+    first or roles silently come up without their GRANTS edges.
+    Idempotent.
+
+    Args:
+        db: Graph database connection.
+
+    Returns:
+        dict with keys:
+            - 'retired': Number of retired permissions removed
+            - 'permissions': Number of permissions created
+            - 'roles': Number of roles created
+
+    """
+    retired = await cleanup_retired_permissions(db)
+    permissions_created = await seed_permissions(db)
+    roles_created = await seed_default_roles(db)
+    return {
+        'retired': retired,
+        'permissions': permissions_created,
+        'roles': roles_created,
+    }
+
+
 async def bootstrap_auth_system(
     db: graph.Graph,
     org_slug: str = 'default',
@@ -848,9 +879,9 @@ async def bootstrap_auth_system(
     LOGGER.info('Starting authentication system bootstrap')
 
     org_created = await seed_default_organization(db, org_slug, org_name)
-    await cleanup_retired_permissions(db)
-    permissions_created = await seed_permissions(db)
-    roles_created = await seed_default_roles(db)
+    seeded = await seed_permissions_and_roles(db)
+    permissions_created = seeded['permissions']
+    roles_created = seeded['roles']
 
     result: dict[str, int | bool] = {
         'organization': org_created,

--- a/apps/api/src/imbi/api/entrypoint.py
+++ b/apps/api/src/imbi/api/entrypoint.py
@@ -77,6 +77,80 @@ async def _backfill_integration_ids(db: graph.Graph) -> int:
     return count
 
 
+@main.command('setup-clickhouse')
+def setup_clickhouse() -> None:
+    """Apply the ClickHouse schema without running the full setup.
+
+    Executes the enabled DDL from the packaged ``schemata.toml`` — the
+    same work as step 3 of ``setup`` — so a deployment that adds tables
+    or materialized views can roll them out without re-seeding auth or
+    re-prompting for an admin user. Idempotent.
+    """
+    asyncio.run(_setup_clickhouse_async())
+
+
+async def _setup_clickhouse_async() -> None:
+    """Async body of ``setup-clickhouse``."""
+    try:
+        await clickhouse.initialize()
+    except Exception as e:
+        typer.echo(f'✗ Failed to connect to ClickHouse: {e}', err=True)
+        raise typer.Exit(code=1) from e
+
+    try:
+        await _apply_clickhouse_schema()
+    finally:
+        await clickhouse.aclose()
+
+
+async def _apply_clickhouse_schema() -> None:
+    """Execute the packaged ClickHouse DDL, reporting progress."""
+    try:
+        await clickhouse.setup_schema()
+        typer.echo('  ✓ ClickHouse schema created successfully')
+    except Exception as e:
+        typer.echo(f'✗ Failed to set up ClickHouse schema: {e}', err=True)
+        raise typer.Exit(code=1) from e
+
+
+@main.command('setup-permissions')
+def setup_permissions() -> None:
+    """Seed permissions and default roles without running the full setup.
+
+    Prunes retired permissions, then re-seeds the standard permissions
+    and default roles, refreshing each role's GRANTS edges. Use this to
+    roll out permissions added by a release without re-seeding an
+    organization or touching the admin user. Idempotent.
+    """
+    asyncio.run(_setup_permissions_async())
+
+
+async def _setup_permissions_async() -> None:
+    """Async body of ``setup-permissions``."""
+    db = graph.Graph()
+    try:
+        await db.open()
+    except Exception as e:
+        typer.echo(f'✗ Failed to connect to PostgreSQL: {e}', err=True)
+        raise typer.Exit(code=1) from e
+
+    try:
+        result = await seed.seed_permissions_and_roles(db)
+    except Exception as e:
+        typer.echo(f'✗ Failed to seed permissions and roles: {e}', err=True)
+        raise typer.Exit(code=1) from e
+    finally:
+        await db.close()
+
+    if result['retired']:
+        typer.echo(f'  ✓ Removed {result["retired"]} retired permission(s)')
+    typer.echo(
+        f'  ✓ Created {result["permissions"]} permission(s) '
+        f'and {result["roles"]} role(s)'
+    )
+    typer.echo('\n✓ Permissions and roles are up to date')
+
+
 @main.command()
 def setup() -> None:
     """
@@ -195,15 +269,7 @@ async def _setup_async() -> None:
 
         # Step 3: Set up ClickHouse schema
         typer.echo('\nStep 3: Setting up ClickHouse schema...')
-        try:
-            await clickhouse.setup_schema()
-            typer.echo('  ✓ ClickHouse schema created successfully')
-        except Exception as e:
-            typer.echo(
-                f'✗ Failed to set up ClickHouse schema: {e}',
-                err=True,
-            )
-            raise typer.Exit(code=1) from e
+        await _apply_clickhouse_schema()
 
         # Success message
         typer.echo('\n✓ Setup complete!')

--- a/apps/api/src/imbi/api/entrypoint.py
+++ b/apps/api/src/imbi/api/entrypoint.py
@@ -92,10 +92,16 @@ def setup_clickhouse() -> None:
 async def _setup_clickhouse_async() -> None:
     """Async body of ``setup-clickhouse``."""
     try:
-        await clickhouse.initialize()
+        connected = await clickhouse.initialize()
     except Exception as e:
         typer.echo(f'✗ Failed to connect to ClickHouse: {e}', err=True)
         raise typer.Exit(code=1) from e
+    if not connected:
+        typer.echo(
+            '✗ Failed to connect to ClickHouse: connection attempts exhausted',
+            err=True,
+        )
+        raise typer.Exit(code=1)
 
     try:
         await _apply_clickhouse_schema()
@@ -144,10 +150,15 @@ async def _setup_permissions_async() -> None:
 
     if result['retired']:
         typer.echo(f'  ✓ Removed {result["retired"]} retired permission(s)')
-    typer.echo(
-        f'  ✓ Created {result["permissions"]} permission(s) '
-        f'and {result["roles"]} role(s)'
-    )
+    if result['permissions'] or result['roles']:
+        typer.echo(
+            f'  ✓ Created {result["permissions"]} permission(s) '
+            f'and {result["roles"]} role(s)'
+        )
+    else:
+        typer.echo(
+            '  ✓ Permissions and roles already exist (no new entities created)'
+        )
     typer.echo('\n✓ Permissions and roles are up to date')
 
 
@@ -179,11 +190,18 @@ async def _setup_async() -> None:
 
     # Initialize ClickHouse connection
     try:
-        await clickhouse.initialize()
+        connected = await clickhouse.initialize()
     except Exception as e:
         typer.echo(f'✗ Failed to connect to ClickHouse: {e}', err=True)
         await db.close()
         raise typer.Exit(code=1) from e
+    if not connected:
+        typer.echo(
+            '✗ Failed to connect to ClickHouse: connection attempts exhausted',
+            err=True,
+        )
+        await db.close()
+        raise typer.Exit(code=1)
 
     try:
         # Check if system is already set up

--- a/apps/api/tests/clickhouse/test_client.py
+++ b/apps/api/tests/clickhouse/test_client.py
@@ -84,13 +84,15 @@ class ClickhouseClientTestCase(unittest.IsolatedAsyncioTestCase):
         with mock.patch.object(
             ch, '_load_schemata_queries', return_value=mock_queries
         ):
-            with mock.patch.object(ch, 'query', return_value=[]) as mock_query:
+            with mock.patch.object(
+                ch, 'command', return_value=None
+            ) as mock_command:
                 await ch.setup_schema()
 
                 # Only enabled queries should be executed
-                self.assertEqual(mock_query.call_count, 2)
-                mock_query.assert_any_call('CREATE TABLE test1')
-                mock_query.assert_any_call('CREATE TABLE test3')
+                self.assertEqual(mock_command.call_count, 2)
+                mock_command.assert_any_call('CREATE TABLE test1')
+                mock_command.assert_any_call('CREATE TABLE test3')
 
     async def test_initialize_connection_failure(self) -> None:
         """Test initialization with connection failure after retries."""
@@ -424,13 +426,15 @@ class ClickhouseClientTestCase(unittest.IsolatedAsyncioTestCase):
         with mock.patch.object(
             ch, '_load_schemata_queries', return_value=mock_queries
         ):
-            with mock.patch.object(ch, 'query', return_value=[]) as mock_query:
+            with mock.patch.object(
+                ch, 'command', return_value=None
+            ) as mock_command:
                 await ch._execute_schemata_queries()
 
                 # Only enabled queries should be executed
-                self.assertEqual(mock_query.call_count, 2)
-                mock_query.assert_any_call('SELECT 1')
-                mock_query.assert_any_call('SELECT 3')
+                self.assertEqual(mock_command.call_count, 2)
+                mock_command.assert_any_call('SELECT 1')
+                mock_command.assert_any_call('SELECT 3')
 
     async def test_execute_schemata_queries_with_error(self) -> None:
         """Test executing schemata queries continues on error."""
@@ -451,18 +455,18 @@ class ClickhouseClientTestCase(unittest.IsolatedAsyncioTestCase):
         with mock.patch.object(
             ch, '_load_schemata_queries', return_value=mock_queries
         ):
-            with mock.patch.object(ch, 'query') as mock_query:
+            with mock.patch.object(ch, 'command') as mock_command:
                 # Second query fails
-                mock_query.side_effect = [
-                    [],
+                mock_command.side_effect = [
+                    None,
                     client.DatabaseError('SQL error'),
-                    [],
+                    None,
                 ]
 
                 # Should not raise, should continue with remaining queries
                 await ch._execute_schemata_queries()
 
-                self.assertEqual(mock_query.call_count, 3)
+                self.assertEqual(mock_command.call_count, 3)
 
     async def test_execute_schemata_queries_with_error_and_sentry(
         self,
@@ -480,8 +484,8 @@ class ClickhouseClientTestCase(unittest.IsolatedAsyncioTestCase):
         with mock.patch.object(
             ch, '_load_schemata_queries', return_value=mock_queries
         ):
-            with mock.patch.object(ch, 'query') as mock_query:
-                mock_query.side_effect = client.DatabaseError('SQL error')
+            with mock.patch.object(ch, 'command') as mock_command:
+                mock_command.side_effect = client.DatabaseError('SQL error')
 
                 with mock.patch(
                     'imbi.common.clickhouse.client.sentry_sdk', mock_sentry
@@ -495,7 +499,7 @@ class ClickhouseClientTestCase(unittest.IsolatedAsyncioTestCase):
         ch = client.Clickhouse.get_instance()
 
         with mock.patch.object(ch, '_load_schemata_queries', return_value=[]):
-            with mock.patch.object(ch, 'query') as mock_query:
+            with mock.patch.object(ch, 'command') as mock_command:
                 await ch._execute_schemata_queries()
 
-                mock_query.assert_not_called()
+                mock_command.assert_not_called()

--- a/apps/api/tests/test_entrypoint.py
+++ b/apps/api/tests/test_entrypoint.py
@@ -265,6 +265,161 @@ class SetupTestCase(unittest.TestCase):
         self.mock_ch_close.assert_awaited_once()
 
 
+class SetupClickhouseTestCase(unittest.TestCase):
+    """Test cases for the ``setup-clickhouse`` command.
+
+    Uses regular TestCase because the command calls asyncio.run() which
+    creates its own event loop.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.runner = typer.testing.CliRunner()
+        self.mock_graph_cls = self.enterContext(
+            mock.patch.object(entrypoint.graph, 'Graph')
+        )
+        self.mock_ch_init = self.enterContext(
+            mock.patch.object(
+                entrypoint.clickhouse,
+                'initialize',
+                new_callable=mock.AsyncMock,
+            )
+        )
+        self.mock_ch_close = self.enterContext(
+            mock.patch.object(
+                entrypoint.clickhouse, 'aclose', new_callable=mock.AsyncMock
+            )
+        )
+        self.mock_ch_schema = self.enterContext(
+            mock.patch.object(
+                entrypoint.clickhouse,
+                'setup_schema',
+                new_callable=mock.AsyncMock,
+            )
+        )
+
+    def test_applies_schema(self) -> None:
+        """The schema is applied and the connection closed."""
+        result = self.runner.invoke(entrypoint.main, ['setup-clickhouse'])
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn('ClickHouse schema created', result.output)
+        self.mock_ch_schema.assert_awaited_once()
+        self.mock_ch_close.assert_awaited_once()
+
+    def test_does_not_touch_postgres_or_prompt(self) -> None:
+        """No graph connection is opened and no input is requested."""
+        result = self.runner.invoke(entrypoint.main, ['setup-clickhouse'])
+
+        self.assertEqual(result.exit_code, 0)
+        self.mock_graph_cls.assert_not_called()
+
+    def test_connection_failure(self) -> None:
+        """A ClickHouse connection failure exits non-zero."""
+        self.mock_ch_init.side_effect = ConnectionError('refused')
+
+        result = self.runner.invoke(entrypoint.main, ['setup-clickhouse'])
+
+        self.assertEqual(result.exit_code, 1)
+        self.assertIn('Failed to connect to ClickHouse', result.output)
+        self.mock_ch_schema.assert_not_awaited()
+
+    def test_schema_failure_closes_connection(self) -> None:
+        """A schema failure exits non-zero and still closes the client."""
+        self.mock_ch_schema.side_effect = RuntimeError('schema error')
+
+        result = self.runner.invoke(entrypoint.main, ['setup-clickhouse'])
+
+        self.assertEqual(result.exit_code, 1)
+        self.assertIn('Failed to set up ClickHouse schema', result.output)
+        self.mock_ch_close.assert_awaited_once()
+
+
+class SetupPermissionsTestCase(unittest.TestCase):
+    """Test cases for the ``setup-permissions`` command.
+
+    Uses regular TestCase because the command calls asyncio.run() which
+    creates its own event loop.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.runner = typer.testing.CliRunner()
+        self.mock_graph = mock.MagicMock()
+        self.mock_graph.open = mock.AsyncMock()
+        self.mock_graph.close = mock.AsyncMock()
+        self.enterContext(
+            mock.patch.object(
+                entrypoint.graph, 'Graph', return_value=self.mock_graph
+            )
+        )
+        self.mock_ch_init = self.enterContext(
+            mock.patch.object(
+                entrypoint.clickhouse,
+                'initialize',
+                new_callable=mock.AsyncMock,
+            )
+        )
+        self.mock_seed = self.enterContext(
+            mock.patch.object(
+                entrypoint.seed,
+                'seed_permissions_and_roles',
+                new_callable=mock.AsyncMock,
+                return_value={'retired': 0, 'permissions': 4, 'roles': 3},
+            )
+        )
+
+    def test_seeds_permissions_and_roles(self) -> None:
+        """Permissions and roles are seeded and the connection closed."""
+        result = self.runner.invoke(entrypoint.main, ['setup-permissions'])
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn('Created 4 permission(s) and 3 role(s)', result.output)
+        self.assertIn('up to date', result.output)
+        self.mock_seed.assert_awaited_once_with(self.mock_graph)
+        self.mock_graph.close.assert_awaited_once()
+
+    def test_reports_retired_permissions(self) -> None:
+        """Retired permissions are reported when any were removed."""
+        self.mock_seed.return_value = {
+            'retired': 2,
+            'permissions': 0,
+            'roles': 0,
+        }
+
+        result = self.runner.invoke(entrypoint.main, ['setup-permissions'])
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn('Removed 2 retired permission(s)', result.output)
+
+    def test_does_not_touch_clickhouse_or_prompt(self) -> None:
+        """No ClickHouse connection is opened and no input is requested."""
+        result = self.runner.invoke(entrypoint.main, ['setup-permissions'])
+
+        self.assertEqual(result.exit_code, 0)
+        self.mock_ch_init.assert_not_awaited()
+
+    def test_graph_connection_failure(self) -> None:
+        """A PostgreSQL connection failure exits non-zero."""
+        self.mock_graph.open.side_effect = ConnectionError('refused')
+
+        result = self.runner.invoke(entrypoint.main, ['setup-permissions'])
+
+        self.assertEqual(result.exit_code, 1)
+        self.assertIn('Failed to connect to PostgreSQL', result.output)
+        self.mock_seed.assert_not_awaited()
+
+    def test_seed_failure_closes_connection(self) -> None:
+        """A seeding failure exits non-zero and still closes the graph."""
+        self.mock_seed.side_effect = RuntimeError('boom')
+
+        result = self.runner.invoke(entrypoint.main, ['setup-permissions'])
+
+        self.assertEqual(result.exit_code, 1)
+        self.assertIn('Failed to seed permissions and roles', result.output)
+        self.mock_graph.close.assert_awaited_once()
+
+
 class BackfillNodeIdsTestCase(unittest.TestCase):
     """Test cases for the ``backfill-node-ids`` command (#291).
 

--- a/apps/api/tests/test_entrypoint.py
+++ b/apps/api/tests/test_entrypoint.py
@@ -214,6 +214,16 @@ class SetupTestCase(unittest.TestCase):
         self.assertIn('Failed to connect to ClickHouse', result.output)
         self.mock_graph.close.assert_awaited_once()
 
+    def test_setup_clickhouse_connection_attempts_exhausted(self) -> None:
+        """Test setup when initialize() returns False without raising."""
+        self.mock_ch_init.return_value = False
+
+        result = self.runner.invoke(entrypoint.main, ['setup'])
+
+        self.assertEqual(result.exit_code, 1)
+        self.assertIn('Failed to connect to ClickHouse', result.output)
+        self.mock_graph.close.assert_awaited_once()
+
     def test_setup_empty_password(self) -> None:
         """Test setup rejects empty password."""
         self.mock_getpass.return_value = ''
@@ -324,6 +334,21 @@ class SetupClickhouseTestCase(unittest.TestCase):
         self.assertIn('Failed to connect to ClickHouse', result.output)
         self.mock_ch_schema.assert_not_awaited()
 
+    def test_exhausted_connection_attempts(self) -> None:
+        """A falsy initialize() result exits non-zero without the DDL.
+
+        ``initialize()`` returns False rather than raising once the
+        connect retries are exhausted, so the boolean has to be checked
+        or the schema step reports a misleading error instead.
+        """
+        self.mock_ch_init.return_value = False
+
+        result = self.runner.invoke(entrypoint.main, ['setup-clickhouse'])
+
+        self.assertEqual(result.exit_code, 1)
+        self.assertIn('Failed to connect to ClickHouse', result.output)
+        self.mock_ch_schema.assert_not_awaited()
+
     def test_schema_failure_closes_connection(self) -> None:
         """A schema failure exits non-zero and still closes the client."""
         self.mock_ch_schema.side_effect = RuntimeError('schema error')
@@ -391,6 +416,20 @@ class SetupPermissionsTestCase(unittest.TestCase):
 
         self.assertEqual(result.exit_code, 0)
         self.assertIn('Removed 2 retired permission(s)', result.output)
+
+    def test_reports_no_new_entities(self) -> None:
+        """A no-op re-run says so instead of reporting zero counts."""
+        self.mock_seed.return_value = {
+            'retired': 0,
+            'permissions': 0,
+            'roles': 0,
+        }
+
+        result = self.runner.invoke(entrypoint.main, ['setup-permissions'])
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn('already exist', result.output)
+        self.assertNotIn('Created 0 permission(s)', result.output)
 
     def test_does_not_touch_clickhouse_or_prompt(self) -> None:
         """No ClickHouse connection is opened and no input is requested."""

--- a/docs/getting-started/setup.md
+++ b/docs/getting-started/setup.md
@@ -40,9 +40,27 @@ The setup command performs the following:
    roles with appropriate permissions
 3. **Creates the admin user** - Interactively prompts for email, display
    name, and password
+4. **Creates the ClickHouse schema** - Executes the DDL for the analytics
+   tables and materialized views
 
 The setup command is idempotent: it checks whether the system has already
 been seeded before making changes, so it is safe to run multiple times.
+
+## Applying Upgrades
+
+`setup` is interactive and covers everything, which is more than an
+existing instance needs when a release only adds ClickHouse tables or new
+permissions. Two commands run those steps on their own, without prompting
+or touching the admin user:
+
+```bash
+imbi-api setup-clickhouse    # apply the ClickHouse schema only
+imbi-api setup-permissions   # seed permissions and default roles only
+```
+
+Both are idempotent and safe to re-run. `setup-permissions` also refreshes
+each default role's permission grants and prunes permissions retired by a
+previous release.
 
 ## Post-Setup
 

--- a/libraries/common/src/imbi/common/clickhouse/client.py
+++ b/libraries/common/src/imbi/common/clickhouse/client.py
@@ -154,6 +154,29 @@ class Clickhouse:
                 table, data, column_names=column_names
             )
 
+    async def command(
+        self, statement: str, parameters: dict[str, typing.Any] | None = None
+    ) -> None:
+        """Execute a DDL/DML statement, ignoring any response body.
+
+        Use this rather than :meth:`query` for DDL. The driver's
+        ``query()`` wraps a command response in a ``QueryResult`` carrying
+        *empty* ``column_names``, so :meth:`query`'s strict
+        ``zip(column_names, row)`` raises as soon as the response body is
+        non-empty. Single-node ``CREATE`` returns an empty body and slips
+        through, but the same DDL rendered ``ON CLUSTER`` returns a
+        per-host status row and blows up.
+        """
+        if not self._clickhouse:
+            await self.initialize()
+        if not self._clickhouse:
+            raise RuntimeError('Failed to initialize ClickHouse client')
+        LOGGER.debug('Clickhouse COMMAND: %s', statement)
+        with _translate_errors('command'):
+            await self._clickhouse.command(
+                statement, parameters=parameters or {}
+            )
+
     async def query(
         self, statement: str, parameters: dict[str, typing.Any] | None = None
     ) -> list[dict[str, typing.Any]]:
@@ -276,7 +299,7 @@ class Clickhouse:
                 query_obj.query, cluster_name
             )
             try:
-                await self.query(statement)
+                await self.command(statement)
                 LOGGER.debug(
                     'Successfully executed schemata query: %s', query_obj.name
                 )

--- a/libraries/common/tests/clickhouse/test_client.py
+++ b/libraries/common/tests/clickhouse/test_client.py
@@ -262,13 +262,15 @@ class ClickhouseClientTestCase(unittest.IsolatedAsyncioTestCase):
         with mock.patch.object(
             ch, '_load_schemata_queries', return_value=mock_queries
         ):
-            with mock.patch.object(ch, 'query', return_value=[]) as mock_query:
+            with mock.patch.object(
+                ch, 'command', return_value=None
+            ) as mock_command:
                 await ch.setup_schema()
 
                 # Only enabled queries should be executed
-                self.assertEqual(mock_query.call_count, 2)
-                mock_query.assert_any_call('CREATE TABLE test1')
-                mock_query.assert_any_call('CREATE TABLE test3')
+                self.assertEqual(mock_command.call_count, 2)
+                mock_command.assert_any_call('CREATE TABLE test1')
+                mock_command.assert_any_call('CREATE TABLE test3')
 
     async def test_initialize_connection_failure(self) -> None:
         """Test initialization with connection failure after retries."""
@@ -494,6 +496,39 @@ class ClickhouseClientTestCase(unittest.IsolatedAsyncioTestCase):
 
         mock_sentry.capture_exception.assert_called_once()
 
+    async def test_command_executes_without_parsing_rows(self) -> None:
+        """command() runs DDL without mapping result rows to columns."""
+        ch = client.Clickhouse.get_instance()
+
+        with mock.patch.object(
+            ch, '_execute_schemata_queries', return_value=None
+        ):
+            await ch.initialize()
+
+        await ch.command('CREATE TABLE test ON CLUSTER c (id UInt32)')
+
+        self.mock_client.command.assert_called_once_with(
+            'CREATE TABLE test ON CLUSTER c (id UInt32)', parameters={}
+        )
+
+    async def test_command_database_error(self) -> None:
+        """command() translates driver errors into DatabaseError."""
+        ch = client.Clickhouse.get_instance()
+
+        self.mock_client.command.side_effect = exceptions.DatabaseError(
+            'Command failed'
+        )
+
+        with mock.patch.object(
+            ch, '_execute_schemata_queries', return_value=None
+        ):
+            await ch.initialize()
+
+        with self.assertRaises(client.DatabaseError) as cm:
+            await ch.command('CREATE TABLE test (id UInt32)')
+
+        self.assertIn('Command failed', str(cm.exception))
+
     async def test_connect_success(self) -> None:
         """Test successful connection."""
         ch = client.Clickhouse.get_instance()
@@ -636,13 +671,15 @@ class ClickhouseClientTestCase(unittest.IsolatedAsyncioTestCase):
         with mock.patch.object(
             ch, '_load_schemata_queries', return_value=mock_queries
         ):
-            with mock.patch.object(ch, 'query', return_value=[]) as mock_query:
+            with mock.patch.object(
+                ch, 'command', return_value=None
+            ) as mock_command:
                 await ch._execute_schemata_queries()
 
                 # Only enabled queries should be executed
-                self.assertEqual(mock_query.call_count, 2)
-                mock_query.assert_any_call('SELECT 1')
-                mock_query.assert_any_call('SELECT 3')
+                self.assertEqual(mock_command.call_count, 2)
+                mock_command.assert_any_call('SELECT 1')
+                mock_command.assert_any_call('SELECT 3')
 
     async def test_execute_schemata_queries_with_error(self) -> None:
         """Test executing schemata queries continues on error."""
@@ -663,18 +700,18 @@ class ClickhouseClientTestCase(unittest.IsolatedAsyncioTestCase):
         with mock.patch.object(
             ch, '_load_schemata_queries', return_value=mock_queries
         ):
-            with mock.patch.object(ch, 'query') as mock_query:
+            with mock.patch.object(ch, 'command') as mock_command:
                 # Second query fails
-                mock_query.side_effect = [
-                    [],
+                mock_command.side_effect = [
+                    None,
                     client.DatabaseError('SQL error'),
-                    [],
+                    None,
                 ]
 
                 # Should not raise, should continue with remaining queries
                 await ch._execute_schemata_queries()
 
-                self.assertEqual(mock_query.call_count, 3)
+                self.assertEqual(mock_command.call_count, 3)
 
     async def test_execute_schemata_queries_with_error_and_sentry(
         self,
@@ -692,8 +729,8 @@ class ClickhouseClientTestCase(unittest.IsolatedAsyncioTestCase):
         with mock.patch.object(
             ch, '_load_schemata_queries', return_value=mock_queries
         ):
-            with mock.patch.object(ch, 'query') as mock_query:
-                mock_query.side_effect = client.DatabaseError('SQL error')
+            with mock.patch.object(ch, 'command') as mock_command:
+                mock_command.side_effect = client.DatabaseError('SQL error')
 
                 with mock.patch(
                     'imbi.common.clickhouse.client.sentry_sdk', mock_sentry
@@ -707,10 +744,10 @@ class ClickhouseClientTestCase(unittest.IsolatedAsyncioTestCase):
         ch = client.Clickhouse.get_instance()
 
         with mock.patch.object(ch, '_load_schemata_queries', return_value=[]):
-            with mock.patch.object(ch, 'query') as mock_query:
+            with mock.patch.object(ch, 'command') as mock_command:
                 await ch._execute_schemata_queries()
 
-                mock_query.assert_not_called()
+                mock_command.assert_not_called()
 
     async def test_execute_schemata_queries_without_cluster(self) -> None:
         """Without a cluster name, the placeholder is removed."""
@@ -726,10 +763,12 @@ class ClickhouseClientTestCase(unittest.IsolatedAsyncioTestCase):
         with mock.patch.object(
             ch, '_load_schemata_queries', return_value=mock_queries
         ):
-            with mock.patch.object(ch, 'query', return_value=[]) as mock_query:
+            with mock.patch.object(
+                ch, 'command', return_value=None
+            ) as mock_command:
                 await ch._execute_schemata_queries()
 
-        mock_query.assert_called_once_with('CREATE TABLE imbi.t (id String)')
+        mock_command.assert_called_once_with('CREATE TABLE imbi.t (id String)')
 
     async def test_execute_schemata_queries_with_cluster(self) -> None:
         """With a cluster name, ON CLUSTER replaces the placeholder."""
@@ -745,10 +784,12 @@ class ClickhouseClientTestCase(unittest.IsolatedAsyncioTestCase):
         with mock.patch.object(
             ch, '_load_schemata_queries', return_value=mock_queries
         ):
-            with mock.patch.object(ch, 'query', return_value=[]) as mock_query:
+            with mock.patch.object(
+                ch, 'command', return_value=None
+            ) as mock_command:
                 await ch._execute_schemata_queries()
 
-        mock_query.assert_called_once_with(
+        mock_command.assert_called_once_with(
             'CREATE TABLE imbi.t ON CLUSTER prod (id String)'
         )
 


### PR DESCRIPTION
## Summary

Fixes ClickHouse schema setup failing on any deployment with
`CLICKHOUSE_CLUSTER_NAME` set, and adds two targeted setup commands so an
existing instance can pick up a release without re-running interactive setup.

## Problem

Setting up the new ClickHouse tables in production failed:

```
Step 3: Setting up ClickHouse schema...
✗ Failed to set up ClickHouse schema: zip() argument 2 is longer than argument 1
```

The DDL from `schemata.toml` was executed through `Clickhouse.query()`, which
maps result rows to columns with a strict zip:

```python
data = dict(zip(result.column_names, row, strict=True))
```

The driver's `query()` delegates to `command()` for DDL and wraps the response
in a `QueryResult` carrying **empty** `column_names`, so the strict zip raises
as soon as the response body is non-empty. Single-node `CREATE` returns an
empty body and slipped through, which is why this never surfaced in dev — but
the same DDL rendered `ON CLUSTER` returns a per-host status row and broke.
Reproduced against the real driver, yielding the exact production error.

Separately, rolling out schema or permission changes to an existing instance
meant running the full interactive `setup`, which also prompts for an
organization and an admin user.

## Solution

DDL has no business going through the SELECT row-parsing path, so add
`Clickhouse.command()` wrapping the driver's own `command()` and execute the
schemata statements through it. `query()` keeps its strict zip for actual
SELECTs.

Two new commands cover the individual setup steps:

```bash
imbi-api setup-clickhouse    # apply the ClickHouse schema only
imbi-api setup-permissions   # seed permissions and default roles only
```

`setup-permissions` is backed by `seed_permissions_and_roles()`, extracted from
`bootstrap_auth_system()` so the load-bearing permissions-before-roles ordering
stays in one place rather than being duplicated. `setup` now shares the
ClickHouse schema step with the new command instead of inlining it.

## Verification

- Full workspace suite: 4793 passed.
- `moon run :lint :typecheck :format`: 43 tasks, 0 errors.
- Both new commands run against live backing services, and are idempotent on
  re-run (second `setup-permissions` reported 0 created).
- Reproduced the original `zip()` failure through the old `query()` path and
  confirmed the new `command()` path succeeds on the same statement.

Note: the `ON CLUSTER` path itself could not be exercised end-to-end locally —
a single node has no Keeper, so the real DDL is rejected before responding. The
fix does not depend on the cluster response shape, since routing DDL through
`command()` bypasses row parsing entirely.

## Docs

The setup docs listed only 3 of `setup`'s 4 steps, omitting ClickHouse — now
documented, along with an upgrade section covering the new commands.
