### PR TITLE
Gate lifecycle credentials on manifest credential fields

### DIFF
--- a/apps/api/src/imbi/api/plugins/lifecycle_dispatch.py
+++ b/apps/api/src/imbi/api/plugins/lifecycle_dispatch.py
@@ -353,17 +353,33 @@ def _resolve_credentials(
     account PAT).  Raises :class:`PluginCredentialsMissing` when
     neither is available so the dispatcher surfaces a clear ``failed``
     invocation.
+
+    The blob is validated against the plugin manifest's *required*
+    :class:`CredentialField` names rather than a fixed
+    ``access_token``/``token`` pair -- api-token plugins name their
+    field differently (PagerDuty ``api_key``, Logz.io ``api_token``)
+    and were being rejected despite being fully configured.
     """
     if ctx.identity is not None and ctx.identity.access_token:
         return {'access_token': ctx.identity.access_token}
     credentials = decrypt_integration_credentials(
         resolved.encrypted_credentials
     )
-    if not credentials.get('access_token') and not credentials.get('token'):
+    required = [
+        field.name
+        for field in resolved.entry.manifest.credentials
+        if field.required
+    ]
+    missing = [name for name in required if not credentials.get(name)]
+    if not credentials or missing:
+        detail = (
+            f'missing {", ".join(missing)}'
+            if missing
+            else 'bind an identity or configure a service-account token'
+        )
         raise PluginCredentialsMissing(
             f'No credentials available for plugin '
-            f'{resolved.plugin_slug!r}: bind an identity or configure '
-            f'a service-account token.'
+            f'{resolved.plugin_slug!r}: {detail}.'
         )
     return credentials
 

--- a/apps/api/tests/test_lifecycle_dispatch.py
+++ b/apps/api/tests/test_lifecycle_dispatch.py
@@ -16,6 +16,7 @@ from imbi.api.plugins.lifecycle_dispatch import (
     LifecycleContextBundle,
     LifecycleEvent,
     LifecycleInvocation,
+    _resolve_credentials,
     build_lifecycle_context_bundle,
     dispatch_lifecycle,
 )
@@ -23,6 +24,7 @@ from imbi.api.plugins.resolution import ResolvedCapability
 from imbi.common.plugins.base import (
     Capability,
     ConfigurationCapability,
+    CredentialField,
     LifecycleCapability,
     LifecycleResult,
     LinkWriteback,
@@ -30,6 +32,7 @@ from imbi.common.plugins.base import (
     PluginManifest,
     ServiceWriteback,
 )
+from imbi.common.plugins.errors import PluginCredentialsMissing
 from imbi.common.plugins.registry import RegistryEntry
 
 
@@ -406,6 +409,67 @@ async def _passthrough_identity_retry(
     """Stub that skips identity hydration entirely."""
     del db, resolved, auth, identity_options, attached
     return await fn(ctx)
+
+
+class ResolveCredentialsTestCase(unittest.TestCase):
+    """Credential gating honors the manifest's declared field names."""
+
+    @staticmethod
+    def _resolved_with(
+        credential_fields: list[CredentialField],
+    ) -> ResolvedCapability:
+        class _Handler(LifecycleCapability):
+            async def on_project_archived(self, ctx, credentials):  # type: ignore[override]
+                return LifecycleResult(status='ok')
+
+        entry = _entry('pd', _Handler)
+        entry.manifest.credentials = credential_fields
+        return _resolved(entry)
+
+    @staticmethod
+    def _call(
+        resolved: ResolvedCapability, blob: dict[str, str]
+    ) -> dict[str, str]:
+        ctx = PluginContext(
+            project_id='proj-1', project_slug='p', org_slug='o'
+        )
+        with mock.patch(
+            'imbi.api.plugins.lifecycle_dispatch'
+            '.decrypt_integration_credentials',
+            return_value=blob,
+        ):
+            return _resolve_credentials(ctx, resolved)
+
+    def test_api_key_credential_is_accepted(self) -> None:
+        resolved = self._resolved_with(
+            [CredentialField(name='api_key', label='API key')]
+        )
+        self.assertEqual(
+            self._call(resolved, {'api_key': 'secret'}), {'api_key': 'secret'}
+        )
+
+    def test_missing_required_field_names_the_field(self) -> None:
+        resolved = self._resolved_with(
+            [CredentialField(name='api_key', label='API key')]
+        )
+        with self.assertRaises(PluginCredentialsMissing) as ctx:
+            self._call(resolved, {'other': 'x'})
+        self.assertIn('missing api_key', str(ctx.exception))
+
+    def test_empty_blob_is_rejected_without_required_fields(self) -> None:
+        resolved = self._resolved_with(
+            [CredentialField(name='access_token', label='PAT', required=False)]
+        )
+        with self.assertRaises(PluginCredentialsMissing):
+            self._call(resolved, {})
+
+    def test_optional_fields_only_accepts_any_populated_blob(self) -> None:
+        resolved = self._resolved_with(
+            [CredentialField(name='app_id', label='App ID', required=False)]
+        )
+        self.assertEqual(
+            self._call(resolved, {'app_id': '1'}), {'app_id': '1'}
+        )
 
 
 class LifecycleInvocationSerializationTestCase(unittest.TestCase):

