### PR TITLE
Require a SonarQube user token, not an analysis token

### DIFF
--- a/plugins/sonarqube/README.md
+++ b/plugins/sonarqube/README.md
@@ -7,7 +7,8 @@ by the imbi-common registry's `imbi_plugin_*` convention scan via the
 module-level `PLUGIN` attribute. Its manifest declares:
 
 - a `service_url` integration-level option (the SonarQube base URL),
-- an `api_token` credential (the integration's only credential), and
+- an `api_token` credential (the integration's only credential) holding a
+  SonarQube **user** token, and
 - one `webhook-actions` capability cataloging the
   `update_project_from_webhook` action.
 
@@ -24,6 +25,16 @@ handler:
 
 Operators create a SonarQube Integration, set its `service_url` option, and
 store the SonarQube API token in the Integration's encrypted credentials.
+
+The `api_token` **must be a user token** — created under *My Account >
+Security* in SonarQube and prefixed `squ_`. SonarQube's analysis tokens,
+`sqa_` (global) and `sqp_` (project), are restricted to the endpoints a
+scanner uses and answer `403` to every request this plugin makes, including
+`/api/measures/component` and the Project Doctor's component lookup. The
+restriction rides on the token *type*, so issuing an analysis token from an
+administrator account does not help. Grant the token's account Browse on the
+projects being read, plus Create Projects if the Project Doctor should create
+missing SonarQube projects.
 
 A typical webhook rule:
 

--- a/plugins/sonarqube/src/imbi/plugins/sonarqube/README.md
+++ b/plugins/sonarqube/src/imbi/plugins/sonarqube/README.md
@@ -7,7 +7,8 @@ by the imbi-common registry's `imbi_plugin_*` convention scan via the
 module-level `PLUGIN` attribute. Its manifest declares:
 
 - a `service_url` integration-level option (the SonarQube base URL),
-- an `api_token` credential (the integration's only credential), and
+- an `api_token` credential (the integration's only credential) holding a
+  SonarQube **user** token, and
 - one `webhook-actions` capability cataloging the
   `update_project_from_webhook` action.
 
@@ -24,6 +25,16 @@ handler:
 
 Operators create a SonarQube Integration, set its `service_url` option, and
 store the SonarQube API token in the Integration's encrypted credentials.
+
+The `api_token` **must be a user token** — created under *My Account >
+Security* in SonarQube and prefixed `squ_`. SonarQube's analysis tokens,
+`sqa_` (global) and `sqp_` (project), are restricted to the endpoints a
+scanner uses and answer `403` to every request this plugin makes, including
+`/api/measures/component` and the Project Doctor's component lookup. The
+restriction rides on the token *type*, so issuing an analysis token from an
+administrator account does not help. Grant the token's account Browse on the
+projects being read, plus Create Projects if the Project Doctor should create
+missing SonarQube projects.
 
 A typical webhook rule:
 

--- a/plugins/sonarqube/src/imbi/plugins/sonarqube/doctor.py
+++ b/plugins/sonarqube/src/imbi/plugins/sonarqube/doctor.py
@@ -114,23 +114,41 @@ def _component_key(
     return None
 
 
-def _token_type_hint(exc: Exception) -> str:
-    """Nudge toward a user token when SonarQube answers 403.
+def _token_type_hint(exc: Exception, api_token: str) -> str:
+    """Explain a 403 from the token's own prefix.
 
-    A 403 here is almost always the credential being one of SonarQube's
-    analysis tokens (``sqa_`` global, ``sqp_`` project) rather than a
-    user token (``squ_``): analysis tokens only reach the endpoints a
-    scanner uses, so they are refused regardless of the issuing
-    account's permissions.  Say so in the finding -- the bare status
-    code reads like a permissions problem and sends operators off
-    granting rights that cannot fix it.
+    SonarQube prefixes tokens by type, so the credential says which of
+    two unrelated causes is in play and the finding should not make the
+    operator guess.  An analysis token (``sqa_`` global, ``sqp_``
+    project) only reaches the endpoints a scanner uses and is refused
+    regardless of the issuing account's rights -- replacing it is the
+    only fix.  A user token (``squ_``) that is refused is a permissions
+    problem, where telling someone to swap a token that is already the
+    right type sends them in circles.  Tokens issued before SonarQube
+    added the prefixes carry neither, so those get both possibilities.
+    Returns ``''`` for non-403 failures, which need no token guidance.
     """
     if '403' not in str(exc):
         return ''
+    if api_token.startswith(('sqa_', 'sqp_')):
+        return (
+            ' The api_token credential is an analysis token, which only '
+            'reaches scanner endpoints; replace it with a user token '
+            '(`squ_`, from My Account > Security).'
+        )
+    if api_token.startswith('squ_'):
+        return (
+            ' The api_token credential is a user token, so this is the '
+            "token account's permissions rather than the token type -- "
+            'verify it has Browse on this project (SonarQube also '
+            'restricts some project APIs to administrators).'
+        )
     return (
-        ' A 403 usually means the api_token credential is an analysis '
-        'token (`sqa_` / `sqp_`); this API needs a user token (`squ_`, '
-        'from My Account > Security).'
+        ' Check whether the api_token credential is an analysis token '
+        '(`sqa_` / `sqp_`), which only reaches scanner endpoints and '
+        'needs replacing with a user token (`squ_`); if it is already a '
+        "user token, verify the token account's Browse permission on "
+        'this project.'
     )
 
 
@@ -211,7 +229,7 @@ class SonarQubeDoctor(AnalysisCapability):
                     'SonarQube project',
                     'warn',
                     f'Could not reach SonarQube to verify component {key!r}: '
-                    f'{exc}{_token_type_hint(exc)}',
+                    f'{exc}{_token_type_hint(exc, api_token)}',
                 )
             ]
 

--- a/plugins/sonarqube/src/imbi/plugins/sonarqube/doctor.py
+++ b/plugins/sonarqube/src/imbi/plugins/sonarqube/doctor.py
@@ -114,6 +114,26 @@ def _component_key(
     return None
 
 
+def _token_type_hint(exc: Exception) -> str:
+    """Nudge toward a user token when SonarQube answers 403.
+
+    A 403 here is almost always the credential being one of SonarQube's
+    analysis tokens (``sqa_`` global, ``sqp_`` project) rather than a
+    user token (``squ_``): analysis tokens only reach the endpoints a
+    scanner uses, so they are refused regardless of the issuing
+    account's permissions.  Say so in the finding -- the bare status
+    code reads like a permissions problem and sends operators off
+    granting rights that cannot fix it.
+    """
+    if '403' not in str(exc):
+        return ''
+    return (
+        ' A 403 usually means the api_token credential is an analysis '
+        'token (`sqa_` / `sqp_`); this API needs a user token (`squ_`, '
+        'from My Account > Security).'
+    )
+
+
 def _canonical_url(base_url: str, key: str) -> str:
     quoted = urllib.parse.quote(key, safe='')
     return f'{base_url.rstrip("/")}/api/components/show?component={quoted}'
@@ -161,7 +181,9 @@ class SonarQubeDoctor(AnalysisCapability):
                     'SonarQube API token',
                     'warn',
                     'No api_token credential configured; cannot inspect the '
-                    'SonarQube project.',
+                    'SonarQube project. Set the Integration credential to a '
+                    'SonarQube user token (prefix `squ_`) -- analysis tokens '
+                    '(`sqa_` / `sqp_`) cannot read this API.',
                 )
             ]
 
@@ -189,7 +211,7 @@ class SonarQubeDoctor(AnalysisCapability):
                     'SonarQube project',
                     'warn',
                     f'Could not reach SonarQube to verify component {key!r}: '
-                    f'{exc}',
+                    f'{exc}{_token_type_hint(exc)}',
                 )
             ]
 

--- a/plugins/sonarqube/src/imbi/plugins/sonarqube/plugin.py
+++ b/plugins/sonarqube/src/imbi/plugins/sonarqube/plugin.py
@@ -79,12 +79,17 @@ class SonarQubePlugin(plugins.Plugin):
             'credentials': [
                 {
                     'name': 'api_token',
-                    'label': 'SonarQube API Token',
+                    'label': 'SonarQube user token',
                     'description': (
-                        'User or analysis token with read access to '
-                        '/api/measures/component, plus the Create Projects '
-                        'permission if the Project Doctor should search for '
-                        'and create SonarQube projects.'
+                        'A SonarQube **user** token (My Account > Security '
+                        'in SonarQube), which is prefixed `squ_`. Analysis '
+                        'tokens -- `sqa_` (global) and `sqp_` (project) -- '
+                        'are scoped to scanner endpoints and return 403 on '
+                        'every call this plugin makes, no matter what '
+                        'permissions the issuing account holds. The token '
+                        'needs Browse on the projects being read, plus '
+                        'Create Projects if the Project Doctor should create '
+                        'missing SonarQube projects.'
                     ),
                 }
             ],

--- a/plugins/sonarqube/tests/test_doctor.py
+++ b/plugins/sonarqube/tests/test_doctor.py
@@ -85,6 +85,30 @@ class AnalyzeTestCase(unittest.IsolatedAsyncioTestCase):
     async def test_warns_without_token(self) -> None:
         results = await SonarQubeDoctor().analyze(_ctx(), {})
         self.assertEqual(results[0].slug, 'api-token')
+        self.assertIn('squ_', results[0].description)
+
+    @respx.mock
+    async def test_forbidden_hints_at_analysis_token(self) -> None:
+        # A 403 reads like a permissions problem, so the finding has to
+        # point at the token *type* -- analysis tokens are refused here
+        # no matter what rights the issuing account holds.
+        respx.get(_SEARCH).mock(return_value=httpx.Response(403))
+        ctx = _ctx(connections=[_conn()])
+        results = await SonarQubeDoctor().analyze(ctx, _CREDS)
+        finding = _by_slug(results)['component']
+        self.assertEqual(finding.status, 'warn')
+        self.assertIn('status 403', finding.description)
+        self.assertIn('analysis token', finding.description)
+        self.assertIn('squ_', finding.description)
+
+    @respx.mock
+    async def test_other_errors_omit_token_hint(self) -> None:
+        respx.get(_SEARCH).mock(return_value=httpx.Response(500))
+        ctx = _ctx(connections=[_conn()])
+        results = await SonarQubeDoctor().analyze(ctx, _CREDS)
+        finding = _by_slug(results)['component']
+        self.assertIn('status 500', finding.description)
+        self.assertNotIn('analysis token', finding.description)
 
     async def test_warns_without_derivable_key(self) -> None:
         results = await SonarQubeDoctor().analyze(_ctx(team_slug=None), _CREDS)

--- a/plugins/sonarqube/tests/test_doctor.py
+++ b/plugins/sonarqube/tests/test_doctor.py
@@ -88,18 +88,39 @@ class AnalyzeTestCase(unittest.IsolatedAsyncioTestCase):
         self.assertIn('squ_', results[0].description)
 
     @respx.mock
-    async def test_forbidden_hints_at_analysis_token(self) -> None:
-        # A 403 reads like a permissions problem, so the finding has to
-        # point at the token *type* -- analysis tokens are refused here
-        # no matter what rights the issuing account holds.
+    async def _forbidden_description(self, token: str) -> str:
         respx.get(_SEARCH).mock(return_value=httpx.Response(403))
-        ctx = _ctx(connections=[_conn()])
-        results = await SonarQubeDoctor().analyze(ctx, _CREDS)
+        results = await SonarQubeDoctor().analyze(
+            _ctx(connections=[_conn()]), {'api_token': token}
+        )
         finding = _by_slug(results)['component']
         self.assertEqual(finding.status, 'warn')
         self.assertIn('status 403', finding.description)
-        self.assertIn('analysis token', finding.description)
-        self.assertIn('squ_', finding.description)
+        return finding.description
+
+    async def test_forbidden_analysis_token_says_replace_it(self) -> None:
+        # The prefix makes the cause certain, so the finding names it
+        # rather than hedging: no permission grant can fix this one.
+        for prefix in ('sqa_', 'sqp_'):
+            with self.subTest(prefix=prefix):
+                desc = await self._forbidden_description(f'{prefix}abc')
+                self.assertIn('is an analysis token', desc)
+                self.assertIn('squ_', desc)
+                self.assertNotIn('Browse', desc)
+
+    async def test_forbidden_user_token_points_at_permissions(self) -> None:
+        # Telling someone holding a squ_ token to swap token types sends
+        # them in circles -- a refused user token is a rights problem.
+        desc = await self._forbidden_description('squ_abc')
+        self.assertIn('Browse', desc)
+        self.assertNotIn('replace it', desc)
+
+    async def test_forbidden_unprefixed_token_covers_both(self) -> None:
+        # Tokens predating SonarQube's prefixes tell us nothing, so the
+        # finding has to offer both causes.
+        desc = await self._forbidden_description('legacy-token')
+        self.assertIn('analysis token', desc)
+        self.assertIn('Browse', desc)
 
     @respx.mock
     async def test_other_errors_omit_token_hint(self) -> None:
@@ -109,6 +130,7 @@ class AnalyzeTestCase(unittest.IsolatedAsyncioTestCase):
         finding = _by_slug(results)['component']
         self.assertIn('status 500', finding.description)
         self.assertNotIn('analysis token', finding.description)
+        self.assertNotIn('Browse', finding.description)
 
     async def test_warns_without_derivable_key(self) -> None:
         results = await SonarQubeDoctor().analyze(_ctx(team_slug=None), _CREDS)


### PR DESCRIPTION
## Summary

The SonarQube `api_token` credential description said "User or analysis
token". An analysis token can never satisfy this plugin, which made a 403
look like a permissions problem. The description now requires a user token
and names the analysis-token prefixes as the cause.

## Problem

SonarQube issues three token types: user (`squ_`), global analysis
(`sqa_`), and project analysis (`sqp_`). Analysis tokens are scoped to the
endpoints a scanner uses, so they return 403 on every call this plugin
makes — `/api/measures/component` for the webhook action and
`/api/projects/search` for the Project Doctor. The restriction rides on the
token *type*, not the account, so an analysis token issued by an
administrator is refused exactly the same way.

Observed as a Project Doctor warning that pointed nowhere useful:

```
SonarQube project — WARN — sonarqube
Could not reach SonarQube to verify component 'conv:account': SonarQube returned status 403
```

Confirmed against a live server: an `sqa_` token issued from an admin
account 403s on `/api/components/show`, which needs only Browse.

## Solution

- Rewrite the credential description to require a user token (`squ_`, from
  My Account > Security), name `sqa_` / `sqp_` as the 403 cause, and state
  the Browse / Create Projects permissions needed; relabel the field
  "SonarQube user token"
- Append a token-type hint to the doctor's component finding when SonarQube
  answers 403, and to its no-token warning
- Document the same in the plugin README, including that an admin-issued
  analysis token is still refused
- Sync `plugins/sonarqube/README.md` with the in-package copy — identical
  files at HEAD that would otherwise drift

Both surfaces render Markdown (`FieldDescription` for credentials,
`ProjectDoctorTab` for findings), so the prefixes are code spans.

## Verification

`plugins/sonarqube/tests/`: 55 passed, including new coverage for the 403
hint and its absence on other statuses. pre-commit (ruff + mypy) and
basedpyright clean.

## Not included

Whether `/api/projects/search` also needs Administer System is still open —
it is an administrative endpoint, so a non-admin user token may still 403
there even after this change. If it does, the follow-up is to switch
`search_project()` to `/api/components/show`, which needs only Browse and
already models "absent" as `None`. Left out pending confirmation against a
real user token.