### PR TITLE
Add release blocking to stop a bad release shipping

### DIFF
--- a/apps/api/src/imbi/api/endpoints/project_deployments.py
+++ b/apps/api/src/imbi/api/endpoints/project_deployments.py
@@ -260,6 +260,36 @@ class ReleaseHistoryEntry(pydantic.BaseModel):
     release_url: str | None = None
     tag_url: str | None = None
     package_url: str | None = None
+    #: ``True`` when the release is blocked from shipping. Deploys and
+    #: promotes targeting it are refused with a 409; the UI renders the
+    #: row as blocked and surfaces ``blocked_reason``.
+    blocked: bool = False
+    blocked_reason: str | None = None
+    blocked_by: str | None = None
+    blocked_at: datetime.datetime | None = None
+
+
+class ReleaseBlockRequest(pydantic.BaseModel):
+    """Body for ``POST /deployments/releases/{tag}/block``."""
+
+    model_config = pydantic.ConfigDict(extra='forbid')
+
+    reason: typing.Annotated[
+        str,
+        pydantic.StringConstraints(
+            strip_whitespace=True, min_length=1, max_length=500
+        ),
+    ]
+
+
+class ReleaseBlockResponse(pydantic.BaseModel):
+    """Block state for a release after a block / unblock."""
+
+    tag: str
+    blocked: bool
+    blocked_reason: str | None = None
+    blocked_by: str | None = None
+    blocked_at: datetime.datetime | None = None
 
 
 class ReleaseCutRequest(pydantic.BaseModel):
@@ -1480,6 +1510,14 @@ async def _handle_deploy(
                 "this env's can_deploy flag."
             ),
         )
+    # Refuse before touching the plugin: a blocked release must not reach
+    # the remote at all, and the check is a single graph read.
+    await _assert_not_blocked(
+        db,
+        project_id,
+        tag=body.ref_label,
+        committish=body.committish[:7].lower(),
+    )
     resolved, ctx, credentials = await _resolve_and_context(
         db,
         org_slug,
@@ -1780,6 +1818,18 @@ async def _handle_promote(
                 "Enable the env's can_promote flag to allow promotes."
             ),
         )
+
+    # ``body.tag`` may name an existing release (promote-from-tag) or a SHA
+    # a new tag gets cut at; ``from_committish`` is the build being
+    # promoted.  Either identity resolving to a blocked release stops the
+    # promote, so blocking a rolled-back tag also stops it being re-cut
+    # from the same commit.
+    await _assert_not_blocked(
+        db,
+        project_id,
+        tag=body.tag,
+        committish=body.from_committish[:7].lower(),
+    )
 
     # Infer promote behaviour from the ref shape of ``body.tag``:
     #
@@ -2729,6 +2779,7 @@ async def get_release_history(
         node = nodes.get(name) or {}
         tagger = row.get('tagger_name')
         created_by = node.get('created_by')
+        blocked_at = node.get('blocked_at')
         entries.append(
             ReleaseHistoryEntry(
                 tag=name,
@@ -2747,6 +2798,10 @@ async def get_release_history(
                 release_url=_release_url_from_links(node.get('links')),
                 tag_url=str(row['url']) if row.get('url') else None,
                 package_url=None,
+                blocked=bool(blocked_at),
+                blocked_reason=node.get('blocked_reason'),
+                blocked_by=node.get('blocked_by'),
+                blocked_at=blocked_at,
             )
         )
     # Order by released version (highest semver first) so the head of the
@@ -2870,3 +2925,252 @@ async def cut_release(
         recorded=True,
         warning='; '.join(warnings) if warnings else None,
     )
+
+
+# ---------------------------------------------------------------------------
+# Release blocks
+#
+# Blocking a release keeps it from shipping again -- the rollback follow-up:
+# a regression is found, the release is rolled back, and the tag is blocked
+# so nobody re-deploys or re-promotes it while the fix is in flight.  The
+# block is global (every environment) and carries a required reason.  State
+# lives on the ``Release`` node as ``blocked_at`` / ``blocked_by`` /
+# ``blocked_reason``; ``blocked_at`` is the flag.
+# ---------------------------------------------------------------------------
+
+
+async def _tag_sha(project_id: str, tag: str) -> str | None:
+    """Return the synced commit SHA for ``tag``, or ``None``."""
+    rows = await clickhouse.query(
+        'SELECT sha FROM tags FINAL '
+        'WHERE project_id = {project_id:String} AND name = {tag:String} '
+        'LIMIT 1',
+        {'project_id': project_id, 'tag': tag},
+    )
+    return str(rows[0]['sha']) if rows and rows[0].get('sha') else None
+
+
+async def _set_release_block(
+    db: graph.Graph,
+    *,
+    org_slug: str,
+    project_id: str,
+    tag: str,
+    blocked_at: str | None,
+    blocked_by: str | None,
+    reason: str | None,
+) -> bool:
+    """Write the ``blocked_*`` properties on a tagged ``Release``.
+
+    Passing ``None`` for all three clears the block (AGE stores a
+    ``null`` assignment as property removal).  Returns ``False`` when no
+    ``Release`` node for ``tag`` exists under the org, letting the caller
+    decide between creating one and returning a 404.
+    """
+    query: typing.LiteralString = """
+    MATCH (p:Project {{id: {project_id}}})
+          -[:OWNED_BY]->(:Team)
+          -[:BELONGS_TO]->(:Organization {{slug: {org_slug}}})
+    MATCH (p)-[:HAS_RELEASE]->(r:Release {{tag: {tag}}})
+    SET r.blocked_at = {blocked_at},
+        r.blocked_by = {blocked_by},
+        r.blocked_reason = {reason},
+        r.updated_at = {now}
+    RETURN r.id AS rid
+    """
+    rows = await db.execute(
+        query,
+        {
+            'project_id': project_id,
+            'org_slug': org_slug,
+            'tag': tag,
+            'blocked_at': blocked_at,
+            'blocked_by': blocked_by,
+            'reason': reason,
+            'now': datetime.datetime.now(datetime.UTC).isoformat(),
+        },
+        ['rid'],
+    )
+    return bool(rows)
+
+
+async def _blocked_release(
+    db: graph.Graph,
+    project_id: str,
+    *,
+    tag: str | None,
+    committish: str | None,
+) -> tuple[str, str | None] | None:
+    """Return ``(tag_or_committish, reason)`` for a blocked release.
+
+    Matches on either identity so both shipping paths are covered: a
+    deploy names a tag or a raw SHA, and a promote names the tag being
+    promoted plus the committish it was cut from.  ``None`` means
+    nothing blocked matches.  Empty strings stand in for the absent
+    identity -- neither ever matches a stored value, and AGE has no
+    NULL equality.
+    """
+    query: typing.LiteralString = """
+    MATCH (:Project {{id: {project_id}}})-[:HAS_RELEASE]->(r:Release)
+    WHERE r.blocked_at IS NOT NULL
+      AND (COALESCE(r.tag, '') = {tag}
+           OR COALESCE(r.committish, '') = {committish})
+    RETURN r{{.tag, .committish, .blocked_reason}} AS release
+    """
+    rows = await db.execute(
+        query,
+        {
+            'project_id': project_id,
+            'tag': tag or '',
+            'committish': committish or '',
+        },
+        ['release'],
+    )
+    if not rows:
+        return None
+    node = typing.cast(
+        'dict[str, typing.Any]', graph.parse_agtype(rows[0]['release'])
+    )
+    label = node.get('tag') or node.get('committish') or (tag or committish)
+    reason = node.get('blocked_reason')
+    return str(label), str(reason) if reason else None
+
+
+async def _assert_not_blocked(
+    db: graph.Graph,
+    project_id: str,
+    *,
+    tag: str | None = None,
+    committish: str | None = None,
+) -> None:
+    """Raise 409 when the release being shipped is blocked."""
+    blocked = await _blocked_release(
+        db, project_id, tag=tag, committish=committish
+    )
+    if blocked is None:
+        return
+    label, reason = blocked
+    detail = f'Release {label!r} is blocked and cannot be deployed'
+    if reason:
+        detail += f': {reason}'
+    raise fastapi.HTTPException(status_code=409, detail=detail)
+
+
+@project_deployments_router.post('/releases/{tag}/block')
+async def block_release(
+    org_slug: str,
+    project_id: str,
+    tag: str,
+    body: ReleaseBlockRequest,
+    db: graph.Pool,
+    auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(
+            permissions.require_permission('project:deployment:write'),
+        ),
+    ],
+) -> ReleaseBlockResponse:
+    """Block ``tag`` from being deployed or promoted, with a reason.
+
+    Blocking is idempotent and re-blocking overwrites the reason and
+    re-stamps the actor.  A tag that has been synced but never cut
+    through Imbi has no ``Release`` node yet; one is created from the
+    synced tag so the block still holds.  A tag Imbi has never seen is
+    a 404.
+    """
+    blocked_at = datetime.datetime.now(datetime.UTC)
+    matched = await _set_release_block(
+        db,
+        org_slug=org_slug,
+        project_id=project_id,
+        tag=tag,
+        blocked_at=blocked_at.isoformat(),
+        blocked_by=auth.principal_name,
+        reason=body.reason,
+    )
+    if not matched:
+        sha = await _tag_sha(project_id, tag)
+        if sha is None:
+            raise fastapi.HTTPException(
+                status_code=404,
+                detail=f'No release found for tag {tag!r}',
+            )
+        await _upsert_release_node(
+            db,
+            project_id=project_id,
+            tag=tag,
+            committish=sha[:7].lower(),
+            title=tag,
+            notes_markdown='',
+            release_url=None,
+            created_by=auth.principal_name,
+        )
+        matched = await _set_release_block(
+            db,
+            org_slug=org_slug,
+            project_id=project_id,
+            tag=tag,
+            blocked_at=blocked_at.isoformat(),
+            blocked_by=auth.principal_name,
+            reason=body.reason,
+        )
+        if not matched:
+            raise fastapi.HTTPException(
+                status_code=404,
+                detail=f'No release found for tag {tag!r}',
+            )
+    LOGGER.info(
+        'Release blocked: project=%s tag=%s actor=%s reason=%s',
+        project_id,
+        tag,
+        auth.principal_name,
+        body.reason,
+    )
+    return ReleaseBlockResponse(
+        tag=tag,
+        blocked=True,
+        blocked_reason=body.reason,
+        blocked_by=auth.principal_name,
+        blocked_at=blocked_at,
+    )
+
+
+@project_deployments_router.delete('/releases/{tag}/block')
+async def unblock_release(
+    org_slug: str,
+    project_id: str,
+    tag: str,
+    db: graph.Pool,
+    auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(
+            permissions.require_permission('project:deployment:write'),
+        ),
+    ],
+) -> ReleaseBlockResponse:
+    """Clear the block on ``tag``, letting it ship again.
+
+    Unblocking an unblocked release is a no-op, not an error; a 404 only
+    means no ``Release`` node exists for the tag.
+    """
+    matched = await _set_release_block(
+        db,
+        org_slug=org_slug,
+        project_id=project_id,
+        tag=tag,
+        blocked_at=None,
+        blocked_by=None,
+        reason=None,
+    )
+    if not matched:
+        raise fastapi.HTTPException(
+            status_code=404,
+            detail=f'No release found for tag {tag!r}',
+        )
+    LOGGER.info(
+        'Release unblocked: project=%s tag=%s actor=%s',
+        project_id,
+        tag,
+        auth.principal_name,
+    )
+    return ReleaseBlockResponse(tag=tag, blocked=False)

