### PR TITLE
Group operations-log release trains by release, not description

### DIFF
--- a/apps/api/src/imbi/api/endpoints/_helpers.py
+++ b/apps/api/src/imbi/api/endpoints/_helpers.py
@@ -180,6 +180,7 @@ def deployed_operation_log(
     performed_by: str | None,
     action: str,
     version: str | None,
+    commit_sha: str | None = None,
     plugin_slug: str = '',
     run_url: str | None = None,
     release_url: str | None = None,
@@ -195,6 +196,12 @@ def deployed_operation_log(
     ``release_url``) are filtered through :func:`safe_audit_url` so
     non-http(s) schemes never reach the audit JSON or the ``link``.
 
+    ``commit_sha`` is the committish the deploy shipped, recorded even
+    when ``version`` is a tag: the operations-log UI correlates the rows
+    of one release train across environments by tag *or* committish, and
+    an untagged environment (testing deploys straight off a commit) only
+    shares the committish with its later tagged promotions.
+
     ``occurred_at`` is only overridden when supplied; callers that
     backfill historical deploys pin it to the real deploy time because
     ``lookup_ops_log_performed_by`` ranks with
@@ -206,6 +213,7 @@ def deployed_operation_log(
     description = json.dumps(
         {
             'action': action,
+            'commit_sha': commit_sha,
             'plugin_slug': plugin_slug,
             'run_url': safe_run_url,
             'release_url': safe_audit_url(release_url),

--- a/apps/api/src/imbi/api/endpoints/operations_log.py
+++ b/apps/api/src/imbi/api/endpoints/operations_log.py
@@ -192,7 +192,7 @@ async def complete_opslog_entry(
         return False
     row = dict(rows[0])
     row['completed_at'] = completed_at
-    row['_row_version'] = _next_row_version(int(row['_row_version']))
+    row['_row_version'] = next_row_version(int(row['_row_version']))
     await _insert_row(row)
     return True
 
@@ -265,7 +265,7 @@ async def _fetch_current(
 _row_version_last: int = 0
 
 
-def _next_row_version(current_version: int) -> int:
+def next_row_version(current_version: int) -> int:
     """Return a strictly-increasing ``_row_version`` value.
 
     ClickHouse ``ReplacingMergeTree`` requires the version column to
@@ -640,7 +640,7 @@ async def patch_operation_log(
     entry.recorded_at = current['recorded_at']
     entry.recorded_by = current['recorded_by']
     entry.project_id = current['project_id']
-    entry.row_version = _next_row_version(int(current['_row_version']))
+    entry.row_version = next_row_version(int(current['_row_version']))
     entry.is_deleted = False
 
     row = _model_to_row(entry)
@@ -667,7 +667,7 @@ async def delete_operation_log(
         )
 
     tombstone = dict(current)
-    tombstone['_row_version'] = _next_row_version(int(current['_row_version']))
+    tombstone['_row_version'] = next_row_version(int(current['_row_version']))
     tombstone['is_deleted'] = 1
 
     await _insert_row(tombstone)

--- a/apps/api/src/imbi/api/endpoints/project_deployments.py
+++ b/apps/api/src/imbi/api/endpoints/project_deployments.py
@@ -663,7 +663,9 @@ async def _record_deployment_audit(
 
     ``OperationLog.version`` is populated with ``tag if tag else
     committish`` — a single human-friendly display string that the
-    operations-log UI can render directly.
+    operations-log UI can render directly.  ``committish`` is *also*
+    recorded as ``commit_sha`` in the audit JSON so the UI can correlate
+    a tagged promotion with the untagged deploy of the same commit.
     """
     entry = deployed_operation_log(
         project_id=project_id,
@@ -673,6 +675,7 @@ async def _record_deployment_audit(
         performed_by=recorded_by,
         action=action,
         version=tag or committish,
+        commit_sha=committish,
         plugin_slug=plugin_slug,
         run_url=run_url,
         release_url=release_url,

--- a/apps/api/src/imbi/api/maintenance/operations.py
+++ b/apps/api/src/imbi/api/maintenance/operations.py
@@ -518,9 +518,13 @@ async def execute_opslog_backfill(
             len(repairs),
             project_id,
         )
+        repair_columns = list(repairs[0].keys())
         await client_instance.insert(
             'operations_log',
-            [list(repair.values()) for repair in repairs],
-            list(repairs[0].keys()),
+            [
+                [repair[column] for column in repair_columns]
+                for repair in repairs
+            ],
+            repair_columns,
         )
     return 'succeeded'

--- a/apps/api/src/imbi/api/maintenance/operations.py
+++ b/apps/api/src/imbi/api/maintenance/operations.py
@@ -327,7 +327,7 @@ def _with_commit_sha(
     repair.  ``operations_log`` is a ``ReplacingMergeTree``, so an insert
     that reuses the row's ``id`` with a bumped ``_row_version`` replaces
     it -- the same read-modify-insert the PATCH endpoint and
-    ``complete_opslog_entry`` use.  ``_next_row_version`` is borrowed
+    ``complete_opslog_entry`` use.  ``next_row_version`` is borrowed
     from that module rather than reimplemented because its monotonic
     guard is process-wide state.
 
@@ -336,19 +336,22 @@ def _with_commit_sha(
     human-authored entries, and a payload that already has the
     committish is already correlatable.
     """
-    from imbi.api.endpoints.operations_log import _next_row_version
+    from imbi.api.endpoints.operations_log import next_row_version
 
     try:
-        payload = json.loads(str(row.get('description') or ''))
+        decoded: object = json.loads(str(row.get('description') or ''))
     except ValueError:
         return None
-    if not isinstance(payload, dict) or payload.get('commit_sha'):
+    if not isinstance(decoded, dict):
+        return None
+    payload = typing.cast(dict[str, typing.Any], decoded)
+    if payload.get('commit_sha'):
         return None
     repaired = dict(row)
     repaired['description'] = json.dumps(
         {**payload, 'commit_sha': committish}, sort_keys=True
     )
-    repaired['_row_version'] = _next_row_version(int(row['_row_version']))
+    repaired['_row_version'] = next_row_version(int(row['_row_version']))
     return repaired
 
 

--- a/apps/api/src/imbi/api/maintenance/operations.py
+++ b/apps/api/src/imbi/api/maintenance/operations.py
@@ -18,6 +18,7 @@ endpoints package at import time.
 from __future__ import annotations
 
 import functools
+import json
 import logging
 import typing
 
@@ -286,19 +287,86 @@ RETURN e.slug AS env_slug,
 """
 
 
+def _commit_sha_repairs(
+    *,
+    env_slug: str,
+    committish: str | None,
+    candidates: list[str],
+    existing_rows: dict[tuple[str, str], list[dict[str, typing.Any]]],
+    repaired_ids: set[str],
+) -> list[dict[str, typing.Any]]:
+    """Rows to re-insert so one deployment edge's env carries its sha.
+
+    Probes both version candidates because an untagged deploy stored the
+    committish where a tagged one stored the tag.  ``repaired_ids`` is
+    updated in place: two releases cut from the same commit both resolve
+    the same untagged row, and it should be rewritten once.
+    """
+    if not committish:
+        return []
+    repairs: list[dict[str, typing.Any]] = []
+    for candidate in candidates:
+        for existing in existing_rows.get((env_slug, candidate), []):
+            entry_id = str(existing.get('id') or '')
+            if entry_id in repaired_ids:
+                continue
+            repair = _with_commit_sha(existing, committish)
+            if repair is None:
+                continue
+            repaired_ids.add(entry_id)
+            repairs.append(repair)
+    return repairs
+
+
+def _with_commit_sha(
+    row: dict[str, typing.Any], committish: str
+) -> dict[str, typing.Any] | None:
+    """Rewrite an existing ops-log row to carry ``commit_sha``.
+
+    Returns the row to re-insert, or ``None`` when there is nothing to
+    repair.  ``operations_log`` is a ``ReplacingMergeTree``, so an insert
+    that reuses the row's ``id`` with a bumped ``_row_version`` replaces
+    it -- the same read-modify-insert the PATCH endpoint and
+    ``complete_opslog_entry`` use.  ``_next_row_version`` is borrowed
+    from that module rather than reimplemented because its monotonic
+    guard is process-wide state.
+
+    Only rows whose ``description`` is a plugin payload object missing a
+    ``commit_sha`` are touched: free-text descriptions belong to
+    human-authored entries, and a payload that already has the
+    committish is already correlatable.
+    """
+    from imbi.api.endpoints.operations_log import _next_row_version
+
+    try:
+        payload = json.loads(str(row.get('description') or ''))
+    except ValueError:
+        return None
+    if not isinstance(payload, dict) or payload.get('commit_sha'):
+        return None
+    repaired = dict(row)
+    repaired['description'] = json.dumps(
+        {**payload, 'commit_sha': committish}, sort_keys=True
+    )
+    repaired['_row_version'] = _next_row_version(int(row['_row_version']))
+    return repaired
+
+
 async def _existing_opslog_rows(
     project_id: str,
-) -> tuple[set[str], set[tuple[str, str]]]:
+) -> tuple[set[str], dict[tuple[str, str], list[dict[str, typing.Any]]]]:
     """Return the ``operations_log`` 'Deployed' rows already on file.
 
-    Two dedupe indexes for one project: the set of ``external_run_id``
-    values, and the set of ``(environment_slug, version)`` pairs.  Read
-    ``FINAL`` so the ``ReplacingMergeTree`` collapse is applied and
-    superseded rows don't resurrect a stale key.
+    Two views of one project's rows: the set of ``external_run_id``
+    values, and the full rows grouped by ``(environment_slug,
+    version)``.  Both dedupe inserts; the grouped rows also let the
+    enrichment pass rewrite a row in place, which is why this reads whole
+    rows rather than the three key columns.  Read ``FINAL`` so the
+    ``ReplacingMergeTree`` collapse is applied and superseded rows don't
+    resurrect a stale key.
     """
     sql = (
-        'SELECT environment_slug, version, external_run_id'
-        ' FROM operations_log FINAL'
+        'SELECT * FROM operations_log FINAL'
         " WHERE entry_type = 'Deployed'"
         ' AND is_deleted = 0'
         ' AND project_id = {project_id:String}'
@@ -307,7 +375,7 @@ async def _existing_opslog_rows(
         sql, {'project_id': project_id}
     )
     run_ids: set[str] = set()
-    env_versions: set[tuple[str, str]] = set()
+    by_env_version: dict[tuple[str, str], list[dict[str, typing.Any]]] = {}
     for row in rows:
         run_id = row.get('external_run_id')
         if run_id:
@@ -315,8 +383,8 @@ async def _existing_opslog_rows(
         env = str(row.get('environment_slug') or '')
         version = str(row.get('version') or '')
         if env and version:
-            env_versions.add((env, version))
-    return run_ids, env_versions
+            by_env_version.setdefault((env, version), []).append(row)
+    return run_ids, by_env_version
 
 
 async def execute_opslog_backfill(
@@ -339,8 +407,15 @@ async def execute_opslog_backfill(
     newest-first per edge so the most recent attributed deployer is the
     one that survives dedupe for a given ``(environment, version)``.
 
-    Skipped when the project has no deployment edges or every attributed
-    event already has a matching ops-log row.
+    It also repairs the rows that already exist: any 'Deployed' row whose
+    audit payload predates ``commit_sha`` is re-inserted with the
+    committish from its deployment edge, so the operations-log UI can
+    join every environment of one release train (see
+    :func:`_commit_sha_repairs`).
+
+    Skipped when the project has no deployment edges, or every attributed
+    event already has a matching ops-log row and no row needs a
+    committish filled in.
     """
     from imbi.api.endpoints._helpers import (
         deployed_operation_log,
@@ -356,12 +431,13 @@ async def execute_opslog_backfill(
     if not rows:
         return 'skipped'
 
-    existing_run_ids, existing_env_versions = await _existing_opslog_rows(
-        project_id
-    )
+    existing_run_ids, existing_rows = await _existing_opslog_rows(project_id)
+    existing_env_versions = set(existing_rows)
     project_slug, _team_slug = await lookup_project_slugs(db, project_id)
 
     pending: list[common_models.OperationLog] = []
+    repairs: list[dict[str, typing.Any]] = []
+    repaired_ids: set[str] = set()
     for row in rows:
         env_slug = graph.parse_agtype(row.get('env_slug'))
         if not isinstance(env_slug, str) or not env_slug:
@@ -374,6 +450,19 @@ async def execute_opslog_backfill(
         if not version:
             continue
         candidates = ops_log_version_candidates(tag, committish)
+        # Rows written before the audit payload carried `commit_sha` can
+        # only be joined to the rest of their release train by tag, which
+        # leaves an untagged environment stranded. The edge knows the
+        # committish, so fill it in on the rows that already exist.
+        repairs.extend(
+            _commit_sha_repairs(
+                env_slug=env_slug,
+                committish=committish,
+                candidates=candidates,
+                existing_rows=existing_rows,
+                repaired_ids=repaired_ids,
+            )
+        )
         events = common_models.parse_deployment_events(
             graph.parse_agtype(row.get('deployments')), on_error='skip'
         )
@@ -394,6 +483,7 @@ async def execute_opslog_backfill(
                     performed_by=event.performed_by,
                     action='opslog-backfill',
                     version=version,
+                    commit_sha=committish,
                     run_url=event.external_run_url,
                     external_run_id=event.external_run_id,
                     occurred_at=event.timestamp,
@@ -403,18 +493,31 @@ async def execute_opslog_backfill(
                 existing_run_ids.add(run_id)
             existing_env_versions.add((env_slug, version))
 
-    if not pending:
+    if not pending and not repairs:
         return 'skipped'
 
-    columns: list[str] = []
-    values: list[list[typing.Any]] = []
-    for entry in pending:
-        dumped = entry.model_dump(by_alias=True, mode='python')
-        dumped['is_deleted'] = 1 if entry.is_deleted else 0
-        if not columns:
-            columns = list(dumped.keys())
-        values.append(list(dumped.values()))
-    await clickhouse.client.Clickhouse.get_instance().insert(
-        'operations_log', values, columns
-    )
+    client_instance = clickhouse.client.Clickhouse.get_instance()
+    if pending:
+        columns: list[str] = []
+        values: list[list[typing.Any]] = []
+        for entry in pending:
+            dumped = entry.model_dump(by_alias=True, mode='python')
+            dumped['is_deleted'] = 1 if entry.is_deleted else 0
+            if not columns:
+                columns = list(dumped.keys())
+            values.append(list(dumped.values()))
+        await client_instance.insert('operations_log', values, columns)
+    if repairs:
+        # A separate insert: the repaired rows come off ``SELECT *`` and
+        # need not share the model dump's column order.
+        LOGGER.debug(
+            'opslog-backfill: filling commit_sha on %d row(s) of project %s',
+            len(repairs),
+            project_id,
+        )
+        await client_instance.insert(
+            'operations_log',
+            [list(repair.values()) for repair in repairs],
+            list(repairs[0].keys()),
+        )
     return 'succeeded'

--- a/apps/api/src/imbi/api/maintenance/registry.py
+++ b/apps/api/src/imbi/api/maintenance/registry.py
@@ -103,7 +103,9 @@ OPERATIONS: dict[MaintenanceSlug, OperationDefinition] = {
                 'Ensure the operations log has Deployed entries for every '
                 'attributed deployment event on each release, so deployer '
                 'attribution resolves for deployments recorded outside '
-                'Imbi.'
+                'Imbi. Also fills the release committish in on existing '
+                'entries that predate it, so release trains group across '
+                'every environment.'
             ),
             pause_key=None,
             enumerate=operations.enumerate_all_projects,

--- a/apps/api/tests/endpoints/test_project_deployments.py
+++ b/apps/api/tests/endpoints/test_project_deployments.py
@@ -1796,6 +1796,35 @@ class SafeAuditUrlTestCase(unittest.TestCase):
         self.assertIsNone(safe_audit_url('file:///etc/passwd'))
 
 
+class DeployedOperationLogTestCase(unittest.TestCase):
+    """The audit row records both release identities."""
+
+    @staticmethod
+    def _build(**kwargs: typing.Any) -> dict[str, typing.Any]:
+        from imbi.api.endpoints._helpers import deployed_operation_log
+
+        entry = deployed_operation_log(
+            project_id='p1',
+            project_slug='webform',
+            environment_slug='production',
+            recorded_by='dang@aweber.com',
+            performed_by='dang@aweber.com',
+            action='deploy',
+            **kwargs,
+        )
+        return json.loads(entry.description)
+
+    def test_commit_sha_recorded_alongside_a_tag(self) -> None:
+        # The UI joins the rows of one release train by tag *or*
+        # committish, so a tagged row must still carry the committish.
+        description = self._build(version='1.29.0', commit_sha='c67213d')
+        self.assertEqual('c67213d', description['commit_sha'])
+
+    def test_commit_sha_defaults_to_none(self) -> None:
+        description = self._build(version='1.29.0')
+        self.assertIsNone(description['commit_sha'])
+
+
 def _relocating_resolved() -> ResolvedCapability:
     return _make_resolved(
         _RelocatingDeploymentPlugin, options={'owner': 'octo', 'repo': 'demo'}

--- a/apps/api/tests/test_maintenance_operations.py
+++ b/apps/api/tests/test_maintenance_operations.py
@@ -303,6 +303,28 @@ def _edge_row(
     }
 
 
+def _existing_row(
+    *,
+    entry_id: str = 'opslog-1',
+    version: str = 'v1.2.3',
+    environment_slug: str = 'production',
+    description: str | None = None,
+) -> dict[str, object]:
+    """An ops-log row as ``SELECT *`` returns it, minus commit_sha."""
+    return {
+        'id': entry_id,
+        'environment_slug': environment_slug,
+        'entry_type': 'Deployed',
+        'description': description
+        if description is not None
+        else json.dumps({'action': 'deploy', 'plugin_slug': 'github'}),
+        'version': version,
+        'external_run_id': None,
+        '_row_version': 7,
+        'is_deleted': 0,
+    }
+
+
 def _event(
     *,
     status: str = 'success',
@@ -478,6 +500,78 @@ class ExecuteOpslogBackfillTests(unittest.IsolatedAsyncioTestCase):
         self.assertIsNone(row['link'])
         description = json.loads(str(row['description']))
         self.assertIsNone(description['run_url'])
+
+    async def test_fills_commit_sha_on_existing_row(self) -> None:
+        # A row written before the audit payload carried commit_sha is
+        # re-inserted with the edge's committish and a bumped
+        # _row_version, so ReplacingMergeTree collapses to the repaired
+        # row. The event itself dedupes away, so the repair is the only
+        # write.
+        outcome, instance = await self._run(
+            edge_rows=[_edge_row(deployments=[_event(external_run_id=None)])],
+            existing_ch_rows=[_existing_row()],
+        )
+        self.assertEqual('succeeded', outcome)
+        row = self._inserted_row(instance)
+        self.assertEqual('opslog-1', row['id'])
+        description = json.loads(str(row['description']))
+        self.assertEqual('abc1234', description['commit_sha'])
+        self.assertEqual('deploy', description['action'])
+        self.assertGreater(int(str(row['_row_version'])), 7)
+
+    async def test_leaves_rows_that_already_have_commit_sha(self) -> None:
+        outcome, instance = await self._run(
+            edge_rows=[_edge_row(deployments=[_event(external_run_id=None)])],
+            existing_ch_rows=[
+                _existing_row(
+                    description=json.dumps(
+                        {'action': 'deploy', 'commit_sha': 'abc1234'}
+                    )
+                )
+            ],
+        )
+        self.assertEqual('skipped', outcome)
+        instance.insert.assert_not_awaited()
+
+    async def test_leaves_free_text_descriptions_alone(self) -> None:
+        # Human-authored entries own their description; never rewrite one.
+        outcome, instance = await self._run(
+            edge_rows=[_edge_row(deployments=[_event(external_run_id=None)])],
+            existing_ch_rows=[
+                _existing_row(description='deployed by hand during incident')
+            ],
+        )
+        self.assertEqual('skipped', outcome)
+        instance.insert.assert_not_awaited()
+
+    async def test_repairs_row_matched_by_committish_version(self) -> None:
+        # The row records the committish as its version (an untagged
+        # deploy); it still gets the commit_sha so the tagged rows of the
+        # same release can join it.
+        _outcome, instance = await self._run(
+            edge_rows=[_edge_row(deployments=[_event(external_run_id=None)])],
+            existing_ch_rows=[_existing_row(version='abc1234')],
+        )
+        row = self._inserted_row(instance)
+        description = json.loads(str(row['description']))
+        self.assertEqual('abc1234', description['commit_sha'])
+
+    async def test_repairs_each_row_once(self) -> None:
+        # Two releases cut from the same commit both list the committish
+        # as a version candidate, so both edges resolve the same untagged
+        # row. It must be re-inserted once, not once per edge.
+        _outcome, instance = await self._run(
+            edge_rows=[
+                _edge_row(deployments=[_event(external_run_id=None)]),
+                _edge_row(
+                    tag='v1.2.4',
+                    deployments=[_event(external_run_id=None)],
+                ),
+            ],
+            existing_ch_rows=[_existing_row(version='abc1234')],
+        )
+        _table, values, _columns = instance.insert.await_args.args
+        self.assertEqual(1, len(values))
 
     async def test_existing_rows_query_filters_soft_deleted(self) -> None:
         # A tombstoned (is_deleted=1) ops-log row must not dedupe-suppress

--- a/ui/src/components/operations-log/OperationsLogReleaseCard.tsx
+++ b/ui/src/components/operations-log/OperationsLogReleaseCard.tsx
@@ -48,7 +48,7 @@ export const OperationsLogReleaseCard = memo(function OperationsLogReleaseCard({
   const latest = group.latestEntry
   const performer = latest.performed_by ?? latest.recorded_by
   const displayName = performerDisplayNames.get(performer) ?? performer
-  const version = group.stops[0]?.entry.version ?? latest.version ?? ''
+  const version = group.version || latest.version || ''
   const desc = renderEntryLabel(latest, {
     environment: environmentsBySlug.get(latest.environment_slug),
     performerDisplayName: displayName,

--- a/ui/src/components/operations-log/__tests__/opsLogHelpers.test.ts
+++ b/ui/src/components/operations-log/__tests__/opsLogHelpers.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it } from 'vitest'
+
+import type { OperationsLogRecord } from '@/types'
+
+import { groupReleases } from '../opsLogHelpers'
+
+const SHA = 'c67213d'
+
+function makeEntry(
+  overrides: Partial<OperationsLogRecord> = {},
+): OperationsLogRecord {
+  return {
+    description: payload('deploy'),
+    entry_type: 'Deployed',
+    environment_slug: 'production',
+    id: 'opslog-1',
+    occurred_at: '2026-07-27T12:25:28.139Z',
+    plugin_slug: 'github',
+    project_id: 'proj-1',
+    project_slug: 'webform',
+    recorded_at: '2026-07-27T12:25:28.139Z',
+    recorded_by: 'dang@aweber.com',
+    version: '1.29.0',
+    ...overrides,
+  }
+}
+
+function payload(action: string, sha: null | string = SHA): string {
+  return JSON.stringify({
+    action,
+    commit_sha: sha,
+    from_environment: action === 'promote' ? 'testing' : null,
+    plugin_slug: 'github',
+  })
+}
+
+describe('groupReleases', () => {
+  it('groups a promote and a deploy of the same version into one train', () => {
+    const items = groupReleases([
+      makeEntry(),
+      makeEntry({
+        description: payload('promote'),
+        environment_slug: 'staging',
+        id: 'opslog-2',
+        occurred_at: '2026-07-27T12:02:34.325Z',
+      }),
+    ])
+    expect(items).toHaveLength(1)
+    expect(items[0]!.kind).toBe('release')
+    if (items[0]!.kind !== 'release') return
+    const group = items[0]!.group
+    expect(group.version).toBe('1.29.0')
+    expect(group.latestEntry.id).toBe('opslog-1')
+    expect(group.stops.map((s) => s.environment_slug)).toEqual([
+      'production',
+      'staging',
+    ])
+  })
+
+  it('joins an untagged deploy to the train by committish', () => {
+    const items = groupReleases([
+      makeEntry(),
+      makeEntry({
+        description: payload('promote'),
+        environment_slug: 'staging',
+        id: 'staging',
+        occurred_at: '2026-07-27T12:02:34.325Z',
+      }),
+      // Testing shipped straight off the commit: no tag, so the sha is
+      // both the version and the committish.
+      makeEntry({
+        environment_slug: 'testing',
+        id: 'testing',
+        occurred_at: '2026-07-27T11:40:00.000Z',
+        version: SHA,
+      }),
+    ])
+    expect(items).toHaveLength(1)
+    if (items[0]!.kind !== 'release') return
+    expect(items[0]!.group.version).toBe('1.29.0')
+    expect(items[0]!.group.stops.map((s) => s.environment_slug)).toEqual([
+      'production',
+      'staging',
+      'testing',
+    ])
+  })
+
+  it('fuses trains that each knew only one identity', () => {
+    const items = groupReleases([
+      // Legacy row: tag but no recorded committish.
+      makeEntry({ description: payload('deploy', null), id: 'prod-no-sha' }),
+      makeEntry({
+        environment_slug: 'testing',
+        id: 'testing',
+        occurred_at: '2026-07-27T11:40:00.000Z',
+        version: SHA,
+      }),
+      // Knows both, so it fuses the two trains above.
+      makeEntry({
+        description: payload('promote'),
+        environment_slug: 'staging',
+        id: 'staging',
+        occurred_at: '2026-07-27T12:02:34.325Z',
+      }),
+    ])
+    expect(items).toHaveLength(1)
+    if (items[0]!.kind !== 'release') return
+    const group = items[0]!.group
+    expect(group.version).toBe('1.29.0')
+    expect(group.latestEntry.id).toBe('prod-no-sha')
+    expect(group.stops.map((s) => s.environment_slug).sort()).toEqual([
+      'production',
+      'staging',
+      'testing',
+    ])
+  })
+
+  it('keeps a tag as the display version over a bare committish', () => {
+    const items = groupReleases([
+      makeEntry({
+        environment_slug: 'testing',
+        id: 'testing',
+        occurred_at: '2026-07-27T12:40:00.000Z',
+        version: SHA,
+      }),
+      makeEntry({ id: 'prod', occurred_at: '2026-07-27T12:25:28.139Z' }),
+    ])
+    expect(items).toHaveLength(1)
+    if (items[0]!.kind !== 'release') return
+    expect(items[0]!.group.version).toBe('1.29.0')
+    expect(items[0]!.group.latestEntry.id).toBe('testing')
+  })
+
+  it('keeps different versions in separate groups', () => {
+    const items = groupReleases([
+      makeEntry(),
+      makeEntry({
+        description: payload('deploy', 'deadbee'),
+        id: 'opslog-3',
+        occurred_at: '2026-07-21T15:25:27.903Z',
+        version: '1.28.2',
+      }),
+    ])
+    expect(items).toHaveLength(2)
+    expect(
+      items.map((i) => (i.kind === 'release' ? i.group.version : null)),
+    ).toEqual(['1.29.0', '1.28.2'])
+  })
+
+  it('keeps the earliest deploy into each environment as the stop', () => {
+    const items = groupReleases([
+      makeEntry({ id: 'later', occurred_at: '2026-06-16T19:12:09.163Z' }),
+      makeEntry({ id: 'earlier', occurred_at: '2026-06-16T11:46:06.501Z' }),
+    ])
+    expect(items).toHaveLength(1)
+    if (items[0]!.kind !== 'release') return
+    expect(items[0]!.group.stops[0]!.entry.id).toBe('earlier')
+    expect(items[0]!.group.latestEntry.id).toBe('later')
+  })
+
+  it('leaves non-deploy entries and versionless deploys ungrouped', () => {
+    const items = groupReleases([
+      makeEntry({ entry_type: 'Configured', id: 'cfg', version: null }),
+      makeEntry({ id: 'no-version', version: null }),
+    ])
+    expect(items.map((i) => i.kind)).toEqual(['single', 'single'])
+  })
+
+  it('does not group the same version across projects', () => {
+    const items = groupReleases([
+      makeEntry(),
+      makeEntry({ id: 'other', project_slug: 'messages-client' }),
+    ])
+    expect(items).toHaveLength(2)
+  })
+})

--- a/ui/src/components/operations-log/__tests__/opsLogHelpers.test.ts
+++ b/ui/src/components/operations-log/__tests__/opsLogHelpers.test.ts
@@ -115,6 +115,42 @@ describe('groupReleases', () => {
     ])
   })
 
+  it('keeps the fused train in the newest slot of the two it merged', () => {
+    const items = groupReleases([
+      // Legacy row: tag but no recorded committish. Newest, so the train
+      // it opens is the slot the fused train has to keep.
+      makeEntry({ description: payload('deploy', null), id: 'prod-no-sha' }),
+      // Ungrouped row sitting between the two trains. If the merge kept
+      // the absorbed (older) train's slot instead, the fused train would
+      // sort below this restart.
+      makeEntry({
+        entry_type: 'Restarted',
+        id: 'restart',
+        occurred_at: '2026-07-27T12:10:00.000Z',
+        version: null,
+      }),
+      makeEntry({
+        environment_slug: 'testing',
+        id: 'testing',
+        occurred_at: '2026-07-27T11:40:00.000Z',
+        version: SHA,
+      }),
+      // Knows both identities, so it fuses the two trains above.
+      makeEntry({
+        description: payload('promote'),
+        environment_slug: 'staging',
+        id: 'staging',
+        occurred_at: '2026-07-27T12:02:34.325Z',
+      }),
+    ])
+    expect(items.map((i) => i.kind)).toEqual(['release', 'single'])
+    if (items[0]!.kind !== 'release') return
+    expect(items[0]!.group.latestEntry.id).toBe('prod-no-sha')
+    expect(items[0]!.group.stops.map((s) => s.environment_slug).sort()).toEqual(
+      ['production', 'staging', 'testing'],
+    )
+  })
+
   it('keeps a tag as the display version over a bare committish', () => {
     const items = groupReleases([
       makeEntry({

--- a/ui/src/components/operations-log/opsLogHelpers.ts
+++ b/ui/src/components/operations-log/opsLogHelpers.ts
@@ -17,10 +17,10 @@ export type FeedItem =
 export type OperationsLogView = 'grouped' | 'stream'
 
 export interface ReleaseGroup {
-  description: string
   latestEntry: OperationsLogRecord
   project_slug: string
   stops: ReleaseStop[]
+  version: string
 }
 
 export interface ReleaseStop {
@@ -30,10 +30,29 @@ export interface ReleaseStop {
 
 export type TimeRange = '7d' | '24h' | '30d' | '90d' | 'all'
 
+// Cheap targeted read of `commit_sha` out of the plugin-owned JSON
+// description. Grouping walks every loaded entry, so we skip a full
+// JSON.parse per row; the value is a hex committish, so there is no
+// escaping to honour.
+const COMMIT_SHA_RE = /"commit_sha"\s*:\s*"([^"]+)"/
+
 interface DayBucketKey {
   date: Date
   key: string
   label: string
+}
+
+// Grouping bookkeeping that never leaves this module: `envIndex` makes
+// the earliest-wins stop merge O(1) instead of a findIndex scan,
+// `stopMs`/`latestMs` cache parsed timestamps, and `slot` is the train's
+// position in the output so a merge can vacate the loser's row.
+interface ReleaseBucket {
+  envIndex: Map<string, number>
+  group: ReleaseGroup
+  latestMs: number
+  slot: number
+  stopMs: number[]
+  tagged: boolean
 }
 
 export function bucketByDay(
@@ -86,63 +105,75 @@ export function cleanName(email: null | string | undefined): string {
   return part || email
 }
 
-// Group contiguous same-version deploys of one project into a single
-// release train. Keys by `project_slug::description` — the API emits the
-// same description for each env a single release moves through.
+// Group every deploy of one release into a single release train.
+//
+// A release has two identities and the environments it passes through
+// don't all know both: an untagged deploy (testing ships straight off a
+// commit) records the committish as its `version`, while the promotion
+// that tags it records the tag as `version` and the same committish as
+// `commit_sha`. So an entry joins a train when it shares *either* the
+// version or the committish with it, and the train displays the tag once
+// any of its stops carries one. The JSON description payload differs per
+// action (`deploy` / `promote` / `redeploy`), so it is never an identity.
+//
+// Entries arrive newest-first; a train renders in the slot of its newest
+// entry. Rows that aren't versioned deploys stay ungrouped.
 export function groupReleases(entries: OperationsLogRecord[]): FeedItem[] {
-  // envIndexByGroup tracks env→stops index so the "earliest-wins" merge
-  // is O(1) instead of findIndex (avoids O(stops²) per group).
-  // latestMs tracks the group's current newest occurred_at in ms so we
-  // avoid re-parsing on every comparison.
-  const groups = new Map<string, ReleaseGroup>()
-  const envIndexByGroup = new Map<string, Map<string, number>>()
-  const latestMsByGroup = new Map<string, number>()
-  const stopMsByGroup = new Map<string, number[]>()
-  const order: FeedItem[] = []
+  const byKey = new Map<string, ReleaseBucket>()
+  // Slots of trains absorbed by a merge are nulled out rather than
+  // spliced, so surviving slot indices stay valid while we iterate.
+  const order: (FeedItem | null)[] = []
   for (const e of entries) {
-    if (e.entry_type !== 'Deployed') {
+    const version = (e.version || '').trim()
+    if (e.entry_type !== 'Deployed' || !version) {
       order.push({ entry: e, kind: 'single' })
       continue
     }
-    const descKey = (e.description || '').trim()
-    const key = `${e.project_slug}::${descKey}`
+    const sha = commitShaOf(e)
+    const keys = [`${e.project_slug}::v:${version}`]
+    if (sha) keys.push(`${e.project_slug}::c:${sha}`)
     const occurredMs = toMs(e.occurred_at)
-    let g = groups.get(key)
-    if (!g) {
-      g = {
-        description: descKey,
-        latestEntry: e,
-        project_slug: e.project_slug,
-        stops: [],
-      }
-      groups.set(key, g)
-      envIndexByGroup.set(key, new Map())
-      latestMsByGroup.set(key, occurredMs)
-      stopMsByGroup.set(key, [])
-      order.push({ group: g, kind: 'release' })
+    // Both keys can already point at trains built from entries that only
+    // knew one identity each -- that's the signal to fuse them.
+    let bucket: ReleaseBucket | undefined
+    for (const key of keys) {
+      const found = byKey.get(key)
+      if (!found) continue
+      bucket =
+        !bucket || found === bucket
+          ? found
+          : mergeBuckets(bucket, found, order, byKey)
     }
-    const envIndex = envIndexByGroup.get(key)!
-    const stopMs = stopMsByGroup.get(key)!
-    const envSlug = e.environment_slug
-    const existingIdx = envIndex.get(envSlug)
-    if (existingIdx !== undefined) {
-      // Keep the earliest deploy into each env.
-      if (occurredMs < stopMs[existingIdx]) {
-        g.stops[existingIdx] = { entry: e, environment_slug: envSlug }
-        stopMs[existingIdx] = occurredMs
+    if (!bucket) {
+      bucket = {
+        envIndex: new Map(),
+        group: {
+          latestEntry: e,
+          project_slug: e.project_slug,
+          stops: [],
+          version,
+        },
+        latestMs: occurredMs,
+        slot: order.length,
+        stopMs: [],
+        tagged: false,
       }
-    } else {
-      envIndex.set(envSlug, g.stops.length)
-      g.stops.push({ entry: e, environment_slug: envSlug })
-      stopMs.push(occurredMs)
+      order.push({ group: bucket.group, kind: 'release' })
     }
-    const latestMs = latestMsByGroup.get(key)!
-    if (occurredMs > latestMs) {
-      g.latestEntry = e
-      latestMsByGroup.set(key, occurredMs)
+    for (const key of keys) byKey.set(key, bucket)
+    addStop(bucket, e, occurredMs)
+    // A tag beats a bare committish as the train's display version; the
+    // first tag encountered (the newest) wins.
+    if (!bucket.tagged && version !== sha) {
+      bucket.group.version = version
+      bucket.tagged = true
+    }
+    if (occurredMs > bucket.latestMs) {
+      bucket.group.latestEntry = e
+      bucket.latestMs = occurredMs
     }
   }
-  return order
+  return order.filter((item): item is FeedItem => item !== null)
 }
 
 export { relTime } from '@/lib/formatDate'
@@ -154,6 +185,31 @@ export { relTime } from '@/lib/formatDate'
 // the allocation that causes GC pressure during bulk loads.
 export function toMs(iso: string): number {
   return Date.parse(iso)
+}
+
+function addStop(
+  bucket: ReleaseBucket,
+  entry: OperationsLogRecord,
+  occurredMs: number,
+): void {
+  const envSlug = entry.environment_slug
+  const existingIdx = bucket.envIndex.get(envSlug)
+  if (existingIdx === undefined) {
+    bucket.envIndex.set(envSlug, bucket.group.stops.length)
+    bucket.group.stops.push({ entry, environment_slug: envSlug })
+    bucket.stopMs.push(occurredMs)
+    return
+  }
+  // Keep the earliest deploy into each env: that's when the release
+  // reached it, not when it was last redeployed there.
+  if (occurredMs < bucket.stopMs[existingIdx]!) {
+    bucket.group.stops[existingIdx] = { entry, environment_slug: envSlug }
+    bucket.stopMs[existingIdx] = occurredMs
+  }
+}
+
+function commitShaOf(entry: OperationsLogRecord): string {
+  return COMMIT_SHA_RE.exec(entry.description ?? '')?.[1] ?? ''
 }
 
 function dayKeyFromDate(d: Date, todayMs: number): DayBucketKey {
@@ -170,6 +226,35 @@ function dayKeyFromDate(d: Date, todayMs: number): DayBucketKey {
     key: d.toDateString(),
     label: d.toLocaleDateString(undefined, { weekday: 'long' }),
   }
+}
+
+// Fuse two trains that turned out to be the same release. The one in the
+// earlier (newer) slot survives so the fused train keeps the newest
+// entry's position in the feed; the loser's slot is vacated and every key
+// pointing at it is repointed.
+function mergeBuckets(
+  a: ReleaseBucket,
+  b: ReleaseBucket,
+  order: (FeedItem | null)[],
+  byKey: Map<string, ReleaseBucket>,
+): ReleaseBucket {
+  const [keep, drop] = a.slot <= b.slot ? [a, b] : [b, a]
+  drop.group.stops.forEach((stop, i) => {
+    addStop(keep, stop.entry, drop.stopMs[i]!)
+  })
+  if (drop.latestMs > keep.latestMs) {
+    keep.group.latestEntry = drop.group.latestEntry
+    keep.latestMs = drop.latestMs
+  }
+  if (!keep.tagged && drop.tagged) {
+    keep.group.version = drop.group.version
+    keep.tagged = true
+  }
+  order[drop.slot] = null
+  for (const [key, bucket] of byKey) {
+    if (bucket === drop) byKey.set(key, keep)
+  }
+  return keep
 }
 
 function parseUtcIso(iso: string): Date {


### PR DESCRIPTION
## Summary

Operations-log release groupings were merging unrelated releases and reporting the wrong version, instead of collapsing the stages of one release into a single train. This keys trains on the release itself — version *and* committish — and adds the committish to the audit payload so every environment of a release can be correlated.

## Problem

`groupReleases` keyed groups on `project_slug::description`. But `description` on a deploy row is a plugin-owned JSON payload, not a per-release string:

```json
{"action":"deploy","from_environment":null,"plugin_slug":"github","release_url":null,"run_url":null}
```

Every production deploy of a project emits that byte-identical payload, so the key collapsed **all** of them into one group. Meanwhile the staging promote — whose payload differs (`action: "promote"`, `release_url` set) — could never join it.

Two visible consequences, both confirmed against production data for `webform`:

- The group's `stops` held a single `production` entry and the merge rule keeps the *earliest* deploy per env, so the stop was the 1.28.2 deploy while `latestEntry` was today's 1.29.0 deploy. The version column and train chip read off `stops[0]` (`1.28.2`); the description read off `latestEntry` ("Deployed 1.29.0 to Production").
- The 1.29.0 staging promote stayed a separate row, so there was no row reduction at all and the stage-recreating train never formed.

A release also has two identities, and the environments it passes through don't all know both: an untagged deploy (testing ships straight off a commit) records the committish as its `version`, while the promotion that tags it records the tag. The committish was never persisted on the row, so those two could not be joined.

## Solution

**UI — a train is joined by tag *or* committish** (`opsLogHelpers.ts`)

Each entry contributes two identity keys, `project::v:<version>` and `project::c:<commit_sha>`, and joins a train matching either. When both keys hit *different* trains — one built from an entry that knew only the tag (a legacy row with no `commit_sha`), another only the sha — `mergeBuckets` fuses them, keeping the newer slot so the row stays put in the feed. The train displays the tag once any of its stops carries one. `OperationsLogReleaseCard` reads `group.version` instead of `stops[0].entry.version`, so the header, chip, and description can no longer disagree.

For `webform` this turns three rows into one: Testing `c67213d` → Staging `1.29.0` → Production `1.29.0`, headline version `1.29.0`.

**API — record the committish even when there's a tag**

Every writer already had it in hand; `deployed_operation_log` was discarding it via `version = tag or committish`. It now also emits `commit_sha` in the audit payload (which surfaces in the expanded details panel for free). Covers deploy, redeploy, promote, release-cut, and the maintenance backfill.

**API — `opslog-backfill` repairs existing rows**

The operation was insert-only with dedupe, so it would never have fixed the history. It now also enriches in place: any existing `Deployed` row whose payload predates `commit_sha` is re-inserted with the committish from its deployment edge and a bumped `_row_version` — the same read-modify-insert on the `ReplacingMergeTree` that the PATCH endpoint and `complete_opslog_entry` use. Free-text descriptions (human-authored entries) are never rewritten, and a row shared by two releases cut from the same commit is rewritten once.

## Verification

- 8 new `groupReleases` cases: committish join, two-identity fusion, tag-beats-sha, earliest-per-env stop, versionless/non-deploy rows ungrouped, cross-project isolation.
- 5 new backfill cases: repairs an existing row (same `id`, `commit_sha` filled, `_row_version` bumped), skips rows that already have it, never touches free text, matches by committish version, rewrites a shared row once. Plus 2 on the audit payload itself.
- Full UI suite 585/585, `tsc --noEmit`, oxlint (0 errors), oxfmt, `ruff check` (incl. the C901 gate) and `ruff format` all clean.
- `tests/endpoints/test_maintenance.py` could not be run locally — it hangs constructing the shared app without Postgres/Valkey forwarded. CI covers it.

## Operational note

Only rows written from here on carry the committish. **Run the *Backfill Deployments to Operations Log* maintenance operation once after this deploys** to correlate the existing history. The repair sources the committish from `Release.committish` on the `DEPLOYED_TO` edge, so a release whose graph node lacks one stays uncorrelated — run *Sync Deployments* / *Sync Commits & Tags* first for maximum coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
