### PR TITLE
Show who deployed the entry environment and when

### DIFF
--- a/ui/src/components/deployments/CommitDeployCard.test.tsx
+++ b/ui/src/components/deployments/CommitDeployCard.test.tsx
@@ -35,6 +35,8 @@ const currentFor = (committish: string): CurrentReleaseEnvironment => ({
   environment: { name: 'testing', slug: 'testing' },
   external_run_url: null,
   last_event_at: '2026-06-01T00:00:00Z',
+  performed_by: 'Imbi Automations',
+  performed_by_email: null,
   release: {
     committish,
     created_at: '2026-06-01T00:00:00Z',
@@ -90,6 +92,12 @@ describe('CommitDeployCard', () => {
     expect(screen.getByText('HEAD')).toBeInTheDocument()
     expect(screen.getAllByRole('button', { name: /Deploy/ })).toHaveLength(1)
     expect(screen.getAllByRole('button', { name: /Roll back/ })).toHaveLength(1)
+  })
+
+  it('attributes the running deployment to who deployed it and when', () => {
+    setup('bbb2222bbb2222')
+    expect(screen.getByText(/^Deployed/)).toBeInTheDocument()
+    expect(screen.getByText('Imbi Automations')).toBeInTheDocument()
   })
 
   it('pulls the deployed commit forward when it is outside the display window', () => {

--- a/ui/src/components/deployments/CommitDeployCard.test.tsx
+++ b/ui/src/components/deployments/CommitDeployCard.test.tsx
@@ -49,8 +49,11 @@ const currentFor = (committish: string): CurrentReleaseEnvironment => ({
   },
 })
 
-const makeStage = (committish: string): PipelineStage => ({
-  current: currentFor(committish),
+const makeStage = (
+  committish: string,
+  current: Partial<CurrentReleaseEnvironment> = {},
+): PipelineStage => ({
+  current: { ...currentFor(committish), ...current },
   env: ENV,
   kind: 'commit',
   pendingCommits: [],
@@ -74,14 +77,18 @@ const RECENT = [
   commit('ccc3333ccc3333', 'older change'),
 ]
 
-const setup = (committish: string, recentCommits: RecentCommit[] = RECENT) =>
+const setup = (
+  committish: string,
+  recentCommits: RecentCommit[] = RECENT,
+  current: Partial<CurrentReleaseEnvironment> = {},
+) =>
   render(
     <CommitDeployCard
       accent={null}
       actions={makeActions()}
       canTrigger
       recentCommits={recentCommits}
-      stage={makeStage(committish)}
+      stage={makeStage(committish, current)}
     />,
   )
 
@@ -96,8 +103,20 @@ describe('CommitDeployCard', () => {
 
   it('attributes the running deployment to who deployed it and when', () => {
     setup('bbb2222bbb2222')
-    expect(screen.getByText(/^Deployed/)).toBeInTheDocument()
+    const deployedAt = screen.getByText(/^Deployed/).querySelector('time')
+    expect(deployedAt).toHaveAttribute('datetime', '2026-06-01T00:00:00Z')
     expect(screen.getByText('Imbi Automations')).toBeInTheDocument()
+  })
+
+  it('omits the deploy metadata the stage did not record', () => {
+    const undated = RECENT.map(({ authored_at: _unused, ...rest }) => rest)
+    setup('bbb2222bbb2222', undated, {
+      last_event_at: null,
+      performed_by: null,
+    })
+    expect(screen.queryByText(/^Deployed/)).toBeNull()
+    expect(screen.queryByText('Imbi Automations')).toBeNull()
+    expect(document.querySelectorAll('time')).toHaveLength(0)
   })
 
   it('pulls the deployed commit forward when it is outside the display window', () => {

--- a/ui/src/components/deployments/CommitDeployCard.tsx
+++ b/ui/src/components/deployments/CommitDeployCard.tsx
@@ -1,6 +1,7 @@
 import { Fragment, useState } from 'react'
 
 import {
+  Clock,
   ExternalLink,
   GitCommitHorizontal,
   Loader2,
@@ -11,6 +12,7 @@ import {
 import { CiStatusDot } from '@/components/releases/CiStatusDot'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
+import { RelativeTime } from '@/components/ui/RelativeTime'
 import { UserIdentity } from '@/components/ui/user-identity'
 import type { ChipColors } from '@/lib/chip-colors'
 import type { RecentCommit } from '@/types'
@@ -78,10 +80,36 @@ export function CommitDeployCard({
       icon={GitCommitHorizontal}
       subtitle={
         currentSha ? (
-          <>
-            On <span className="font-mono">{currentSha.slice(0, 7)}</span> ·
-            deploy a newer commit or roll back
-          </>
+          <span className="flex flex-wrap items-center gap-x-3 gap-y-1">
+            <span>
+              On <span className="font-mono">{currentSha.slice(0, 7)}</span>
+            </span>
+            {stage.current?.last_event_at ? (
+              <>
+                <span aria-hidden="true">·</span>
+                <span className="inline-flex items-center gap-1.5">
+                  <Clock size={13} />
+                  Deployed{' '}
+                  <RelativeTime
+                    value={stage.current.last_event_at}
+                    variant="long"
+                  />
+                </span>
+              </>
+            ) : null}
+            {stage.current?.performed_by ? (
+              <>
+                <span aria-hidden="true">by</span>
+                <UserIdentity
+                  actor={stage.current.performed_by}
+                  email={stage.current.performed_by_email}
+                  size="small"
+                />
+              </>
+            ) : null}
+            <span aria-hidden="true">·</span>
+            <span>deploy a newer commit or roll back</span>
+          </span>
         ) : (
           'Nothing deployed yet — deploy a commit to get started'
         )
@@ -196,6 +224,13 @@ function CommitRow({
       </span>
       {commit.ci_status !== 'unknown' ? (
         <CiStatusDot status={commit.ci_status} />
+      ) : null}
+      {commit.authored_at ? (
+        <RelativeTime
+          className="text-tertiary hidden shrink-0 text-xs sm:inline"
+          value={commit.authored_at}
+          variant="narrow"
+        />
       ) : null}
       {commit.author ? (
         <span className="hidden shrink-0 sm:inline">

--- a/ui/src/components/deployments/CommitDeployCard.tsx
+++ b/ui/src/components/deployments/CommitDeployCard.tsx
@@ -99,7 +99,7 @@ export function CommitDeployCard({
             ) : null}
             {stage.current?.performed_by ? (
               <>
-                <span aria-hidden="true">by</span>
+                <span>by</span>
                 <UserIdentity
                   actor={stage.current.performed_by}
                   email={stage.current.performed_by_email}


### PR DESCRIPTION
## Summary

The Deployments tab now shows who deployed the entry environment's running commit and when, and gives each commit row a date.

## Problem

The entry environment (the first stage in the pipeline — e.g. Testing) renders `CommitDeployCard`, and its header said only:

```
Testing
On e2751b5 · deploy a newer commit or roll back
```

That is the one deployment stage that never attributed its running deployment. The promoted environments render `CurrentlyRunningCard`, which has always shown `Deployed <when> · <who>` in the same header slot. So looking at Testing, there was no way to tell who put `e2751b5` there or how long it had been running without leaving the tab for the operations log.

The commit rows below had a related gap: each showed the commit's author but no date at all, so "when did this land?" was equally unanswerable.

## Solution

- Add the deploy time and deployer to the `CommitDeployCard` header, reusing the same `Clock` + `RelativeTime variant="long"` + `UserIdentity` composition `CurrentlyRunningCard` uses, so the two card types read identically. A `by` separates the time from the person now that they sit adjacent.
- Add a narrow relative authored time to each commit row, between the CI dot and the author, so a row reads *message · CI · when · who*.

No API or data changes: `last_event_at`, `performed_by`, and `performed_by_email` were already on the stage model (`CurrentReleaseEnvironment`), and `authored_at` was already on `RecentCommit`. This card simply ignored them.

Both header segments stay conditional — an in-product deploy with no recorded actor omits the name rather than rendering a placeholder. The pinned "not in the synced commit history" fallback row carries no `authored_at` and renders nothing in the time slot.

## Impact

Display-only change to one tab; no behavior, permissions, or endpoints touched. The header line is longer than before and wraps on narrow viewports (it is a `flex-wrap` row); the row-level timestamp is hidden below the `sm` breakpoint, matching how the author identity in that row already behaves.

## Testing

- `vitest run` — full suite passes, including two new `CommitDeployCard` cases: one asserting the header names the deployer and carries a `<time datetime>` matching `last_event_at`, one asserting a stage that recorded neither a deploy time nor a deployer renders no time and no name.
- `tsc -p ui/tsconfig.json --noEmit` and `oxfmt --check` clean; `oxlint` 0 errors.
- Verified visually in the running dev environment.