--- a/apps/api/tests/endpoints/test_project_deployments.py
+++ b/apps/api/tests/endpoints/test_project_deployments.py
@@ -2445,11 +2445,23 @@ class ReleaseBlockTestCase(ProjectDeploymentsTestCase):
 
     def test_block_creates_release_node_for_a_synced_tag(self) -> None:
         """A tag synced but never cut in Imbi still blocks."""
-        # First SET matches nothing; after the upsert the second SET does.
-        # The upsert itself issues a create then an update read.
-        self.mock_db.execute = mock.AsyncMock(
-            side_effect=[[], [], [{'rid': 'r9'}], [{'rid': 'r9'}]]
-        )
+        # Dispatch on the query rather than call order: the block only
+        # lands once the upsert has created the node, and keying off the
+        # text survives a change in how many round-trips the upsert makes.
+        created: dict[str, bool] = {'node': False}
+
+        def _execute(
+            query: str, params: typing.Any, columns: typing.Any
+        ) -> list[dict[str, typing.Any]]:
+            del params, columns
+            if 'CREATE (p)-[:HAS_RELEASE]' in query:
+                created['node'] = True
+                return []
+            if 'SET r.blocked_at' in query:
+                return [{'rid': 'r9'}] if created['node'] else []
+            return [{'rid': 'r9'}]
+
+        self.mock_db.execute = mock.AsyncMock(side_effect=_execute)
         query = mock.AsyncMock(return_value=[{'sha': '1a9c610abcdef'}])
         with (
             mock.patch(f'{_MODULE}.clickhouse.query', new=query),

--- a/apps/api/tests/endpoints/test_project_deployments.py
+++ b/apps/api/tests/endpoints/test_project_deployments.py
@@ -245,6 +245,11 @@ class ProjectDeploymentsTestCase(support.SharedAppTestCase):
             mock_get_current_user
         )
         self.mock_db = mock.AsyncMock(spec=graph.Graph)
+        # Default every ad-hoc Cypher read to "no rows".  Without this the
+        # AsyncMock hands back a truthy MagicMock, which reads as a match to
+        # any caller that treats a non-empty result as a hit (e.g. the
+        # release-block gate).  Tests needing rows set their own side_effect.
+        self.mock_db.execute = mock.AsyncMock(return_value=[])
         self.test_app.dependency_overrides[graph._inject_graph] = lambda: (
             self.mock_db
         )
@@ -2360,6 +2365,215 @@ class ReleasesTabEndpointsTestCase(ProjectDeploymentsTestCase):
         data = response.json()
         self.assertIsNotNone(data['warning'])
         self.assertIn('create_release', data['warning'])
