### PR TITLE
Fix stale pre-v3 slugs in the GitHub plugin README

### DIFF
--- a/plugins/github/README.md
+++ b/plugins/github/README.md
@@ -125,9 +125,10 @@ per call, so an identity-only or App-only Integration is valid:
 | `client_id`       | `identity`         | OAuth App client id.                              |
 | `client_secret`   | `identity`         | OAuth App client secret.                          |
 
-For the service capabilities (commit-sync, pr-sync, deployment,
-lifecycle) provide **either** `access_token` **or** `app_id` +
-`private_key`.
+For `commit-sync`, `pr-sync`, and `deployment` provide **either**
+`access_token` **or** `app_id` + `private_key`. `lifecycle` acts as the
+user and takes only `access_token` (or `token`) — it does not fall back
+to GitHub App credentials.
 
 ## License
 

--- a/plugins/github/README.md
+++ b/plugins/github/README.md
@@ -1,17 +1,21 @@
 # imbi-plugin-github
 
-GitHub plugins for Imbi. Three flavors (github.com, GitHub Enterprise Cloud,
-GitHub Enterprise Server) of each plugin type so the admin UI can wire
-projects to the right backend.
+GitHub plugin for Imbi. A single plugin — slug **`github`** — backs every
+GitHub Integration; the integration-level `flavor` option selects
+github.com (`github`), GitHub Enterprise Cloud (`ghec`), or GitHub
+Enterprise Server (`ghes`), and `host` names the tenant or appliance.
 
-## Plugin types
+## Capabilities
 
-| Type       | Slugs                                                                |
-| ---------- | -------------------------------------------------------------------- |
-| Identity   | `github`, `github-enterprise-cloud`, `github-enterprise-server`      |
-| Deployment | `github-deployment`, `github-deployment-ec`, `github-deployment-es`  |
-| Lifecycle  | `github-lifecycle`, `github-lifecycle-ec`, `github-lifecycle-es`     |
-| Webhook    | `github-commit-sync`                                                  |
+| Kind              | Handler                   |
+| ----------------- | ------------------------- |
+| `identity`        | `GitHubIdentity`          |
+| `deployment`      | `GitHubDeployment`        |
+| `lifecycle`       | `GitHubLifecycle`         |
+| `webhook-actions` | `GitHubWebhookActions`    |
+| `commit-sync`     | `GitHubCommitSync`        |
+| `pr-sync`         | `GitHubPullRequestSync`   |
+| `analysis`        | `GitHubDoctor`            |
 
 ### Identity
 
@@ -45,21 +49,29 @@ org.
 Archiving requires admin scope on the repo; transferring additionally
 requires admin permission on the target organization.
 
-### Webhook (commit / tag sync)
+### Webhook actions (commit / tag / PR sync)
 
-A single `github-commit-sync` webhook-action plugin exposes two actions
-the gateway dispatches on `push` deliveries:
+The `webhook-actions` capability exposes the actions the gateway
+dispatches from webhook deliveries. A `WebhookRule.handler` is
+`"<plugin_slug>#<action_name>"`, and the slug is the **plugin** slug —
+`github` — not the capability kind:
 