--- a/apps/api/tests/test_lifecycle_dispatch.py
+++ b/apps/api/tests/test_lifecycle_dispatch.py
@@ -419,7 +419,10 @@ class ResolveCredentialsTestCase(unittest.TestCase):
         credential_fields: list[CredentialField],
     ) -> ResolvedCapability:
         class _Handler(LifecycleCapability):
-            async def on_project_archived(self, ctx, credentials):  # type: ignore[override]
+            async def on_project_archived(
+                self, ctx: PluginContext, credentials: dict[str, str]
+            ) -> LifecycleResult:
+                del ctx, credentials
                 return LifecycleResult(status='ok')
 
         entry = _entry('pd', _Handler)

--- a/apps/api/tests/test_lifecycle_dispatch.py
+++ b/apps/api/tests/test_lifecycle_dispatch.py
@@ -74,7 +74,9 @@ def _make_lifecycle_entry(
     """
 
     class _FakeLifecycle(LifecycleCapability):
-        async def on_project_archived(self, ctx, credentials):  # type: ignore[override]
+        async def on_project_archived(
+            self, ctx: PluginContext, credentials: dict[str, str]
+        ) -> LifecycleResult:
             if archive_raises is not None:
                 raise archive_raises('archive boom')
             return LifecycleResult(
@@ -86,7 +88,9 @@ def _make_lifecycle_entry(
     if unarchive_raises is not None:
         _exc = unarchive_raises
 
-        async def _on_unarchived(self, ctx, credentials):  # type: ignore[no-untyped-def]
+        async def _on_unarchived(
+            self, ctx: PluginContext, credentials: dict[str, str]
+        ) -> LifecycleResult:
             raise _exc('unarchive boom')
 
         _FakeLifecycle.on_project_unarchived = _on_unarchived  # type: ignore[method-assign]
@@ -198,7 +202,9 @@ class DispatchLifecycleTestCase(unittest.TestCase):
         # A lifecycle plugin that reports a link writeback on ctx
         # triggers a persist of the stored link via update_project_link.
         class _Reloc(LifecycleCapability):
-            async def on_project_archived(self, ctx, credentials):  # type: ignore[override]
+            async def on_project_archived(
+                self, ctx: PluginContext, credentials: dict[str, str]
+            ) -> LifecycleResult:
                 ctx.link_writeback = LinkWriteback(
                     link_key='github-repository',
                     new_url='https://github.com/octo/renamed',
@@ -226,7 +232,9 @@ class DispatchLifecycleTestCase(unittest.TestCase):
         # triggers an EXISTS_IN upsert + dashboard-link merge against the
         # integration it is bound to (ctx.integration_slug).
         class _Svc(LifecycleCapability):
-            async def on_project_archived(self, ctx, credentials):  # type: ignore[override]
+            async def on_project_archived(
+                self, ctx: PluginContext, credentials: dict[str, str]
+            ) -> LifecycleResult:
                 ctx.service_writeback = ServiceWriteback(
                     identifier='134741',
                     canonical_url='https://api.x.ghe.com/repositories/134741',
@@ -266,7 +274,9 @@ class DispatchLifecycleTestCase(unittest.TestCase):
 
     def test_service_writeback_remove_deletes_edge(self) -> None:
         class _Svc(LifecycleCapability):
-            async def on_project_archived(self, ctx, credentials):  # type: ignore[override]
+            async def on_project_archived(
+                self, ctx: PluginContext, credentials: dict[str, str]
+            ) -> LifecycleResult:
                 ctx.service_writeback = ServiceWriteback(
                     identifier='1',
                     canonical_url='https://api.x/1',
@@ -337,9 +347,9 @@ class DispatchLifecycleTestCase(unittest.TestCase):
 
     def test_http_exception_surfaces_failed(self) -> None:
         class _Raises(LifecycleCapability):
-            async def on_project_archived(  # type: ignore[override]
-                self, ctx, credentials
-            ):
+            async def on_project_archived(
+                self, ctx: PluginContext, credentials: dict[str, str]
+            ) -> LifecycleResult:
                 raise fastapi.HTTPException(
                     status_code=401,
                     detail={
@@ -512,7 +522,9 @@ class WidenedEventNotImplementedTestCase(unittest.TestCase):
         self, event: LifecycleEvent
     ) -> LifecycleInvocation:
         class _Bare(LifecycleCapability):
-            async def on_project_archived(self, ctx, credentials):  # type: ignore[override]
+            async def on_project_archived(
+                self, ctx: PluginContext, credentials: dict[str, str]
+            ) -> LifecycleResult:
                 return LifecycleResult(status='ok')
 
         entry = _entry('bare', _Bare)
@@ -593,19 +605,27 @@ class BundleAndContextPropagationTestCase(unittest.TestCase):
         captured: dict[str, PluginContext] = {}
 
         class _Capture(LifecycleCapability):
-            async def on_project_created(self, ctx, credentials):  # type: ignore[override]
+            async def on_project_created(
+                self, ctx: PluginContext, credentials: dict[str, str]
+            ) -> LifecycleResult:
                 captured['ctx'] = ctx
                 return LifecycleResult(status='ok')
 
-            async def on_project_updated(self, ctx, credentials):  # type: ignore[override]
+            async def on_project_updated(
+                self, ctx: PluginContext, credentials: dict[str, str]
+            ) -> LifecycleResult:
                 captured['ctx'] = ctx
                 return LifecycleResult(status='ok')
 
-            async def on_project_deleted(self, ctx, credentials):  # type: ignore[override]
+            async def on_project_deleted(
+                self, ctx: PluginContext, credentials: dict[str, str]
+            ) -> LifecycleResult:
                 captured['ctx'] = ctx
                 return LifecycleResult(status='ok')
 
-            async def on_project_archived(self, ctx, credentials):  # type: ignore[override]
+            async def on_project_archived(
+                self, ctx: PluginContext, credentials: dict[str, str]
+            ) -> LifecycleResult:
                 return LifecycleResult(status='ok')
 
         entry = _entry('cap', _Capture)


### PR DESCRIPTION
## Summary

The lifecycle plugin dispatcher only accepted credential blobs keyed
`access_token` or `token`, so PagerDuty — which stores an `api_key` —
failed every project lifecycle event with a misleading "bind an identity"
message. The gate now reads the plugin manifest's required
`CredentialField` names.

## Problem

`_resolve_credentials()` in `apps/api/src/imbi/api/plugins/lifecycle_dispatch.py`
checked two hardcoded key names:

```python
if not credentials.get('access_token') and not credentials.get('token'):
    raise PluginCredentialsMissing(...)
```

PagerDuty declares its credential field as `api_key` and reads
`credentials['api_key']`, so a fully configured integration was rejected
before its handler ran. Observed in the ClickHouse lifecycle event log:

```
type:    plugin.lifecycle.deleted
integration: pagerduty
payload: {"message":"No credentials available for plugin 'pagerduty': bind
          an identity or configure a service-account token.","status":"failed"}
```

Nothing was actually preferring an identity provider — PagerDuty is
`auth_type='api_token'` with no identity capability, so the identity
branch above the check never fires. The gate was simply GitHub-shaped.

Two more integrations were latently broken the same way: Logz.io
(`api_token`) and any GitHub App-only integration (`app_id` /
`private_key` with no PAT). This is specific to lifecycle dispatch —
every other capability path (e.g. `project_incidents.py`) uses
`if not credentials:` and lets the plugin validate its own field names,
which is why the Incidents tab kept working while lifecycle sync failed.

## Solution

- Validate the decrypted blob against the manifest's required
  `CredentialField` names, and name the missing field in the error
  (`missing api_key`) so operators know what to fill in
- Keep an empty-blob rejection for plugins whose fields are all optional,
  matching the check the other capability call sites already use
- Add `ResolveCredentialsTestCase` covering api-key acceptance, the
  named-missing-field error, and both optional-field paths

Plugins still enforce their own credential shape — the GitHub lifecycle
handler raises when neither a PAT nor App credentials are present — so
this only removes a host-side gate no plugin outside GitHub could satisfy.

## Verification

`apps/api/tests/test_lifecycle_dispatch.py`: 25 passed. pre-commit (ruff +
mypy) and basedpyright clean on both files.

One thing worth confirming after deploy: this assumes the PagerDuty
integration does have an `api_key` stored. If the blob is genuinely
empty the event will now read `missing api_key` instead, which
distinguishes the two cases.