+
+
+class ReleaseBlockTestCase(ProjectDeploymentsTestCase):
+    """Blocking a release, unblocking it, and the deploy / promote gate."""
+
+    _BASE = '/organizations/myorg/projects/proj1/deployments'
+    _BLOCK = f'{_BASE}/releases/v3.32.2/block'
+
+    @staticmethod
+    def _blocked_row(
+        *,
+        tag: str = 'v3.32.2',
+        committish: str = '1a9c610',
+        reason: str | None = 'Regression in checkout',
+    ) -> list[dict[str, typing.Any]]:
+        """One row shaped like the ``_blocked_release`` projection."""
+        return [
+            {
+                'release': json.dumps(
+                    {
+                        'tag': tag,
+                        'committish': committish,
+                        'blocked_reason': reason,
+                    }
+                )
+            }
+        ]
+
+    def test_block_sets_state_and_echoes_reason(self) -> None:
+        self.mock_db.execute = mock.AsyncMock(return_value=[{'rid': 'r1'}])
+        with testclient.TestClient(self.test_app) as client:
+            response = client.post(
+                self._BLOCK, json={'reason': 'Regression in checkout'}
+            )
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(data['tag'], 'v3.32.2')
+        self.assertTrue(data['blocked'])
+        self.assertEqual(data['blocked_reason'], 'Regression in checkout')
+        self.assertEqual(data['blocked_by'], 'admin@example.com')
+        self.assertIsNotNone(data['blocked_at'])
+
+    def test_block_requires_a_reason(self) -> None:
+        with testclient.TestClient(self.test_app) as client:
+            blank = client.post(self._BLOCK, json={'reason': '   '})
+            missing = client.post(self._BLOCK, json={})
+        self.assertEqual(blank.status_code, 422)
+        self.assertEqual(missing.status_code, 422)
+
+    def test_block_creates_release_node_for_a_synced_tag(self) -> None:
+        """A tag synced but never cut in Imbi still blocks."""
+        # First SET matches nothing; after the upsert the second SET does.
+        # The upsert itself issues a create then an update read.
+        self.mock_db.execute = mock.AsyncMock(
+            side_effect=[[], [], [{'rid': 'r9'}], [{'rid': 'r9'}]]
+        )
+        query = mock.AsyncMock(return_value=[{'sha': '1a9c610abcdef'}])
+        with (
+            mock.patch(f'{_MODULE}.clickhouse.query', new=query),
+            testclient.TestClient(self.test_app) as client,
+        ):
+            response = client.post(self._BLOCK, json={'reason': 'Rolled back'})
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.json()['blocked'])
+        self.assertEqual(query.await_args.args[1]['tag'], 'v3.32.2')
+
+    def test_block_unknown_tag_is_404(self) -> None:
+        self.mock_db.execute = mock.AsyncMock(return_value=[])
+        with (
+            mock.patch(
+                f'{_MODULE}.clickhouse.query',
+                new=mock.AsyncMock(return_value=[]),
+            ),
+            testclient.TestClient(self.test_app) as client,
+        ):
+            response = client.post(self._BLOCK, json={'reason': 'Rolled back'})
+        self.assertEqual(response.status_code, 404)
+        self.assertIn('No release found', response.json()['detail'])
+
+    def test_unblock_clears_the_state(self) -> None:
+        self.mock_db.execute = mock.AsyncMock(return_value=[{'rid': 'r1'}])
+        with testclient.TestClient(self.test_app) as client:
+            response = client.delete(self._BLOCK)
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertFalse(data['blocked'])
+        self.assertIsNone(data['blocked_reason'])
+        # All three properties are nulled in the SET.
+        params = self.mock_db.execute.await_args.args[1]
+        self.assertIsNone(params['blocked_at'])
+        self.assertIsNone(params['blocked_by'])
+        self.assertIsNone(params['reason'])
+
+    def test_unblock_unknown_tag_is_404(self) -> None:
+        self.mock_db.execute = mock.AsyncMock(return_value=[])
+        with testclient.TestClient(self.test_app) as client:
+            response = client.delete(self._BLOCK)
+        self.assertEqual(response.status_code, 404)
+
+    def test_deploy_of_a_blocked_release_is_409_with_the_reason(self) -> None:
+        self.mock_db.execute = mock.AsyncMock(return_value=self._blocked_row())
+        with testclient.TestClient(self.test_app) as client:
+            response = client.post(
+                self._BASE,
+                json={
+                    'action': 'deploy',
+                    'environment': 'production',
+                    'committish': '1a9c610',
+                    'ref_label': 'v3.32.2',
+                },
+            )
+        self.assertEqual(response.status_code, 409)
+        detail = response.json()['detail']
+        self.assertIn("Release 'v3.32.2' is blocked", detail)
+        self.assertIn('Regression in checkout', detail)
+
+    def test_promote_of_a_blocked_release_is_409(self) -> None:
+        self.mock_db.execute = mock.AsyncMock(return_value=self._blocked_row())
+        with testclient.TestClient(self.test_app) as client:
+            response = client.post(
+                self._BASE,
+                json={
+                    'action': 'promote',
+                    'from_environment': 'staging',
+                    'to_environment': 'production',
+                    'from_committish': '1a9c610',
+                    'tag': 'v3.32.2',
+                },
+            )
+        self.assertEqual(response.status_code, 409)
+        self.assertIn('is blocked', response.json()['detail'])
+
+    def test_block_gate_omits_the_reason_when_none_recorded(self) -> None:
+        self.mock_db.execute = mock.AsyncMock(
+            return_value=self._blocked_row(reason=None)
+        )
+        with testclient.TestClient(self.test_app) as client:
+            response = client.post(
+                self._BASE,
+                json={
+                    'action': 'deploy',
+                    'environment': 'production',
+                    'committish': '1a9c610',
+                    'ref_label': 'v3.32.2',
+                },
+            )
+        self.assertEqual(response.status_code, 409)
+        self.assertEqual(
+            response.json()['detail'],
+            "Release 'v3.32.2' is blocked and cannot be deployed",
+        )
+
+    def test_release_history_reports_block_state(self) -> None:
+        when = datetime.datetime(2026, 1, 1, tzinfo=datetime.UTC)
+        blocked_at = datetime.datetime(2026, 1, 3, tzinfo=datetime.UTC)
+        query = mock.AsyncMock(
+            side_effect=[
+                [
+                    {
+                        'name': 'v3.32.2',
+                        'sha': 'sha3322',
+                        'tagged_at': when,
+                        'tagger_name': 'Rel Bot',
+                        'url': '',
+                        'recorded_at': when,
+                    },
+                    {
+                        'name': 'v3.32.1',
+                        'sha': 'sha3321',
+                        'tagged_at': when,
+                        'tagger_name': 'Rel Bot',
+                        'url': '',
+                        'recorded_at': when,
+                    },
+                ],
+                [],  # ci_status lookup
+            ]
+        )
+        self.mock_db.execute = mock.AsyncMock(
+            return_value=[
+                {
+                    'release': json.dumps(
+                        {
+                            'tag': 'v3.32.2',
+                            'title': 'Release 3.32.2',
+                            'created_by': 'gr',
+                            'blocked_at': blocked_at.isoformat(),
+                            'blocked_by': 'admin@example.com',
+                            'blocked_reason': 'Regression in checkout',
+                        }
+                    )
+                }
+            ]
+        )
+        with (
+            mock.patch(f'{_MODULE}.clickhouse.query', new=query),
+            testclient.TestClient(self.test_app) as client,
+        ):
+            response = client.get(f'{self._BASE}/release-history')
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(data[0]['tag'], 'v3.32.2')
+        self.assertTrue(data[0]['blocked'])
+        self.assertEqual(data[0]['blocked_reason'], 'Regression in checkout')
+        self.assertEqual(data[0]['blocked_by'], 'admin@example.com')
+        self.assertIsNotNone(data[0]['blocked_at'])
+        # A tag with no Release node is not blocked.
+        self.assertFalse(data[1]['blocked'])
+        self.assertIsNone(data[1]['blocked_reason'])
 
 
 class ResolveTagFormatsTestCase(unittest.IsolatedAsyncioTestCase):

--- a/libraries/common/src/imbi/common/models.py
+++ b/libraries/common/src/imbi/common/models.py
@@ -897,6 +897,12 @@ class Release(GraphModel):
     share a tag like ``1.0.0``).  The active tag format is a runtime
     setting — see ``imbi.common.versioning.validate_version``.
 