-| Action         | Handler                          | Records into ClickHouse |
-| -------------- | -------------------------------- | ----------------------- |
-| `sync_commits` | `github-commit-sync#sync_commits`| `commits`               |
-| `sync_tags`    | `github-commit-sync#sync_tags`   | `tags`                  |
+| Action                | Handler                      | Records into ClickHouse |
+| --------------------- | ---------------------------- | ----------------------- |
+| `sync_commits`        | `github#sync_commits`        | `commits`               |
+| `sync_tags`           | `github#sync_tags`           | `tags`                  |
+| `sync_pull_requests`  | `github#sync_pull_requests`  | `pull_requests`         |
+
+`sync_commits` and `sync_tags` are dispatched from `push` deliveries;
+`sync_pull_requests` from `pull_request` deliveries.
 
 `sync_commits` fetches the full set of commits in a push via the compare
 API (paginated, so it isn't capped by the 20-commit inline payload limit);
 `sync_tags` records the pushed tag and, with `reconcile_all`, the repo's
-full tag list. Branch/tag gating is the rule's CEL `filter_expression`
-(e.g. `ref == "refs/heads/main"`, `ref.startsWith("refs/tags/")`). The API
+full tag list. Branch/tag gating is the rule's CEL `filter_expression`,
+which evaluates against the recorded event — the webhook body is under
+`payload` (e.g. `payload.ref == "refs/heads/main"`,
+`payload.ref.startsWith("refs/tags/")`). The API
 flavor (github.com / GHEC / GHES) is resolved at runtime — explicit
 `api_base_url`, else a connected GitHub plugin on the same service, else
 the service endpoint, else the payload's `repository.url`.
@@ -76,31 +88,46 @@ credential in one of two modes, resolved per call:
   from the pushed repository (`GET /repos/{owner}/{repo}/installation`).
   The App needs **Contents: Read-only**.
 
-## Manifest options (identity)
+## Integration options
 
-| Option           | Required  | Description                                                                |
-| ---------------- | --------- | -------------------------------------------------------------------------- |
-| `host`           | GHEC/GHES | Tenant or appliance host (e.g. `tenant.ghe.com`, `github.example.com`).    |
-| `default_scopes` | no        | Space-separated default OAuth scopes (default: `read:user user:email repo workflow`). |
+Asked once per Integration and delivered to every capability on
+`PluginContext.integration_options`:
 
-## Credentials (identity)
+| Option   | Required  | Description                                                             |
+| -------- | --------- | ----------------------------------------------------------------------- |
+| `flavor` | yes       | `github`, `ghec`, or `ghes`.                                            |
+| `host`   | GHEC/GHES | Tenant or appliance host (e.g. `tenant.ghe.com`, `github.example.com`). |
 
-| Field            | Required |
-| ---------------- | -------- |
-| `client_id`      | yes      |
-| `client_secret`  | yes      |
+## Capability options
 
-## Credentials (commit-sync)
+Scoped to one capability and delivered on
+`PluginContext.capability_options`:
 
-Provide **either** the PAT field **or** the GitHub App fields (all
-individually optional; validated per call):
+| Capability  | Option               | Description                                                                             |
+| ----------- | -------------------- | --------------------------------------------------------------------------------------- |
+| `identity`  | `default_scopes`     | Space-separated OAuth scopes (default: `read:user user:email repo workflow`).            |
+| `lifecycle` | `archive_target_org` | Org to transfer repos to before archiving; blank archives in place.                     |
+| `lifecycle` | `create_org`         | Default org for repo creation when no `org_mapping` entry matches.                       |
+| `lifecycle` | `org_mapping`        | Per-project-type-slug org overrides; the first match wins over `create_org`.             |
 
-| Field             | Mode | Description                                            |
-| ----------------- | ---- | ------------------------------------------------------ |
-| `access_token`    | PAT  | Static personal/service token.                         |
-| `app_id`          | App  | GitHub App identifier.                                 |
-| `private_key`     | App  | App private key — raw PEM or base64-encoded PEM.       |
-| `installation_id` | App  | Optional; discovered from the repo when unset.         |
+## Credentials
+
+One credential store per Integration — every capability receives the
+same decrypted blob. All fields are individually optional and validated
+per call, so an identity-only or App-only Integration is valid:
+
+| Field             | Used by            | Description                                       |
+| ----------------- | ------------------ | ------------------------------------------------- |
+| `access_token`    | service (PAT mode) | Static personal/service token.                    |
+| `app_id`          | service (App mode) | GitHub App identifier.                            |
+| `private_key`     | service (App mode) | App private key — raw PEM or base64-encoded PEM.  |
+| `installation_id` | service (App mode) | Optional; discovered from the repo when unset.    |
+| `client_id`       | `identity`         | OAuth App client id.                              |
+| `client_secret`   | `identity`         | OAuth App client secret.                          |
+
+For the service capabilities (commit-sync, pr-sync, deployment,
+lifecycle) provide **either** `access_token` **or** `app_id` +
+`private_key`.
 
 ## License
 

--- a/plugins/github/src/imbi/plugins/github/README.md
+++ b/plugins/github/src/imbi/plugins/github/README.md
@@ -125,9 +125,10 @@ per call, so an identity-only or App-only Integration is valid:
 | `client_id`       | `identity`         | OAuth App client id.                              |
 | `client_secret`   | `identity`         | OAuth App client secret.                          |
 
-For the service capabilities (commit-sync, pr-sync, deployment,
-lifecycle) provide **either** `access_token` **or** `app_id` +
-`private_key`.
+For `commit-sync`, `pr-sync`, and `deployment` provide **either**
+`access_token` **or** `app_id` + `private_key`. `lifecycle` acts as the
+user and takes only `access_token` (or `token`) — it does not fall back
+to GitHub App credentials.
 
 ## License
 

--- a/plugins/github/src/imbi/plugins/github/README.md
+++ b/plugins/github/src/imbi/plugins/github/README.md
@@ -1,17 +1,21 @@
 # imbi-plugin-github
 
-GitHub plugins for Imbi. Three flavors (github.com, GitHub Enterprise Cloud,
-GitHub Enterprise Server) of each plugin type so the admin UI can wire
-projects to the right backend.
+GitHub plugin for Imbi. A single plugin — slug **`github`** — backs every
+GitHub Integration; the integration-level `flavor` option selects
+github.com (`github`), GitHub Enterprise Cloud (`ghec`), or GitHub
+Enterprise Server (`ghes`), and `host` names the tenant or appliance.
 
-## Plugin types
+## Capabilities
 
-| Type       | Slugs                                                                |
-| ---------- | -------------------------------------------------------------------- |
-| Identity   | `github`, `github-enterprise-cloud`, `github-enterprise-server`      |
-| Deployment | `github-deployment`, `github-deployment-ec`, `github-deployment-es`  |
-| Lifecycle  | `github-lifecycle`, `github-lifecycle-ec`, `github-lifecycle-es`     |
-| Webhook    | `github-commit-sync`                                                  |
+| Kind              | Handler                   |
+| ----------------- | ------------------------- |
+| `identity`        | `GitHubIdentity`          |
+| `deployment`      | `GitHubDeployment`        |
+| `lifecycle`       | `GitHubLifecycle`         |
+| `webhook-actions` | `GitHubWebhookActions`    |
+| `commit-sync`     | `GitHubCommitSync`        |
+| `pr-sync`         | `GitHubPullRequestSync`   |
+| `analysis`        | `GitHubDoctor`            |
 
 ### Identity
 
@@ -45,21 +49,29 @@ org.
 Archiving requires admin scope on the repo; transferring additionally
 requires admin permission on the target organization.
 
-### Webhook (commit / tag sync)
+### Webhook actions (commit / tag / PR sync)
 
-A single `github-commit-sync` webhook-action plugin exposes two actions
-the gateway dispatches on `push` deliveries:
+The `webhook-actions` capability exposes the actions the gateway
+dispatches from webhook deliveries. A `WebhookRule.handler` is
+`"<plugin_slug>#<action_name>"`, and the slug is the **plugin** slug —
+`github` — not the capability kind:
 
-| Action         | Handler                          | Records into ClickHouse |
-| -------------- | -------------------------------- | ----------------------- |
-| `sync_commits` | `github-commit-sync#sync_commits`| `commits`               |
-| `sync_tags`    | `github-commit-sync#sync_tags`   | `tags`                  |
+| Action                | Handler                      | Records into ClickHouse |
+| --------------------- | ---------------------------- | ----------------------- |
+| `sync_commits`        | `github#sync_commits`        | `commits`               |
+| `sync_tags`           | `github#sync_tags`           | `tags`                  |
+| `sync_pull_requests`  | `github#sync_pull_requests`  | `pull_requests`         |
+
+`sync_commits` and `sync_tags` are dispatched from `push` deliveries;
+`sync_pull_requests` from `pull_request` deliveries.
 
 `sync_commits` fetches the full set of commits in a push via the compare
 API (paginated, so it isn't capped by the 20-commit inline payload limit);
 `sync_tags` records the pushed tag and, with `reconcile_all`, the repo's
-full tag list. Branch/tag gating is the rule's CEL `filter_expression`
-(e.g. `ref == "refs/heads/main"`, `ref.startsWith("refs/tags/")`). The API
+full tag list. Branch/tag gating is the rule's CEL `filter_expression`,
+which evaluates against the recorded event — the webhook body is under
+`payload` (e.g. `payload.ref == "refs/heads/main"`,
+`payload.ref.startsWith("refs/tags/")`). The API
 flavor (github.com / GHEC / GHES) is resolved at runtime — explicit
 `api_base_url`, else a connected GitHub plugin on the same service, else
 the service endpoint, else the payload's `repository.url`.
@@ -76,31 +88,46 @@ credential in one of two modes, resolved per call:
   from the pushed repository (`GET /repos/{owner}/{repo}/installation`).
   The App needs **Contents: Read-only**.
 
-## Manifest options (identity)
+## Integration options
 
-| Option           | Required  | Description                                                                |
-| ---------------- | --------- | -------------------------------------------------------------------------- |
-| `host`           | GHEC/GHES | Tenant or appliance host (e.g. `tenant.ghe.com`, `github.example.com`).    |
-| `default_scopes` | no        | Space-separated default OAuth scopes (default: `read:user user:email repo workflow`). |
+Asked once per Integration and delivered to every capability on
+`PluginContext.integration_options`:
 
-## Credentials (identity)
+| Option   | Required  | Description                                                             |
+| -------- | --------- | ----------------------------------------------------------------------- |
+| `flavor` | yes       | `github`, `ghec`, or `ghes`.                                            |
+| `host`   | GHEC/GHES | Tenant or appliance host (e.g. `tenant.ghe.com`, `github.example.com`). |
 
-| Field            | Required |
-| ---------------- | -------- |
-| `client_id`      | yes      |
-| `client_secret`  | yes      |
+## Capability options
 
-## Credentials (commit-sync)
+Scoped to one capability and delivered on
+`PluginContext.capability_options`:
 
-Provide **either** the PAT field **or** the GitHub App fields (all
-individually optional; validated per call):
+| Capability  | Option               | Description                                                                             |
+| ----------- | -------------------- | --------------------------------------------------------------------------------------- |
+| `identity`  | `default_scopes`     | Space-separated OAuth scopes (default: `read:user user:email repo workflow`).            |
+| `lifecycle` | `archive_target_org` | Org to transfer repos to before archiving; blank archives in place.                     |
+| `lifecycle` | `create_org`         | Default org for repo creation when no `org_mapping` entry matches.                       |
+| `lifecycle` | `org_mapping`        | Per-project-type-slug org overrides; the first match wins over `create_org`.             |
 
-| Field             | Mode | Description                                            |
-| ----------------- | ---- | ------------------------------------------------------ |
-| `access_token`    | PAT  | Static personal/service token.                         |
-| `app_id`          | App  | GitHub App identifier.                                 |
-| `private_key`     | App  | App private key — raw PEM or base64-encoded PEM.       |
-| `installation_id` | App  | Optional; discovered from the repo when unset.         |
+## Credentials
+
+One credential store per Integration — every capability receives the
+same decrypted blob. All fields are individually optional and validated
+per call, so an identity-only or App-only Integration is valid:
+
+| Field             | Used by            | Description                                       |
+| ----------------- | ------------------ | ------------------------------------------------- |
+| `access_token`    | service (PAT mode) | Static personal/service token.                    |
+| `app_id`          | service (App mode) | GitHub App identifier.                            |
+| `private_key`     | service (App mode) | App private key — raw PEM or base64-encoded PEM.  |
+| `installation_id` | service (App mode) | Optional; discovered from the repo when unset.    |
+| `client_id`       | `identity`         | OAuth App client id.                              |
+| `client_secret`   | `identity`         | OAuth App client secret.                          |
+
+For the service capabilities (commit-sync, pr-sync, deployment,
+lifecycle) provide **either** `access_token` **or** `app_id` +
+`private_key`.
 
 ## License
 


### PR DESCRIPTION
## Summary

Documentation-only. The GitHub plugin README still described the
pre-Architecture-v3 layout, where each capability was its own plugin.
Most consequentially it gave webhook handlers as
`github-commit-sync#sync_commits` — a slug that no longer exists — so a
`WebhookRule` copied from the README silently fails on every delivery.

## Problem

The gateway parses `WebhookRule.handler` as `<plugin_slug>#<action_name>`
and resolves the slug through an exact registry lookup
(`registry.get_plugin`). Under v3 there is one GitHub plugin,
`slug='github'`, and commit sync is its `webhook-actions` capability;
`github-commit-sync` survives only in log strings.

Because `_HANDLER_PATTERN` validates shape and not existence, a rule
using the documented handler saves cleanly and only fails at dispatch —
logging `Unknown plugin 'github-commit-sync' referenced by rule handler`
and recording a `handler not resolvable` outcome per delivery, with no
signal in the admin UI. This was found in production against a
`push`-triggered commit-sync rule that had never synced anything.

The same section's CEL examples had a second instance of the same trap:
`filter_expression` evaluates against the recorded event, where the
webhook body sits under `payload`, so the documented `ref ==
"refs/heads/main"` never matches.

## Solution

- Handlers are `github#sync_commits` / `github#sync_tags`, plus the
  previously undocumented `github#sync_pull_requests`, with a note that
  the slug is the plugin slug and not the capability kind.
- Replace the "Plugin types" flavor-per-slug table (`github-deployment`,
  `github-lifecycle-ec`, `github-enterprise-cloud`, …) with the real
  capability list; `flavor` / `host` are integration options on the one
  `github` plugin.
- Correct the CEL examples to `payload.ref`.
- Split options into integration- vs capability-scoped, picking up the
  three undocumented `lifecycle` options, and collapse the two
  "Credentials (…)" tables into the single per-Integration credential
  blob where every field is optional (the old table wrongly marked
  `client_id` / `client_secret` as required).

Both copies of the README — the distribution root and the packaged one
under `src/` — remain byte-identical, as they were before.

## Verification

No `github-commit-sync#` / `github-pr-sync#` or per-capability slugs
remain under `plugins/github/**.md`; the two copies still diff clean;
pre-commit passes. Default scopes cross-checked against
`identity.py:48`, the `pull_requests` table name against
`pull_requests.py:251`, and the capability list against
`plugin.py:251-332`.

No code changes, so no behavior change — the misconfigured rules
themselves still need correcting in each affected Integration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