+    A release may be blocked to keep it from shipping again — e.g. after
+    a rollback exposed a regression.  ``blocked_at`` is the flag: when it
+    is set, deploys and promotes targeting this release are refused, and
+    ``blocked_reason`` explains why.  Unblocking clears all three
+    ``blocked_*`` properties.
+
     """
 
     project: typing.Annotated[
@@ -929,6 +935,9 @@ class Release(GraphModel):
             ),
         ),
     ]
+    blocked_at: datetime.datetime | None = None
+    blocked_by: str | None = None
+    blocked_reason: str | None = None
 
 
 class ReleaseDeploymentEdge(RelationshipEdge):

--- a/ui/src/api/releases.ts
+++ b/ui/src/api/releases.ts
@@ -3,6 +3,8 @@
 import type {
   CutReleaseRequest,
   CutReleaseResponse,
+  ReleaseBlockRequest,
+  ReleaseBlockResponse,
   ReleaseDrift,
   ReleaseHistoryEntry,
 } from '@/types'
@@ -48,3 +50,21 @@ export const cutRelease = (
     `${base(orgSlug, projectId)}/releases/cut`,
     body,
   )
+
+const blockPath = (orgSlug: string, projectId: string, tag: string): string =>
+  `${base(orgSlug, projectId)}/releases/${encodeURIComponent(tag)}/block`
+
+export const blockRelease = (
+  orgSlug: string,
+  projectId: string,
+  tag: string,
+  body: ReleaseBlockRequest,
+): Promise<ReleaseBlockResponse> =>
+  apiClient.post<ReleaseBlockResponse>(blockPath(orgSlug, projectId, tag), body)
+
+export const unblockRelease = (
+  orgSlug: string,
+  projectId: string,
+  tag: string,
+): Promise<ReleaseBlockResponse> =>
+  apiClient.delete<ReleaseBlockResponse>(blockPath(orgSlug, projectId, tag))

--- a/ui/src/components/deployments/CurrentlyRunningCard.test.tsx
+++ b/ui/src/components/deployments/CurrentlyRunningCard.test.tsx
@@ -1,7 +1,8 @@
-import { screen } from '@testing-library/react'
+import { screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import * as releases from '@/api/releases'
 import { render } from '@/test/utils'
 import type {
   CurrentReleaseEnvironment,
@@ -12,6 +13,20 @@ import type {
 import { CurrentlyRunningCard } from './CurrentlyRunningCard'
 import type { PipelineStage } from './pipeline'
 import type { DeploymentActions } from './useDeploymentActions'
+
+// fallow-ignore-next-line unresolved-import
+vi.mock('@/api/releases', async () => {
+  const actual =
+    await vi.importActual<typeof import('@/api/releases')>('@/api/releases')
+  return { ...actual, blockRelease: vi.fn(), unblockRelease: vi.fn() }
+})
+
+vi.mock('sonner', () => ({
+  toast: { error: vi.fn(), success: vi.fn() },
+}))
+
+const blockRelease = vi.mocked(releases.blockRelease)
+const unblockRelease = vi.mocked(releases.unblockRelease)
 
 const ENV = {
   id: 'production',
@@ -70,16 +85,38 @@ const makeActions = (): DeploymentActions => ({
   promotePending: false,
 })
 
+const renderCard = (stage: PipelineStage = STAGE, actions = makeActions()) =>
+  render(
+    <CurrentlyRunningCard
+      accent={null}
+      actions={actions}
+      canTrigger
+      orgSlug="acme"
+      projectId="p1"
+      stage={stage}
+    />,
+  )
+
+/** The row toggle; anchored so the "Block <tag>" action doesn't match. */
+const rowToggle = (tag: string) =>
+  screen.getByRole('button', {
+    name: new RegExp(`^${tag.replace('.', '\\.')}`),
+  })
+
+const stageWith = (rel: ReleaseHistoryEntry): PipelineStage => ({
+  ...STAGE,
+  rollbackTargets: [rel],
+})
+
 describe('CurrentlyRunningCard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    blockRelease.mockResolvedValue({ blocked: true, tag: 'v6.4.0' })
+    unblockRelease.mockResolvedValue({ blocked: false, tag: 'v6.4.0' })
+  })
+
   it('shows the running version, deployer, and environment URL', () => {
-    render(
-      <CurrentlyRunningCard
-        accent={null}
-        actions={makeActions()}
-        canTrigger
-        stage={STAGE}
-      />,
-    )
+    renderCard()
     expect(screen.getByText('v6.5.0')).toBeInTheDocument()
     expect(screen.getByText('gavin')).toBeInTheDocument()
     expect(screen.getByText('service.example.com')).toBeInTheDocument()
@@ -87,29 +124,15 @@ describe('CurrentlyRunningCard', () => {
 
   it('expands a recent release into its notes', async () => {
     const user = userEvent.setup()
-    render(
-      <CurrentlyRunningCard
-        accent={null}
-        actions={makeActions()}
-        canTrigger
-        stage={STAGE}
-      />,
-    )
-    await user.click(screen.getByRole('button', { name: /v6\.4\.0/ }))
+    renderCard()
+    await user.click(rowToggle('v6.4.0'))
     expect(screen.getByText('old fix')).toBeInTheDocument()
   })
 
   it('rolls back through the confirm dialog', async () => {
     const actions = makeActions()
     const user = userEvent.setup()
-    render(
-      <CurrentlyRunningCard
-        accent={null}
-        actions={actions}
-        canTrigger
-        stage={STAGE}
-      />,
-    )
+    renderCard(STAGE, actions)
     await user.click(screen.getByRole('button', { name: 'Roll back' }))
     await user.click(
       screen.getByRole('button', { name: 'Roll back to v6.4.0' }),
@@ -122,5 +145,41 @@ describe('CurrentlyRunningCard', () => {
       rollback: true,
       sha: '000999000999',
     })
+  })
+
+  it('blocks a recent release with a reason', async () => {
+    const user = userEvent.setup()
+    renderCard()
+    await user.click(screen.getByRole('button', { name: 'Block v6.4.0' }))
+    const submit = screen.getByRole('button', { name: 'Block v6.4.0' })
+    expect(submit).toBeDisabled()
+    await user.type(screen.getByRole('textbox'), 'Regression in checkout')
+    await user.click(submit)
+    await waitFor(() =>
+      expect(blockRelease).toHaveBeenCalledWith('acme', 'p1', 'v6.4.0', {
+        reason: 'Regression in checkout',
+      }),
+    )
+  })
+
+  it('will not roll back to a blocked release, and can unblock it', async () => {
+    const user = userEvent.setup()
+    renderCard(
+      stageWith({
+        ...ROLLBACK,
+        blocked: true,
+        blocked_by: 'gavinr@aweber.com',
+        blocked_reason: 'Regression in checkout',
+      }),
+    )
+    // The Blocked badge replaces the Roll back button outright.
+    expect(screen.getByText('Blocked')).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Roll back' })).toBeNull()
+    // Unblock sits with the reason, not in the collapsed row.
+    expect(screen.queryByRole('button', { name: 'Unblock' })).toBeNull()
+    await user.click(rowToggle('v6.4.0'))
+    expect(screen.getByText(/Regression in checkout/)).toBeInTheDocument()
+    await user.click(screen.getByRole('button', { name: 'Unblock' }))
+    expect(unblockRelease).toHaveBeenCalledWith('acme', 'p1', 'v6.4.0')
   })
 })

--- a/ui/src/components/deployments/CurrentlyRunningCard.tsx
+++ b/ui/src/components/deployments/CurrentlyRunningCard.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 
 import {
+  Ban,
   ChevronDown,
   ChevronRight,
   CircleDot,
@@ -9,7 +10,10 @@ import {
   RotateCcw,
 } from 'lucide-react'
 
+import { BlockReleaseDialog } from '@/components/releases/BlockReleaseDialog'
 import { CiStatusDot } from '@/components/releases/CiStatusDot'
+import { useReleaseBlockMutation } from '@/components/releases/useReleaseBlockMutation'
+import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { RelativeTime } from '@/components/ui/RelativeTime'
 import { UserIdentity } from '@/components/ui/user-identity'
@@ -27,6 +31,8 @@ interface CurrentlyRunningCardProps {
   accent: ChipColors | null
   actions: DeploymentActions
   canTrigger: boolean
+  orgSlug: string
+  projectId: string
   stage: PipelineStage
 }
 
@@ -39,10 +45,21 @@ export function CurrentlyRunningCard({
   accent,
   actions,
   canTrigger,
+  orgSlug,
+  projectId,
   stage,
 }: CurrentlyRunningCardProps) {
   const [openTag, setOpenTag] = useState<null | string>(null)
   const [confirming, setConfirming] = useState<null | ReleaseHistoryEntry>(null)
+  const [blocking, setBlocking] = useState<null | string>(null)
+  const {
+    block,
+    isPending: blockPending,
+    unblock,
+  } = useReleaseBlockMutation({
+    orgSlug,
+    projectId,
+  })
   const release = stage.current?.release ?? null
   const envUrl = sanitizeHttpUrl(stage.env.url ?? null)
 
@@ -139,13 +156,16 @@ export function CurrentlyRunningCard({
             </p>
             {stage.rollbackTargets.map((rel) => (
               <RollbackRow
+                blockPending={blockPending}
                 canTrigger={canTrigger}
                 isOpen={openTag === rel.tag}
                 key={rel.tag}
+                onBlock={() => setBlocking(rel.tag)}
                 onRollback={() => setConfirming(rel)}
                 onToggle={() =>
                   setOpenTag((o) => (o === rel.tag ? null : rel.tag))
                 }
+                onUnblock={() => unblock(rel.tag)}
                 rel={rel}
               />
             ))}
@@ -184,23 +204,44 @@ export function CurrentlyRunningCard({
         open={confirming !== null}
         title={`Roll back ${stage.env.name}?`}
       />
+
+      <BlockReleaseDialog
+        isPending={blockPending}
+        onBlock={(reason) => {
+          if (blocking) block(blocking, reason)
+          setBlocking(null)
+        }}
+        onOpenChange={(next) => {
+          if (!next) setBlocking(null)
+        }}
+        open={blocking !== null}
+        tag={blocking ?? ''}
+      />
     </StageCardShell>
   )
 }
 
+// fallow-ignore-next-line complexity
 function RollbackRow({
+  blockPending,
   canTrigger,
   isOpen,
+  onBlock,
   onRollback,
   onToggle,
+  onUnblock,
   rel,
 }: {
+  blockPending: boolean
   canTrigger: boolean
   isOpen: boolean
+  onBlock: () => void
   onRollback: () => void
   onToggle: () => void
+  onUnblock: () => void
   rel: ReleaseHistoryEntry
 }) {
+  const blocked = !!rel.blocked
   return (
     <div
       className={cn(
@@ -230,20 +271,72 @@ function RollbackRow({
             value={rel.published_at}
           />
         </button>
-        <Button
-          className="h-7 px-2.5 text-xs"
-          disabled={!canTrigger}
-          onClick={onRollback}
-          size="sm"
-          type="button"
-          variant="outline"
-        >
-          <RotateCcw className="mr-1 size-3.5" />
-          Roll back
-        </Button>
+        {/* A blocked release can't be rolled back to, so the badge takes the
+            button's place rather than sitting beside a dead control. */}
+        {blocked ? (
+          <Badge className="inline-flex items-center gap-1" variant="danger">
+            <Ban className="size-3" />
+            Blocked
+          </Badge>
+        ) : (
+          <Button
+            className="h-7 px-2.5 text-xs"
+            disabled={!canTrigger}
+            onClick={onRollback}
+            size="sm"
+            type="button"
+            variant="outline"
+          >
+            <RotateCcw className="mr-1 size-3.5" />
+            Roll back
+          </Button>
+        )}
+        {blocked ? (
+          // Keep the glyph in the slot so rows stay aligned; red, and inert
+          // because the Blocked badge already names the state and Unblock
+          // lives with the reason in the expanded row.
+          <span
+            aria-hidden="true"
+            className="text-danger flex h-7 items-center px-2"
+          >
+            <Ban className="size-3.5" />
+          </span>
+        ) : (
+          <Button
+            aria-label={`Block ${rel.tag}`}
+            className="text-tertiary hover:text-danger h-7 px-2"
+            disabled={blockPending}
+            onClick={onBlock}
+            size="sm"
+            title={`Block ${rel.tag} from being deployed`}
+            type="button"
+            variant="ghost"
+          >
+            <Ban className="size-3.5" />
+          </Button>
+        )}
       </div>
       {isOpen ? (
         <div className="px-2 pb-3 pl-8">
+          {blocked ? (
+            <div className="text-danger mb-2 flex items-start gap-1.5 text-xs leading-relaxed">
+              <Ban className="mt-0.5 size-3.5 shrink-0" />
+              <span>
+                Blocked from deploying and promoting
+                {rel.blocked_reason ? <> — {rel.blocked_reason}</> : null}
+                {rel.blocked_by ? <> · by {rel.blocked_by}</> : null}
+              </span>
+              <Button
+                className="text-danger hover:bg-danger ml-auto h-auto shrink-0 px-2 py-0.5 text-xs"
+                disabled={blockPending}
+                onClick={onUnblock}
+                type="button"
+                variant="ghost"
+              >
+                Unblock
+              </Button>
+            </div>
+          ) : null}
           <ReleaseNotesMarkdown notes={rel.notes_markdown} />
           {rel.author ? (
             <div className="text-tertiary mt-2 inline-flex items-center gap-1.5 text-xs">

--- a/ui/src/components/deployments/EnvironmentDetail.tsx
+++ b/ui/src/components/deployments/EnvironmentDetail.tsx
@@ -69,6 +69,8 @@ export function EnvironmentDetail({
         accent={accent}
         actions={actions}
         canTrigger={canTrigger}
+        orgSlug={orgSlug}
+        projectId={projectId}
         stage={stage}
       />
     </div>

--- a/ui/src/components/deployments/PendingReleasesCard.test.tsx
+++ b/ui/src/components/deployments/PendingReleasesCard.test.tsx
@@ -183,6 +183,38 @@ describe('PendingReleasesCard', () => {
     expect(screen.getByText('notes for v6.5.1')).toBeInTheDocument()
   })
 
+  it('refuses to deploy a blocked release and names the reason', () => {
+    renderCard([
+      {
+        ...entry('v6.5.1', 'bbb222bbb222', 'Cache TTL fix'),
+        blocked: true,
+        blocked_reason: 'Regression in the checkout flow',
+      },
+    ])
+    expect(
+      screen.getByText(/Regression in the checkout flow/),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: /Deploy v6\.5\.1 to production/ }),
+    ).toBeDisabled()
+  })
+
+  it('marks blocked releases in the selectable stack', () => {
+    renderCard([
+      entry('v6.5.2', 'ccc333ccc333', 'Net-zero patch'),
+      {
+        ...entry('v6.5.1', 'bbb222bbb222', 'Cache TTL fix'),
+        blocked: true,
+        blocked_reason: 'Rolled back',
+      },
+    ])
+    // The newest is selected and deployable; the blocked one is labelled.
+    expect(screen.getByText('Blocked')).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: /Deploy v6\.5\.2 to production/ }),
+    ).toBeEnabled()
+  })
+
   it('warns when the pending release ranks below the running one', () => {
     // Production runs 2.101.0; staging's 1.102.3 is still deployable but
     // flagged as a roll back to the older line.

--- a/ui/src/components/deployments/PendingReleasesCard.tsx
+++ b/ui/src/components/deployments/PendingReleasesCard.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 
 import {
+  Ban,
   Check,
   ChevronDown,
   ChevronUp,
@@ -11,6 +12,7 @@ import {
 } from 'lucide-react'
 
 import { CiStatusDot } from '@/components/releases/CiStatusDot'
+import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { RelativeTime } from '@/components/ui/RelativeTime'
 import type { ChipColors } from '@/lib/chip-colors'
@@ -61,7 +63,10 @@ export function PendingReleasesCard({
   const activeIdx = pending.findIndex((rel) => rel.tag === active.tag)
   const rolledUp = pending.slice(activeIdx + 1).map((rel) => rel.tag)
   const stillPending = pending.slice(0, activeIdx).map((rel) => rel.tag)
-  const canSubmit = canTrigger && !actions.deployPending
+  // A blocked release is refused server-side with a 409, so the button is
+  // disabled rather than letting the deploy fail after the fact.
+  const blocked = !!active.blocked
+  const canSubmit = canTrigger && !actions.deployPending && !blocked
   // The upstream can legitimately run a release that semver-ranks below
   // this env's current one (divergent lines / roll-forward of an older
   // line) — deployable, but worth calling out.
@@ -152,6 +157,17 @@ export function PendingReleasesCard({
             </section>
           </>
         )}
+
+        {blocked ? (
+          <div className="border-danger bg-danger text-danger flex gap-2 rounded-md border px-3 py-2.5">
+            <Ban className="mt-0.5 size-3.5 shrink-0" />
+            <span className="text-xs leading-relaxed">
+              <span className="font-mono">{active.tag}</span> is blocked
+              {active.blocked_reason ? <> — {active.blocked_reason}</> : null}.
+              Unblock it on the Releases tab to deploy it.
+            </span>
+          </div>
+        ) : null}
 
         {isDowngrade ? (
           <div className="border-warning bg-warning text-warning flex gap-2 rounded-md border px-3 py-2.5">
@@ -256,6 +272,15 @@ function ReleaseStack({
                 {rel.tag}
               </span>
               <CiStatusDot size={13} status={rel.ci_status} />
+              {rel.blocked ? (
+                <Badge
+                  className="inline-flex shrink-0 items-center gap-1"
+                  variant="danger"
+                >
+                  <Ban className="size-3" />
+                  Blocked
+                </Badge>
+              ) : null}
               <span className="text-secondary min-w-0 flex-1 truncate text-xs">
                 {rel.title ?? ''}
               </span>

--- a/ui/src/components/releases/BlockReleaseDialog.tsx
+++ b/ui/src/components/releases/BlockReleaseDialog.tsx
@@ -1,0 +1,95 @@
+import { useEffect, useState } from 'react'
+
+import { Ban } from 'lucide-react'
+
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Label } from '@/components/ui/label'
+import { RequiredAsterisk } from '@/components/ui/required-asterisk'
+import { Textarea } from '@/components/ui/textarea'
+
+interface BlockReleaseDialogProps {
+  isPending: boolean
+  onBlock: (reason: string) => void
+  onOpenChange: (open: boolean) => void
+  open: boolean
+  tag: string
+}
+
+/**
+ * Captures the reason a release is being blocked. The reason is required —
+ * the block is what stops a deploy, so whoever hits the 409 needs to know
+ * why without going to ask.
+ */
+export function BlockReleaseDialog({
+  isPending,
+  onBlock,
+  onOpenChange,
+  open,
+  tag,
+}: BlockReleaseDialogProps) {
+  const [reason, setReason] = useState('')
+
+  // Clear the draft between openings so a reason typed for one release
+  // can't be submitted against another.
+  useEffect(() => {
+    if (open) setReason('')
+  }, [open, tag])
+
+  const trimmed = reason.trim()
+  return (
+    <Dialog onOpenChange={onOpenChange} open={open}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Ban className="text-danger size-4" />
+            Block release {tag}
+          </DialogTitle>
+          <DialogDescription>
+            Deploys and promotes of <span className="font-mono">{tag}</span>{' '}
+            will be refused until it is unblocked. Environments already running
+            it are left alone.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="p-6">
+          <Label className="text-tertiary flex flex-col gap-1.5 text-xs">
+            <span>
+              Reason
+              <RequiredAsterisk />
+            </span>
+            <Textarea
+              autoFocus
+              className="min-h-24 text-sm"
+              onChange={(e) => setReason(e.target.value)}
+              placeholder="Rolled back — regression in the checkout flow"
+              value={reason}
+            />
+          </Label>
+        </div>
+        <DialogFooter>
+          <Button
+            onClick={() => onOpenChange(false)}
+            type="button"
+            variant="ghost"
+          >
+            Cancel
+          </Button>
+          <Button
+            disabled={!trimmed || isPending}
+            onClick={() => onBlock(trimmed)}
+            type="button"
+          >
+            Block {tag}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/ui/src/components/releases/BlockReleaseDialog.tsx
+++ b/ui/src/components/releases/BlockReleaseDialog.tsx
@@ -67,6 +67,7 @@ export function BlockReleaseDialog({
             <Textarea
               autoFocus
               className="min-h-24 text-sm"
+              maxLength={500}
               onChange={(e) => setReason(e.target.value)}
               placeholder="Rolled back — regression in the checkout flow"
               value={reason}

--- a/ui/src/components/releases/ReleaseHistory.test.tsx
+++ b/ui/src/components/releases/ReleaseHistory.test.tsx
@@ -1,12 +1,30 @@
-import { screen } from '@testing-library/react'
+import { screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import * as releases from '@/api/releases'
 import { render } from '@/test/utils'
 import type { ReleaseHistoryEntry } from '@/types'
 
 import { deriveArtifact } from './artifact'
 import { ReleaseHistory } from './ReleaseHistory'
+
+// fallow-ignore-next-line unresolved-import
+vi.mock('@/api/releases', async () => {
+  const actual =
+    await vi.importActual<typeof import('@/api/releases')>('@/api/releases')
+  return { ...actual, blockRelease: vi.fn(), unblockRelease: vi.fn() }
+})
+
+vi.mock('sonner', () => ({
+  toast: {
+    error: vi.fn(),
+    success: vi.fn(),
+  },
+}))
+
+const blockRelease = vi.mocked(releases.blockRelease)
+const unblockRelease = vi.mocked(releases.unblockRelease)
 
 const RELEASES: ReleaseHistoryEntry[] = [
   {
@@ -33,15 +51,29 @@ const RELEASES: ReleaseHistoryEntry[] = [
 
 const ARTIFACT = deriveArtifact({ links: {}, name: 'lib' })
 
+const renderHistory = (
+  releases: ReleaseHistoryEntry[],
+  currentTag: null | string = 'v1.1.0',
+) =>
+  render(
+    <ReleaseHistory
+      artifact={ARTIFACT}
+      currentTag={currentTag}
+      orgSlug="acme"
+      projectId="p1"
+      releases={releases}
+    />,
+  )
+
 describe('ReleaseHistory', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    blockRelease.mockResolvedValue({ blocked: true, tag: 'v1.1.0' })
+    unblockRelease.mockResolvedValue({ blocked: false, tag: 'v1.0.0' })
+  })
+
   it('renders each release with a Latest badge on the current tag', () => {
-    render(
-      <ReleaseHistory
-        artifact={ARTIFACT}
-        currentTag="v1.1.0"
-        releases={RELEASES}
-      />,
-    )
+    renderHistory(RELEASES)
     expect(screen.getByText('v1.1.0')).toBeInTheDocument()
     expect(screen.getByText('v1.0.0')).toBeInTheDocument()
     expect(screen.getByText('Latest')).toBeInTheDocument()
@@ -49,21 +81,53 @@ describe('ReleaseHistory', () => {
 
   it('expands a row to render its markdown notes', async () => {
     const user = userEvent.setup()
-    render(
-      <ReleaseHistory
-        artifact={ARTIFACT}
-        currentTag="v1.1.0"
-        releases={RELEASES}
-      />,
-    )
+    renderHistory(RELEASES)
     await user.click(screen.getByRole('button', { name: /v1\.1\.0/ }))
     expect(screen.getByText('A thing')).toBeInTheDocument()
   })
 
   it('renders nothing when there are no releases', () => {
-    const { container } = render(
-      <ReleaseHistory artifact={ARTIFACT} currentTag={null} releases={[]} />,
-    )
+    const { container } = renderHistory([], null)
     expect(container).toBeEmptyDOMElement()
+  })
+
+  it('marks a blocked release and shows why, who, and an unblock action', async () => {
+    const user = userEvent.setup()
+    renderHistory([
+      {
+        ...RELEASES[1],
+        blocked: true,
+        blocked_at: '2026-01-03T00:00:00Z',
+        blocked_by: 'gavinr@aweber.com',
+        blocked_reason: 'Regression in the checkout flow',
+      },
+    ])
+    expect(screen.getByText('Blocked')).toBeInTheDocument()
+    await user.click(screen.getByRole('button', { name: /v1\.0\.0/ }))
+    expect(
+      screen.getByText(/Regression in the checkout flow/),
+    ).toBeInTheDocument()
+    expect(screen.getByText(/gavinr@aweber\.com/)).toBeInTheDocument()
+    await user.click(screen.getByRole('button', { name: 'Unblock' }))
+    expect(unblockRelease).toHaveBeenCalledWith('acme', 'p1', 'v1.0.0')
+  })
+
+  it('blocks a release with the reason from the dialog', async () => {
+    const user = userEvent.setup()
+    renderHistory(RELEASES)
+    await user.click(screen.getByRole('button', { name: /v1\.1\.0/ }))
+    await user.click(screen.getByRole('button', { name: /Block release/ }))
+
+    const submit = screen.getByRole('button', { name: 'Block v1.1.0' })
+    // The reason is required — no reason, no block.
+    expect(submit).toBeDisabled()
+
+    await user.type(screen.getByRole('textbox'), 'Rolled back — regression')
+    await user.click(submit)
+    await waitFor(() =>
+      expect(blockRelease).toHaveBeenCalledWith('acme', 'p1', 'v1.1.0', {
+        reason: 'Rolled back — regression',
+      }),
+    )
   })
 })

--- a/ui/src/components/releases/ReleaseHistory.tsx
+++ b/ui/src/components/releases/ReleaseHistory.tsx
@@ -1,21 +1,32 @@
 import { useState } from 'react'
 
-import { ChevronDown, ChevronRight, ExternalLink } from 'lucide-react'
+import { Ban, ChevronDown, ChevronRight, ExternalLink } from 'lucide-react'
 import Markdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 
 import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
 import { RelativeTime } from '@/components/ui/RelativeTime'
 import { UserIdentity } from '@/components/ui/user-identity'
 import { cn } from '@/lib/utils'
 import type { ReleaseHistoryEntry } from '@/types'
 
 import type { ArtifactInfo } from './artifact'
+import { BlockReleaseDialog } from './BlockReleaseDialog'
 import { CiStatusDot } from './CiStatusDot'
+import { useReleaseBlockMutation } from './useReleaseBlockMutation'
+
+interface BlockedNoteProps {
+  isPending: boolean
+  onUnblock: () => void
+  rel: ReleaseHistoryEntry
+}
 
 interface ReleaseHistoryProps {
   artifact: ArtifactInfo
   currentTag: null | string
+  orgSlug: string
+  projectId: string
   releases: ReleaseHistoryEntry[]
 }
 
@@ -23,16 +34,26 @@ interface ReleaseRowProps {
   artifact: ArtifactInfo
   isCurrent: boolean
   isOpen: boolean
+  isPending: boolean
+  onBlock: () => void
   onToggle: () => void
+  onUnblock: () => void
   rel: ReleaseHistoryEntry
 }
 
 export function ReleaseHistory({
   artifact,
   currentTag,
+  orgSlug,
+  projectId,
   releases,
 }: ReleaseHistoryProps) {
   const [open, setOpen] = useState<null | string>(null)
+  const [blocking, setBlocking] = useState<null | string>(null)
+  const { block, isPending, unblock } = useReleaseBlockMutation({
+    orgSlug,
+    projectId,
+  })
   if (releases.length === 0) return null
   return (
     <div className="border-tertiary mt-3 border-t pt-3">
@@ -45,12 +66,62 @@ export function ReleaseHistory({
             artifact={artifact}
             isCurrent={rel.tag === currentTag}
             isOpen={open === rel.tag}
+            isPending={isPending}
             key={rel.tag}
+            onBlock={() => setBlocking(rel.tag)}
             onToggle={() => setOpen((o) => (o === rel.tag ? null : rel.tag))}
+            onUnblock={() => unblock(rel.tag)}
             rel={rel}
           />
         ))}
       </div>
+      <BlockReleaseDialog
+        isPending={isPending}
+        onBlock={(reason) => {
+          if (blocking) block(blocking, reason)
+          setBlocking(null)
+        }}
+        onOpenChange={(next) => {
+          if (!next) setBlocking(null)
+        }}
+        open={blocking !== null}
+        tag={blocking ?? ''}
+      />
+    </div>
+  )
+}
+
+/** Why the release is blocked, who blocked it, and how to lift it. */
+function BlockedNote({ isPending, onUnblock, rel }: BlockedNoteProps) {
+  return (
+    <div className="border-danger bg-danger text-danger mt-1 mb-3 flex items-start gap-2 rounded-md border px-3 py-2.5">
+      <Ban className="mt-0.5 size-3.5 shrink-0" />
+      <div className="min-w-0 flex-1 text-xs leading-relaxed">
+        <p>
+          Blocked from deploying and promoting
+          {rel.blocked_reason ? <> — {rel.blocked_reason}</> : null}
+        </p>
+        {rel.blocked_by ? (
+          <p className="mt-1 opacity-80">
+            by {rel.blocked_by}
+            {rel.blocked_at ? (
+              <>
+                {' · '}
+                <RelativeTime tooltip={false} value={rel.blocked_at} />
+              </>
+            ) : null}
+          </p>
+        ) : null}
+      </div>
+      <Button
+        className="h-auto shrink-0 px-2 py-1 text-xs"
+        disabled={isPending}
+        onClick={onUnblock}
+        type="button"
+        variant="outline"
+      >
+        Unblock
+      </Button>
     </div>
   )
 }
@@ -60,9 +131,13 @@ function ReleaseRow({
   artifact,
   isCurrent,
   isOpen,
+  isPending,
+  onBlock,
   onToggle,
+  onUnblock,
   rel,
 }: ReleaseRowProps) {
+  const blocked = !!rel.blocked
   return (
     <div
       className={cn(
@@ -90,10 +165,25 @@ function ReleaseRow({
           tooltip={false}
           value={rel.published_at}
         />
-        {isCurrent ? <Badge variant="accent">Latest</Badge> : <span />}
+        <span className="flex items-center gap-1.5">
+          {blocked ? (
+            <Badge className="inline-flex items-center gap-1" variant="danger">
+              <Ban className="size-3" />
+              Blocked
+            </Badge>
+          ) : null}
+          {isCurrent ? <Badge variant="accent">Latest</Badge> : null}
+        </span>
       </button>
       {isOpen ? (
         <div className="px-2 pb-3 pl-[2.1rem]">
+          {blocked ? (
+            <BlockedNote
+              isPending={isPending}
+              onUnblock={onUnblock}
+              rel={rel}
+            />
+          ) : null}
           {rel.notes_markdown ? (
             <div className="document-markdown max-w-none text-sm [&>*:first-child]:mt-0 [&>*:last-child]:mb-0">
               <Markdown
@@ -143,6 +233,18 @@ function ReleaseRow({
                 {artifact.indexLabel ?? 'Package index'}
               </a>
             ) : null}
+            {blocked ? null : (
+              <Button
+                className="text-tertiary hover:text-danger ml-auto h-auto gap-1 px-0 py-0 text-xs"
+                disabled={isPending}
+                onClick={onBlock}
+                type="button"
+                variant="ghost"
+              >
+                <Ban className="size-3" />
+                Block release
+              </Button>
+            )}
           </div>
         </div>
       ) : null}

--- a/ui/src/components/releases/ReleasesTab.tsx
+++ b/ui/src/components/releases/ReleasesTab.tsx
@@ -86,6 +86,8 @@ export function ReleasesTab({ orgSlug, project }: ReleasesTabProps) {
         <ReleaseHistory
           artifact={artifact}
           currentTag={released?.tag ?? null}
+          orgSlug={orgSlug}
+          projectId={project.id}
           releases={history}
         />
       </Swap>

--- a/ui/src/components/releases/useReleaseBlockMutation.tsx
+++ b/ui/src/components/releases/useReleaseBlockMutation.tsx
@@ -1,0 +1,73 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { toast } from 'sonner'
+
+import { ApiError } from '@/api/client'
+import { blockRelease, unblockRelease } from '@/api/releases'
+import { extractApiErrorDetail } from '@/lib/apiError'
+
+interface UseReleaseBlockOptions {
+  orgSlug: string
+  projectId: string
+}
+
+interface UseReleaseBlockResult {
+  block: (tag: string, reason: string) => void
+  isPending: boolean
+  unblock: (tag: string) => void
+}
+
+const message = (err: unknown): string =>
+  err instanceof ApiError
+    ? (extractApiErrorDetail(err) ?? err.message)
+    : (err as Error).message
+
+/**
+ * Block / unblock a release tag. Both write the same `blocked_*` state on
+ * the release, so they share one invalidation set: the release history and
+ * the deployment pipeline both render the block.
+ */
+export function useReleaseBlockMutation({
+  orgSlug,
+  projectId,
+}: UseReleaseBlockOptions): UseReleaseBlockResult {
+  const queryClient = useQueryClient()
+  const invalidate = () => {
+    for (const key of [
+      ['releaseHistory', orgSlug, projectId],
+      ['currentReleases', orgSlug, projectId],
+      ['project-releases', orgSlug, projectId],
+    ]) {
+      void queryClient.invalidateQueries({ queryKey: key })
+    }
+  }
+
+  const blockMutation = useMutation({
+    mutationFn: ({ reason, tag }: { reason: string; tag: string }) =>
+      blockRelease(orgSlug, projectId, tag, { reason }),
+    onError: (err) => toast.error(message(err)),
+    onSuccess: (data) => {
+      invalidate()
+      toast.success(`Blocked ${data.tag}`, {
+        description: 'Deploys and promotes of this release are now refused.',
+      })
+    },
+  })
+
+  const unblockMutation = useMutation({
+    mutationFn: (tag: string) => unblockRelease(orgSlug, projectId, tag),
+    onError: (err) => toast.error(message(err)),
+    onSuccess: (data) => {
+      invalidate()
+      toast.success(`Unblocked ${data.tag}`, {
+        description: 'This release can be deployed again.',
+      })
+    },
+  })
+
+  return {
+    block: (tag: string, reason: string) =>
+      blockMutation.mutate({ reason, tag }),
+    isPending: blockMutation.isPending || unblockMutation.isPending,
+    unblock: (tag: string) => unblockMutation.mutate(tag),
+  }
+}

--- a/ui/src/types/index.ts
+++ b/ui/src/types/index.ts
@@ -1265,6 +1265,17 @@ export interface Release {
   title: string
   updated_at?: null | string
 }
+export interface ReleaseBlockRequest {
+  reason: string
+}
+
+export interface ReleaseBlockResponse {
+  blocked: boolean
+  blocked_at?: null | string
+  blocked_by?: null | string
+  blocked_reason?: null | string
+  tag: string
+}
 export interface ReleaseDependenciesResponse {
   components: ReleaseDependencyComponent[]
   release_id: string
@@ -1283,6 +1294,7 @@ export interface ReleaseDependencyComponent {
   supplier?: null | string
   version: string
 }
+
 export interface ReleaseDependencyIdentifier {
   kind: string
   value: string
@@ -1305,6 +1317,11 @@ export interface ReleaseHistoryEntry {
   author?: null | string
   /** Imbi user email of the release author (the resolved `created_by`). */
   author_email?: null | string
+  /** Blocked releases are refused by deploy and promote with a 409. */
+  blocked?: boolean
+  blocked_at?: null | string
+  blocked_by?: null | string
+  blocked_reason?: null | string
   ci_status: DeploymentCommitCiStatus
   notes_markdown?: null | string
   package_url?: null | string


### PR DESCRIPTION
## Summary
Lets a release be blocked from shipping, with a required reason, so a rolled-back release can't be re-deployed or re-promoted while a regression is being fixed.

## Problem
When a release is rolled back for a regression, nothing stops it going out again. The rollback is recorded as a `DeploymentEvent` on the release's `DEPLOYED_TO` edge, but the release itself stays as deployable as any other — the Deployments tab still offers "Roll back" to it, a pending release still offers "Deploy", and a promote will happily re-cut a tag at the same commit. Anyone who wasn't part of the rollback has no way to know the release is poison, and Imbi has no way to tell them.

## Solution
A block is three properties on the `Release` node — `blocked_at` (the flag), `blocked_by`, and `blocked_reason`. Unblocking clears all three.

- `POST` / `DELETE /organizations/{org}/projects/{id}/deployments/releases/{tag}/block`, both gated on `project:deployment:write`. The reason is required (1–500 chars, whitespace-stripped); blocking is idempotent and re-blocking overwrites the reason and re-stamps the actor.
- Release history rows are ClickHouse tags left-joined to `Release` nodes, so a tag can exist with no node. Blocking such a tag creates the node from the synced tag row so the block still holds. A tag Imbi has never seen is a 404.
- `_handle_deploy` and `_handle_promote` refuse with a **409 naming the reason**, checked before any plugin call so a blocked release never reaches the remote. The gate matches on tag *or* committish, so blocking a rolled-back tag also stops a promote re-cutting the same commit under a new tag. `releases/cut` is not gated — a tag that doesn't exist yet can't be blocked.
- Block state rides along on the `release-history` response, so every surface that already reads it can render the block.

UI, on the surfaces where the decision actually gets made:

- **Deployments tab, recent releases** — a `⃠` action per row opens a reason dialog. Once blocked the glyph turns red, a Blocked badge replaces the Roll back button outright (rather than leaving a dead disabled control), and the reason, who blocked it, and Unblock appear in the expanded row.
- **Pending release card** — deploy is disabled with the reason shown, since the API would 409 anyway.
- **Releases tab history** — the same block/unblock control, for projects with no environments where this is the only release surface.

## Impact
Additive. No migration: Apache AGE is schemaless and absent `blocked_*` properties read as not-blocked, so every existing release is unblocked until someone blocks it. No behaviour changes for anyone who never blocks a release.

Two things reviewers should weigh:

- **The block is global and hard, with no override.** A blocked release cannot go to any environment, and there is no force flag — lifting it is an explicit, separate action. Environments already running a blocked release are left alone; nothing is force-rolled-back.
- **No `operations_log` row is written.** The block record carries who, when, and why, and the UI surfaces it, but the ops log doesn't show blocks. `OperationLog.entry_type` is a closed `Literal` and the deploy row shape requires an `environment_slug`, so a proper `Blocked` entry means touching the common model, the ClickHouse enum, and the ops-log renderer. Deliberately left for a follow-up rather than mislabelling blocks as `Deployed`.

## Testing
- 11 new API tests: block/unblock, the required reason, node creation for a synced-but-never-cut tag, both 404s, the 409 on deploy and on promote, the 409 without a recorded reason, and the history projection.
- 6 new UI tests across the three surfaces: blocking with a reason, the reason being required, the badge replacing Roll back, Unblock living with the reason rather than in the collapsed row, and deploy being refused for a blocked pending release.
- Full suites green locally against the compose services: **3594 Python tests**, **592 UI tests**. `basedpyright` 0 errors, ruff clean, `tsc` clean, oxlint 0 errors, `fallow audit` gate clean.
- Verified by hand in Okteto against real project data (`Account`, releases 6.4.0–6.12.0).

One shared-fixture change worth a look: `ProjectDeploymentsTestCase` left `mock_db.execute` at the bare `AsyncMock` default, which returns a truthy `MagicMock`. The new block gate read that as a match and failed all 76 deploy/promote tests, so the mock now defaults to no rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
