### PR TITLE
Expose API reads as MCP tools and filter them per caller

### DIFF
--- a/apps/api/src/imbi/api/auth/permissions.py
+++ b/apps/api/src/imbi/api/auth/permissions.py
@@ -762,6 +762,13 @@ def require_permission(
             )
         return auth
 
+    # Expose the required permission for schema generation. Permission
+    # enforcement lives in a closure, so it is otherwise invisible to
+    # ``app.openapi()``; ``openapi.py`` reads this attribute to stamp
+    # ``x-imbi-permission`` for AI consumers building per-caller
+    # toolsets.
+    check_permission.imbi_permission = permission  # type: ignore[attr-defined]
+
     return check_permission
 
 

--- a/apps/api/src/imbi/api/endpoints/graph_query.py
+++ b/apps/api/src/imbi/api/endpoints/graph_query.py
@@ -45,6 +45,11 @@ async def require_admin(
     return auth
 
 
+# Read by ``openapi.py`` to stamp ``x-imbi-permission``; the sentinel
+# value marks endpoints no non-admin principal can reach.
+require_admin.imbi_permission = 'admin'  # type: ignore[attr-defined]
+
+
 # ---------------------------------------------------------------
 # Request / response models
 # ---------------------------------------------------------------

--- a/apps/api/src/imbi/api/openapi.py
+++ b/apps/api/src/imbi/api/openapi.py
@@ -16,6 +16,7 @@ Usage:
     app.openapi = openapi.create_custom_openapi(app)
 """
 
+import collections.abc
 import logging
 import threading
 import typing
@@ -337,8 +338,75 @@ def _build_schema(
         _hoist_defs_to_components(schemas)
 
     _mark_ai_excluded_operations(openapi_schema)
+    _mark_required_permissions(openapi_schema, app.routes)
 
     return openapi_schema, had_failure
+
+
+def _route_permissions(route: typing.Any) -> list[str]:
+    """Collect permissions enforced by a route's dependency tree.
+
+    ``require_permission`` returns a closure, so the permission string
+    it enforces is not introspectable from the signature; the factory
+    tags the closure with ``imbi_permission`` for this purpose. The
+    dependency tree is walked because permission dependencies may be
+    nested (declared on a router rather than the operation).
+    """
+    dependant = getattr(route, 'dependant', None)
+    if dependant is None:
+        return []
+    found: list[str] = []
+
+    def walk(dependency: typing.Any) -> None:
+        permission = getattr(dependency.call, 'imbi_permission', None)
+        if isinstance(permission, str) and permission not in found:
+            found.append(permission)
+        for sub_dependency in dependency.dependencies:
+            walk(sub_dependency)
+
+    walk(dependant)
+    return found
+
+
+def _mark_required_permissions(
+    openapi_schema: dict[str, typing.Any],
+    routes: collections.abc.Iterable[typing.Any],
+) -> None:
+    """Stamp ``x-imbi-permission`` with each operation's permissions.
+
+    Permission checks are FastAPI dependencies and so are absent from
+    the generated schema. AI consumers (imbi-mcp, imbi-assistant) read
+    this extension to filter a caller's toolset down to what that
+    caller can actually invoke, rather than surfacing tools that can
+    only ever return 403. The value is a list because an operation may
+    enforce more than one permission; ``admin`` means admin-only.
+
+    Advisory only -- the API remains the sole enforcement point.
+    """
+    paths: dict[str, typing.Any] = openapi_schema.get('paths', {})
+    for route in routes:
+        # ``path_format`` is what FastAPI keys ``paths`` by: it strips
+        # converter syntax, so ``/refs/{ref:path}`` is published as
+        # ``/refs/{ref}``. Matching on ``path`` would silently skip
+        # every converter-typed route, leaving it unstamped and so
+        # indistinguishable from an unguarded operation.
+        path = getattr(route, 'path_format', None) or getattr(
+            route, 'path', None
+        )
+        methods = getattr(route, 'methods', None)
+        # Routes hidden from the schema (``/docs``, ``/redoc``) have no
+        # entry in ``paths``.
+        if not methods or path not in paths:
+            continue
+        permissions = _route_permissions(route)
+        if not permissions:
+            continue
+        ops = typing.cast(dict[str, typing.Any], paths[path])
+        for method in methods:
+            operation = ops.get(method.lower())
+            if operation is not None:
+                op = typing.cast(dict[str, typing.Any], operation)
+                op['x-imbi-permission'] = permissions
 
 
 def _mark_ai_excluded_operations(

--- a/apps/api/tests/test_openapi.py
+++ b/apps/api/tests/test_openapi.py
@@ -1,5 +1,6 @@
 """Tests for OpenAPI schema customization with blueprint models."""
 
+import typing
 import unittest
 import unittest.mock
 
@@ -10,6 +11,8 @@ import imbi.common.blueprints
 import imbi.common.models
 from imbi.api import models as imbi_models
 from imbi.api import openapi
+from imbi.api.auth import permissions
+from imbi.api.endpoints import graph_query
 from imbi.common import graph
 
 
@@ -446,6 +449,121 @@ class MarkAiExcludedOperationsTestCase(unittest.TestCase):
             False,
         )
         self.assertNotIn('x-imbi-ai-tool', schema['paths']['/teams/']['get'])
+
+
+class MarkRequiredPermissionsTestCase(unittest.TestCase):
+    """Test cases for _mark_required_permissions."""
+
+    def setUp(self) -> None:
+        """Reset module state and build a fresh app for each test."""
+        _reset_openapi_module_state()
+        self.app = fastapi.FastAPI(title='Test', version='1.0.0')
+
+    def tearDown(self) -> None:
+        _reset_openapi_module_state()
+
+    def test_stamps_operation_level_permission(self) -> None:
+        """A route's require_permission dependency reaches the schema."""
+
+        @self.app.get('/projects/')
+        async def list_projects(
+            _auth: typing.Annotated[
+                permissions.AuthContext,
+                fastapi.Depends(
+                    permissions.require_permission('project:read')
+                ),
+            ],
+        ) -> list[dict]:
+            return []
+
+        schema = openapi.create_custom_openapi(self.app)()
+
+        self.assertEqual(
+            ['project:read'],
+            schema['paths']['/projects/']['get']['x-imbi-permission'],
+        )
+
+    def test_stamps_router_level_permission(self) -> None:
+        """A permission declared on the router is found via nesting."""
+        router = fastapi.APIRouter(
+            dependencies=[
+                fastapi.Depends(
+                    permissions.require_permission('blueprint:write')
+                )
+            ]
+        )
+
+        @router.post('/blueprints/')
+        async def create_blueprint() -> dict:
+            return {}
+
+        self.app.include_router(router)
+
+        schema = openapi.create_custom_openapi(self.app)()
+
+        self.assertEqual(
+            ['blueprint:write'],
+            schema['paths']['/blueprints/']['post']['x-imbi-permission'],
+        )
+
+    def test_stamps_route_with_path_converter(self) -> None:
+        """A converter-typed path is still matched and stamped.
+
+        FastAPI publishes ``/refs/{ref:path}`` as ``/refs/{ref}``, so
+        matching on ``route.path`` rather than ``route.path_format``
+        would skip the route and leave it looking unguarded.
+        """
+
+        @self.app.get('/refs/{ref:path}/commits')
+        async def list_commits(
+            ref: str,
+            _auth: typing.Annotated[
+                permissions.AuthContext,
+                fastapi.Depends(
+                    permissions.require_permission('project:deployment:read')
+                ),
+            ],
+        ) -> list[dict]:
+            return []
+
+        schema = openapi.create_custom_openapi(self.app)()
+
+        self.assertEqual(
+            ['project:deployment:read'],
+            schema['paths']['/refs/{ref}/commits']['get']['x-imbi-permission'],
+        )
+
+    def test_unguarded_operation_not_stamped(self) -> None:
+        """A route with no permission dependency is left alone."""
+
+        @self.app.get('/health')
+        async def health() -> dict:
+            return {}
+
+        schema = openapi.create_custom_openapi(self.app)()
+
+        self.assertNotIn(
+            'x-imbi-permission', schema['paths']['/health']['get']
+        )
+
+    def test_admin_dependency_stamps_sentinel(self) -> None:
+        """require_admin is reported as the ``admin`` sentinel."""
+
+        @self.app.post('/graph/query')
+        async def query(
+            _auth: typing.Annotated[
+                permissions.AuthContext,
+                fastapi.Depends(graph_query.require_admin),
+            ],
+        ) -> dict:
+            return {}
+
+        schema = openapi.create_custom_openapi(self.app)()
+
+        self.assertEqual(
+            ['admin'],
+            schema['paths']['/graph/query']['post']['x-imbi-permission'],
+        )
 
 
 class HoistDefsToComponentsTestCase(unittest.TestCase):

--- a/apps/mcp/src/imbi/mcp/README.md
+++ b/apps/mcp/src/imbi/mcp/README.md
@@ -8,18 +8,23 @@ management platform. Exposes Imbi API functionality to AI agents via the
 
 At startup the server fetches the OpenAPI spec from a running
 [imbi-api](https://github.com/AWeber-Imbi/imbi-api) instance and
-auto-generates MCP tools, resources, and resource templates using
+auto-generates MCP tools using
 [FastMCP](https://github.com/jlowin/fastmcp).
 
 Route mapping rules control what gets exposed:
 
-- **Excluded** -- Auth, MFA, status, and thumbnail endpoints are hidden.
-- **Resources** -- `GET` endpoints that return collections.
-- **Resource templates** -- `GET` endpoints with path parameters.
-- **Tools** -- Everything else (create, update, delete operations).
+- **Excluded** -- Auth, MFA, status, and thumbnail endpoints are hidden,
+  as is any operation the API flags with `x-imbi-ai-tool: false`.
+- **Tools** -- Everything else, reads included. `GET` operations are
+  deliberately exposed as tools rather than as MCP resources or
+  resource templates: many clients only consume `tools/*`, and
+  classifying reads as resources hid them entirely.
 
 The caller's `Authorization` header is forwarded to the API so that
-requests run with the caller's permissions.
+requests run with the caller's permissions. On top of that, `tools/list`
+is filtered per caller: operations the caller lacks permission for are
+omitted, so an agent is not offered tools that could only return `403`.
+The filtering is advisory — the API remains the enforcement point.
 
 ## Authentication
 

--- a/apps/mcp/src/imbi/mcp/server.py
+++ b/apps/mcp/src/imbi/mcp/server.py
@@ -25,34 +25,22 @@ from fastmcp.server.auth.auth import (
     TokenVerifier,
 )
 from fastmcp.server.dependencies import get_http_headers
-from fastmcp.server.providers.openapi import MCPType, RouteMap
 from pydantic import AnyHttpUrl
 from starlette.responses import JSONResponse
 
 import imbi.mcp
 from imbi.common.auth import core
-from imbi.common.mcp import EXCLUDED_ROUTE_MAPS, exclude_non_ai_tools
+from imbi.common.mcp import (
+    EXCLUDED_ROUTE_MAPS,
+    PermissionFilterMiddleware,
+    copy_permissions_to_meta,
+    exclude_non_ai_tools,
+)
 
 if typing.TYPE_CHECKING:
     from starlette.requests import Request
 
 logger = logging.getLogger(__name__)
-
-
-# Read-only list endpoints → resources, parameterised GETs →
-# resource templates, everything else → tools.
-_SEMANTIC_ROUTE_MAPS = [
-    RouteMap(
-        methods=['GET'],
-        pattern=r'.*\{.*\}.*',
-        mcp_type=MCPType.RESOURCE_TEMPLATE,
-    ),
-    RouteMap(
-        methods=['GET'],
-        pattern=r'.*',
-        mcp_type=MCPType.RESOURCE,
-    ),
-]
 
 
 async def _inject_auth(request: httpx.Request) -> None:
@@ -151,12 +139,15 @@ def create_server(
         name='Imbi',
         version=imbi.mcp.version,
         auth=_build_auth(public_url, auth_server_url),
-        route_maps=[
-            *EXCLUDED_ROUTE_MAPS,
-            *_SEMANTIC_ROUTE_MAPS,
-        ],
+        route_maps=list(EXCLUDED_ROUTE_MAPS),
         route_map_fn=exclude_non_ai_tools,
+        mcp_component_fn=copy_permissions_to_meta,
     )
+
+    # ``client`` forwards the caller's Authorization header via
+    # ``_inject_auth``, so the middleware resolves permissions for the
+    # principal making the request rather than a fixed identity.
+    mcp.add_middleware(PermissionFilterMiddleware(client))
 
     @mcp.custom_route('/status', methods=['GET'])
     async def status(_request: Request) -> JSONResponse:

--- a/apps/mcp/tests/test_server.py
+++ b/apps/mcp/tests/test_server.py
@@ -159,48 +159,49 @@ class CreateServerTests(unittest.TestCase):
         self.assertIn(r'^/status/?$', patterns)
         self.assertIn(r'.*/thumbnail/?$', patterns)
 
-    @mock.patch('imbi.mcp.server.httpx.get')
-    @mock.patch('fastmcp.FastMCP.from_openapi')
-    def test_route_maps_classify_get_as_resources(
-        self, mock_from_openapi: mock.Mock, mock_get: mock.Mock
-    ) -> None:
-        mock_get.return_value = self.mock_response
-        mock_from_openapi.return_value = fastmcp.FastMCP(name='stub')
-        server.create_server('http://example:9000')
-        _, kwargs = mock_from_openapi.call_args
-        route_maps = kwargs['route_maps']
-        resource_maps = [
-            rm
-            for rm in route_maps
-            if rm.mcp_type in (MCPType.RESOURCE, MCPType.RESOURCE_TEMPLATE)
-        ]
-        self.assertTrue(
-            all('GET' in rm.methods for rm in resource_maps),
-            'All resource route maps should specify GET method',
-        )
-
 
 class CreateServerExcludesConfigTests(unittest.IsolatedAsyncioTestCase):
-    @mock.patch('imbi.mcp.server.httpx.get')
-    async def test_flagged_endpoint_not_exposed(
-        self, mock_get: mock.Mock
-    ) -> None:
+    def setUp(self) -> None:
         spec = _minimal_openapi_spec()
-        mock_get.return_value = httpx.Response(
+        self.mock_response = httpx.Response(
             200,
             content=json.dumps(spec).encode(),
             headers={'content-type': 'application/json'},
             request=httpx.Request('GET', 'http://localhost:8000/openapi.json'),
         )
+
+    @mock.patch('imbi.mcp.server.httpx.get')
+    async def test_flagged_endpoint_not_exposed(
+        self, mock_get: mock.Mock
+    ) -> None:
+        mock_get.return_value = self.mock_response
         mcp = server.create_server('http://localhost:8000')
         async with fastmcp.Client(mcp) as client:
             tools = await client.list_tools()
-            resources = await client.list_resources()
         names = {t.name for t in tools}
         self.assertNotIn('set_configuration_value', names)
-        # A non-flagged GET still becomes a resource, proving the spec
-        # was processed rather than wholesale rejected.
-        self.assertTrue(resources)
+        # A non-flagged GET becomes a read tool, proving the spec was
+        # processed rather than wholesale rejected.
+        self.assertIn('list_projects', names)
+
+    @mock.patch('imbi.mcp.server.httpx.get')
+    async def test_reads_become_tools_not_resources(
+        self, mock_get: mock.Mock
+    ) -> None:
+        """GETs must be exposed as tools, never as resources.
+
+        Classifying reads as resources hid them from MCP clients that
+        only consume ``tools/*``, which left the toolset mutation-only.
+        """
+        mock_get.return_value = self.mock_response
+        mcp = server.create_server('http://localhost:8000')
+        async with fastmcp.Client(mcp) as client:
+            names = {tool.name for tool in await client.list_tools()}
+            resources = await client.list_resources()
+            templates = await client.list_resource_templates()
+        self.assertIn('list_projects', names)
+        self.assertEqual([], resources)
+        self.assertEqual([], templates)
 
 
 class InjectAuthTests(unittest.IsolatedAsyncioTestCase):

--- a/docs/common/api/mcp.md
+++ b/docs/common/api/mcp.md
@@ -15,6 +15,12 @@ place instead of being copied into each consumer:
 - **`exclude_non_ai_tools`** — a `route_map_fn` that honours the
   `x-imbi-ai-tool: false` extension imbi-api stamps on sensitive
   operations (e.g. project Configuration / SSM Parameter Store).
+- **`copy_permissions_to_meta`** — an `mcp_component_fn` that records the
+  `x-imbi-permission` extension on each generated component's public
+  `meta`.
+- **`PermissionFilterMiddleware`** — narrows `tools/list` per caller to
+  the operations that caller has permission for. Requires
+  `copy_permissions_to_meta`; advisory only, and fails open.
 
 Keeping the *which* in imbi-api (it stamps the extension on tagged
 operations) and the *how to honour it* here means hiding a future endpoint
@@ -47,21 +53,46 @@ server = fastmcp.FastMCP.from_openapi(
 )
 ```
 
-A consumer that also classifies routes (e.g. read-only GETs as MCP
-resources) prepends the shared maps to its own:
+A consumer with its own classification rules prepends the shared maps to
+its own:
 
 ```python
 server = fastmcp.FastMCP.from_openapi(
     openapi_spec=spec,
     client=client,
-    route_maps=[*mcp.EXCLUDED_ROUTE_MAPS, *MY_SEMANTIC_ROUTE_MAPS],
+    route_maps=[*mcp.EXCLUDED_ROUTE_MAPS, *MY_ROUTE_MAPS],
     route_map_fn=mcp.exclude_non_ai_tools,
 )
 ```
 
+Note that every operation becomes a **tool** by default, reads included.
+Classifying `GET`s as MCP resources or resource templates hides them from
+clients that only consume `tools/*`, so consumers should not do it.
+
+To filter each caller's toolset down to what they can actually invoke,
+add the `mcp_component_fn` and the middleware:
+
+```python
+server = fastmcp.FastMCP.from_openapi(
+    openapi_spec=spec,
+    client=client,
+    route_maps=list(mcp.EXCLUDED_ROUTE_MAPS),
+    route_map_fn=mcp.exclude_non_ai_tools,
+    mcp_component_fn=mcp.copy_permissions_to_meta,
+)
+server.add_middleware(mcp.PermissionFilterMiddleware(client))
+```
+
+Both parts are required: without `copy_permissions_to_meta` no tool
+carries permission metadata, so the middleware has nothing to filter on
+and returns every tool. The `client` must forward the calling
+principal's credentials, or every caller is filtered against one
+identity.
+
 `exclude_non_ai_tools` is backward compatible: when the extension is
 absent it returns `None` and changes nothing, so a consumer can adopt it
-before or after imbi-api ships the flag.
+before or after imbi-api ships the flag. `copy_permissions_to_meta` is
+likewise a no-op on operations with no `x-imbi-permission`.
 
 ## API Reference
 
@@ -70,3 +101,13 @@ before or after imbi-api ships the flag.
 ::: imbi.common.mcp.EXCLUDED_ROUTE_MAPS
 
 ::: imbi.common.mcp.exclude_non_ai_tools
+
+::: imbi.common.mcp.PERMISSION_EXTENSION
+
+::: imbi.common.mcp.PERMISSION_META_KEY
+
+::: imbi.common.mcp.copy_permissions_to_meta
+
+::: imbi.common.mcp.required_permissions
+
+::: imbi.common.mcp.PermissionFilterMiddleware

--- a/libraries/common/src/imbi/common/mcp.py
+++ b/libraries/common/src/imbi/common/mcp.py
@@ -11,10 +11,17 @@ rather than being copied into each consumer:
 * :func:`exclude_non_ai_tools` -- a ``route_map_fn`` that honours the
   ``x-imbi-ai-tool: false`` extension imbi-api stamps on sensitive
   operations (e.g. project Configuration / SSM Parameter Store).
+* :class:`PermissionFilterMiddleware` -- middleware that narrows
+  ``tools/list`` per caller, dropping operations whose required
+  permissions (``x-imbi-permission``) the caller does not hold.
 
-The two compose: pass ``EXCLUDED_ROUTE_MAPS`` (optionally alongside a
+These compose. Pass ``EXCLUDED_ROUTE_MAPS`` (optionally alongside a
 consumer's own maps) as ``route_maps`` and :func:`exclude_non_ai_tools`
-as ``route_map_fn``::
+as ``route_map_fn``. :class:`PermissionFilterMiddleware` additionally
+requires :func:`copy_permissions_to_meta` as ``mcp_component_fn`` --
+that is what records each operation's permissions on the tool, so
+without it the middleware finds nothing to filter on and every tool is
+returned::
 
     import fastmcp
     from imbi.common import mcp
@@ -24,7 +31,9 @@ as ``route_map_fn``::
         client=client,
         route_maps=list(mcp.EXCLUDED_ROUTE_MAPS),
         route_map_fn=mcp.exclude_non_ai_tools,
+        mcp_component_fn=mcp.copy_permissions_to_meta,
     )
+    server.add_middleware(mcp.PermissionFilterMiddleware(client))
 
 Requires the ``mcp`` extra (``imbi-common[mcp]``).
 
@@ -32,18 +41,39 @@ Requires the ``mcp`` extra (``imbi-common[mcp]``).
 
 from __future__ import annotations
 
+import collections
+import hashlib
+import logging
+import time
 import typing
 
+import fastmcp.server.middleware
+import httpx
+from fastmcp.server.dependencies import get_http_headers
 from fastmcp.server.providers.openapi import MCPType, RouteMap
 
 if typing.TYPE_CHECKING:
+    import collections.abc
+
+    from fastmcp.tools import Tool
+    from fastmcp.utilities.components import FastMCPComponent
     from fastmcp.utilities.openapi import HTTPRoute
+
+LOGGER = logging.getLogger(__name__)
 
 #: OpenAPI operation extension imbi-api stamps on endpoints that must not
 #: be exposed to AI. Its presence (set to ``False``) hides the operation
 #: regardless of path or method -- the API owns which endpoints are
 #: sensitive (e.g. project Configuration / SSM Parameter Store).
 AI_TOOL_EXTENSION = 'x-imbi-ai-tool'
+
+#: OpenAPI operation extension imbi-api stamps with the list of
+#: permissions an operation requires (``['admin']`` for admin-only
+#: endpoints). Permission checks are FastAPI dependencies and so are
+#: otherwise invisible in the spec.
+#: :class:`PermissionFilterMiddleware` reads it to filter a caller's
+#: toolset down to what that caller can actually invoke.
+PERMISSION_EXTENSION = 'x-imbi-permission'
 
 #: Endpoints that should never become AI tools regardless of tagging --
 #: authentication, MFA, the status probe, and image thumbnails.
@@ -79,3 +109,199 @@ def exclude_non_ai_tools(
     if route.extensions.get(AI_TOOL_EXTENSION) is False:
         return MCPType.EXCLUDE
     return None
+
+
+#: Key under which :func:`copy_permissions_to_meta` records an
+#: operation's required permissions on the generated component's public
+#: ``meta`` dict.
+PERMISSION_META_KEY = 'imbi_permission'
+
+
+def copy_permissions_to_meta(
+    route: HTTPRoute, component: FastMCPComponent
+) -> None:
+    """Copy an operation's required permissions onto the component.
+
+    Intended to be passed as ``mcp_component_fn`` to
+    :meth:`fastmcp.FastMCP.from_openapi`. The route carries
+    :data:`PERMISSION_EXTENSION` from the spec, but the generated
+    component only keeps its route privately; recording the value in
+    the public ``meta`` dict at build time lets
+    :class:`PermissionFilterMiddleware` read it later without reaching
+    into fastmcp internals.
+    """
+    permissions = route.extensions.get(PERMISSION_EXTENSION)
+    if not permissions:
+        return
+    component.meta = (component.meta or {}) | {
+        PERMISSION_META_KEY: permissions
+    }
+
+
+def required_permissions(tool: Tool) -> list[str]:
+    """Return the permissions an operation-backed tool enforces.
+
+    Reads what :func:`copy_permissions_to_meta` recorded. Tools built
+    without that ``mcp_component_fn``, or whose operation has no
+    permission dependency, return an empty list.
+    """
+    meta = getattr(tool, 'meta', None) or {}
+    value = meta.get(PERMISSION_META_KEY)
+    return value if isinstance(value, list) else []
+
+
+class PermissionFilterMiddleware(fastmcp.server.middleware.Middleware):
+    """Hide tools the calling principal cannot invoke.
+
+    ``tools/list`` is filtered down to operations whose required
+    permissions (see :data:`PERMISSION_EXTENSION`) the caller actually
+    holds, so an agent is not offered hundreds of tools that can only
+    ever return ``403``. The caller's effective permissions come from
+    the API's ``/users/me``, which reports ``is_admin`` and the
+    ``permissions`` list; admins are never filtered, matching the
+    API's own admin bypass.
+
+    Requires the server to have been built with
+    :func:`copy_permissions_to_meta` as its ``mcp_component_fn``.
+    Without it no tool carries permission metadata, so there is nothing
+    to filter on and every tool is returned.
+
+    This is **advisory only** -- the API remains the sole enforcement
+    point. Filtering therefore fails *open*: if the profile lookup
+    fails, or the request carries no credentials, the unfiltered list
+    is returned rather than an empty toolset. A caller who invokes a
+    hidden tool anyway still gets a ``403`` from the API.
+
+    Resolved profiles are cached per credential for
+    :data:`CACHE_TTL_SECONDS`, since clients re-list tools on reconnect
+    and on capability changes rather than only once per session. The
+    cache is bounded and keyed on a hash of the credential so the raw
+    token is never held in memory -- the same tradeoff the API makes
+    for API-key auth. Permission changes therefore take effect within
+    the TTL.
+    """
+
+    #: Sentinel permission meaning "admin only" -- no non-admin
+    #: principal can hold it, so such tools are always filtered out.
+    ADMIN_PERMISSION = 'admin'
+
+    #: How long a resolved profile stays usable. Short, so revocations
+    #: and role changes surface quickly.
+    CACHE_TTL_SECONDS = 60
+
+    #: Upper bound on cached profiles, evicted least-recently-used.
+    CACHE_MAX_ENTRIES = 1024
+
+    def __init__(self, client: httpx.AsyncClient) -> None:
+        """Store the API client used to resolve the caller's profile.
+
+        Args:
+            client: Client bound to the Imbi API that forwards the
+                calling principal's credentials -- the same client used
+                to build the toolset. Its auth must be per-caller, or
+                every caller would be filtered against one identity.
+        """
+        self._client = client
+        self._cache: collections.OrderedDict[
+            str, tuple[float, tuple[bool, set[str]]]
+        ] = collections.OrderedDict()
+
+    def _cache_lookup(self, key: str) -> tuple[bool, set[str]] | None:
+        """Return a cached profile if present and unexpired."""
+        entry = self._cache.get(key)
+        if entry is None:
+            return None
+        expires, profile = entry
+        if time.monotonic() > expires:
+            del self._cache[key]
+            return None
+        self._cache.move_to_end(key)
+        return profile
+
+    def _cache_store(self, key: str, profile: tuple[bool, set[str]]) -> None:
+        """Store a profile, evicting the least-recently-used entry."""
+        while len(self._cache) >= self.CACHE_MAX_ENTRIES:
+            self._cache.popitem(last=False)
+        self._cache[key] = (
+            time.monotonic() + self.CACHE_TTL_SECONDS,
+            profile,
+        )
+
+    async def _caller_permissions(self) -> tuple[bool, set[str]] | None:
+        """Return ``(is_admin, permissions)``, or ``None`` if unknown.
+
+        Cached per credential; see the class docstring for the tradeoff.
+        Callers without a credential are not cached, since they would
+        all collide on one key.
+        """
+        credential = get_http_headers(include={'authorization'}).get(
+            'authorization'
+        )
+        key = (
+            hashlib.sha256(credential.encode('utf-8')).hexdigest()
+            if credential
+            else ''
+        )
+        if key:
+            cached = self._cache_lookup(key)
+            if cached is not None:
+                return cached
+        try:
+            response = await self._client.get('/users/me')
+            response.raise_for_status()
+            profile = response.json()
+        except (httpx.HTTPError, ValueError):
+            LOGGER.warning(
+                'Could not resolve caller permissions; '
+                'returning the unfiltered tool list',
+                exc_info=True,
+            )
+            return None
+        permissions = profile.get('permissions') or []
+        resolved = (
+            bool(profile.get('is_admin')),
+            {item for item in permissions if isinstance(item, str)},
+        )
+        if key:
+            self._cache_store(key, resolved)
+        return resolved
+
+    def _is_invocable(self, required: list[str], granted: set[str]) -> bool:
+        """Return whether a non-admin caller may invoke the operation.
+
+        :data:`ADMIN_PERMISSION` is a sentinel rather than a real grant,
+        so it is rejected outright -- admin callers never reach here,
+        and a caller who happens to hold a permission literally named
+        ``admin`` must not thereby gain admin-only tools.
+        """
+        if self.ADMIN_PERMISSION in required:
+            return False
+        return set(required).issubset(granted)
+
+    async def on_list_tools(
+        self,
+        context: fastmcp.server.middleware.MiddlewareContext[typing.Any],
+        call_next: typing.Any,
+    ) -> collections.abc.Sequence[Tool]:
+        """Filter ``tools/list`` to what the caller may invoke."""
+        tools: collections.abc.Sequence[Tool] = await call_next(context)
+        gated = [(tool, required_permissions(tool)) for tool in tools]
+        if not any(required for _, required in gated):
+            return tools
+        resolved = await self._caller_permissions()
+        if resolved is None:
+            return tools
+        is_admin, granted = resolved
+        if is_admin:
+            return tools
+        kept = [
+            tool
+            for tool, required in gated
+            if self._is_invocable(required, granted)
+        ]
+        LOGGER.debug(
+            'Filtered tool list from %d to %d for caller permissions',
+            len(tools),
+            len(kept),
+        )
+        return kept

--- a/libraries/common/src/imbi/common/mcp.py
+++ b/libraries/common/src/imbi/common/mcp.py
@@ -257,6 +257,13 @@ class PermissionFilterMiddleware(fastmcp.server.middleware.Middleware):
                 exc_info=True,
             )
             return None
+        if not isinstance(profile, dict):
+            LOGGER.warning(
+                'Unexpected /users/me payload of type %s; '
+                'returning the unfiltered tool list',
+                type(profile).__name__,
+            )
+            return None
         permissions = profile.get('permissions') or []
         resolved = (
             bool(profile.get('is_admin')),

--- a/libraries/common/tests/test_mcp.py
+++ b/libraries/common/tests/test_mcp.py
@@ -243,6 +243,16 @@ class PermissionFilterMiddlewareTests(unittest.IsolatedAsyncioTestCase):
             names = await self._tool_names(handler)
         self.assertEqual(4, len(names))
 
+    async def test_fails_open_on_non_object_profile(self) -> None:
+        """Well-formed JSON that is not an object also fails open."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json=['not', 'a', 'profile'])
+
+        with self.assertLogs('imbi.common.mcp', level='WARNING'):
+            names = await self._tool_names(handler)
+        self.assertEqual(4, len(names))
+
 
 class PermissionCacheTests(unittest.IsolatedAsyncioTestCase):
     """Profile caching in :class:`PermissionFilterMiddleware`."""

--- a/libraries/common/tests/test_mcp.py
+++ b/libraries/common/tests/test_mcp.py
@@ -3,7 +3,10 @@
 from __future__ import annotations
 
 import json
+import time
+import typing
 import unittest
+import unittest.mock
 
 import fastmcp
 import httpx
@@ -65,24 +68,34 @@ class ExcludedRouteMapsTestCase(unittest.TestCase):
         )
 
 
-def _spec() -> dict[str, object]:
-    """Minimal OpenAPI spec exercising each exclusion path."""
-    ok = {'responses': {'200': {'description': 'OK'}}}
+#: Boilerplate ``responses`` block every test operation needs.
+OK = {'responses': {'200': {'description': 'OK'}}}
+
+
+def _openapi_spec(paths: dict[str, object]) -> dict[str, object]:
+    """Wrap ``paths`` in a minimal OpenAPI envelope."""
     return {
         'openapi': '3.1.0',
         'info': {'title': 'Imbi', 'version': '1.0.0'},
-        'paths': {
-            '/projects/': {'get': {'operationId': 'list_projects', **ok}},
-            '/auth/login': {'post': {'operationId': 'login', **ok}},
+        'paths': paths,
+    }
+
+
+def _spec() -> dict[str, object]:
+    """Minimal OpenAPI spec exercising each exclusion path."""
+    return _openapi_spec(
+        {
+            '/projects/': {'get': {'operationId': 'list_projects', **OK}},
+            '/auth/login': {'post': {'operationId': 'login', **OK}},
             '/configuration/{key}': {
                 'put': {
                     'operationId': 'set_configuration_value',
                     'x-imbi-ai-tool': False,
-                    **ok,
+                    **OK,
                 }
             },
-        },
-    }
+        }
+    )
 
 
 class FromOpenapiExclusionTests(unittest.IsolatedAsyncioTestCase):
@@ -111,3 +124,248 @@ class FromOpenapiExclusionTests(unittest.IsolatedAsyncioTestCase):
     async def test_serializable_spec_round_trips(self) -> None:
         """The spec used in tests is valid JSON (guards typos)."""
         self.assertIn('x-imbi-ai-tool', json.dumps(_spec()))
+
+
+def _permission_spec() -> dict[str, object]:
+    """Spec whose operations carry ``x-imbi-permission``."""
+    return _openapi_spec(
+        {
+            '/projects/': {
+                'get': {
+                    'operationId': 'list_projects',
+                    'x-imbi-permission': ['project:read'],
+                    **OK,
+                },
+                'post': {
+                    'operationId': 'create_project',
+                    'x-imbi-permission': ['project:write'],
+                    **OK,
+                },
+            },
+            '/graph/query': {
+                'post': {
+                    'operationId': 'graph_query',
+                    'x-imbi-permission': ['admin'],
+                    **OK,
+                }
+            },
+            '/ungated': {'get': {'operationId': 'ungated_op', **OK}},
+        }
+    )
+
+
+class PermissionFilterMiddlewareTests(unittest.IsolatedAsyncioTestCase):
+    """Per-caller filtering of ``tools/list``."""
+
+    async def _tool_names(
+        self, handler: typing.Callable[[httpx.Request], httpx.Response]
+    ) -> set[str]:
+        """Build a filtered server and list its tools.
+
+        ``handler`` stands in for the API, answering the middleware's
+        ``/users/me`` lookup.
+        """
+        client = httpx.AsyncClient(
+            base_url='http://localhost:8000',
+            transport=httpx.MockTransport(handler),
+        )
+        try:
+            server = fastmcp.FastMCP.from_openapi(
+                openapi_spec=_permission_spec(),
+                client=client,
+                name='Imbi',
+                route_maps=list(mcp.EXCLUDED_ROUTE_MAPS),
+                route_map_fn=mcp.exclude_non_ai_tools,
+                mcp_component_fn=mcp.copy_permissions_to_meta,
+            )
+            server.add_middleware(mcp.PermissionFilterMiddleware(client))
+            async with fastmcp.Client(server) as connected:
+                return {tool.name for tool in await connected.list_tools()}
+        finally:
+            await client.aclose()
+
+    @staticmethod
+    def _profile(
+        *, is_admin: bool, permissions: list[str]
+    ) -> typing.Callable[[httpx.Request], httpx.Response]:
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                json={'is_admin': is_admin, 'permissions': permissions},
+            )
+
+        return handler
+
+    async def test_filters_tools_caller_cannot_invoke(self) -> None:
+        """Only tools whose permissions the caller holds survive."""
+        names = await self._tool_names(
+            self._profile(is_admin=False, permissions=['project:read'])
+        )
+        self.assertEqual({'list_projects', 'ungated_op'}, names)
+
+    async def test_admin_sees_every_tool(self) -> None:
+        """Admins bypass filtering, matching the API's own bypass."""
+        names = await self._tool_names(
+            self._profile(is_admin=True, permissions=[])
+        )
+        self.assertEqual(
+            {'list_projects', 'create_project', 'graph_query', 'ungated_op'},
+            names,
+        )
+
+    async def test_admin_only_tool_hidden_from_non_admin(self) -> None:
+        """The ``admin`` sentinel is never satisfied by a permission."""
+        names = await self._tool_names(
+            self._profile(is_admin=False, permissions=['admin'])
+        )
+        self.assertNotIn('graph_query', names)
+
+    async def test_fails_open_on_profile_error(self) -> None:
+        """A failed lookup returns the unfiltered list, not an empty one."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(500)
+
+        with self.assertLogs('imbi.common.mcp', level='WARNING'):
+            names = await self._tool_names(handler)
+        self.assertEqual(
+            {'list_projects', 'create_project', 'graph_query', 'ungated_op'},
+            names,
+        )
+
+    async def test_fails_open_on_transport_error(self) -> None:
+        """A connection failure also fails open."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            raise httpx.ConnectError('boom')
+
+        with self.assertLogs('imbi.common.mcp', level='WARNING'):
+            names = await self._tool_names(handler)
+        self.assertEqual(4, len(names))
+
+
+class PermissionCacheTests(unittest.IsolatedAsyncioTestCase):
+    """Profile caching in :class:`PermissionFilterMiddleware`."""
+
+    def setUp(self) -> None:
+        self.calls: list[str] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            self.calls.append(request.headers.get('authorization', ''))
+            return httpx.Response(
+                200, json={'is_admin': False, 'permissions': ['project:read']}
+            )
+
+        self.client = httpx.AsyncClient(
+            base_url='http://localhost:8000',
+            transport=httpx.MockTransport(handler),
+        )
+        self.middleware = mcp.PermissionFilterMiddleware(self.client)
+
+    async def asyncTearDown(self) -> None:
+        await self.client.aclose()
+
+    async def _resolve(self, token: str | None) -> None:
+        """Resolve permissions as though called with ``token``."""
+        headers = {'authorization': token} if token else {}
+        with unittest.mock.patch.object(
+            mcp, 'get_http_headers', return_value=headers
+        ):
+            await self.middleware._caller_permissions()
+
+    async def test_repeated_lookups_hit_the_cache(self) -> None:
+        """The same credential resolves without a second request."""
+        await self._resolve('Bearer token-a')
+        await self._resolve('Bearer token-a')
+        self.assertEqual(1, len(self.calls))
+
+    async def test_distinct_credentials_are_not_shared(self) -> None:
+        """A second caller must not inherit the first one's profile."""
+        await self._resolve('Bearer token-a')
+        await self._resolve('Bearer token-b')
+        self.assertEqual(2, len(self.calls))
+
+    async def test_expired_entry_is_refetched(self) -> None:
+        """Past the TTL the profile is resolved again."""
+        await self._resolve('Bearer token-a')
+        with unittest.mock.patch.object(
+            mcp.time,
+            'monotonic',
+            return_value=time.monotonic()
+            + mcp.PermissionFilterMiddleware.CACHE_TTL_SECONDS
+            + 1,
+        ):
+            await self._resolve('Bearer token-a')
+        self.assertEqual(2, len(self.calls))
+
+    async def test_anonymous_callers_are_not_cached(self) -> None:
+        """With no credential there is no key to cache under."""
+        await self._resolve(None)
+        await self._resolve(None)
+        self.assertEqual(2, len(self.calls))
+
+    async def test_cache_is_bounded(self) -> None:
+        """The cache never grows past its maximum size."""
+        limit = mcp.PermissionFilterMiddleware.CACHE_MAX_ENTRIES
+        for index in range(limit + 10):
+            await self._resolve(f'Bearer token-{index}')
+        self.assertLessEqual(
+            len(self.middleware._cache),
+            limit,
+        )
+
+
+class RequiredPermissionsTests(unittest.IsolatedAsyncioTestCase):
+    """Unit tests for :func:`imbi.common.mcp.required_permissions`."""
+
+    async def test_reads_permissions_recorded_on_meta(self) -> None:
+        """``copy_permissions_to_meta`` makes permissions readable."""
+        client = httpx.AsyncClient(base_url='http://localhost:8000')
+        try:
+            server = fastmcp.FastMCP.from_openapi(
+                openapi_spec=_permission_spec(),
+                client=client,
+                name='Imbi',
+                mcp_component_fn=mcp.copy_permissions_to_meta,
+            )
+            found = {
+                tool.name: mcp.required_permissions(tool)
+                for tool in await server.list_tools()
+            }
+        finally:
+            await client.aclose()
+        self.assertEqual(['project:read'], found['list_projects'])
+        self.assertEqual(['admin'], found['graph_query'])
+        self.assertEqual([], found['ungated_op'])
+
+    async def test_meta_survives_the_mcp_protocol(self) -> None:
+        """Permissions reach a connected client, not just the server.
+
+        ``meta`` is a public field, so it is carried over the wire --
+        this guards the coupling that reading a private ``_route``
+        attribute previously created.
+        """
+        client = httpx.AsyncClient(base_url='http://localhost:8000')
+        try:
+            server = fastmcp.FastMCP.from_openapi(
+                openapi_spec=_permission_spec(),
+                client=client,
+                name='Imbi',
+                mcp_component_fn=mcp.copy_permissions_to_meta,
+            )
+            async with fastmcp.Client(server) as connected:
+                tools = {
+                    tool.name: tool for tool in await connected.list_tools()
+                }
+        finally:
+            await client.aclose()
+        self.assertEqual(
+            ['project:read'],
+            mcp.required_permissions(tools['list_projects']),
+        )
+        self.assertEqual([], mcp.required_permissions(tools['ungated_op']))
+
+    def test_non_openapi_tool_has_no_permissions(self) -> None:
+        """A tool with no recorded meta yields an empty list."""
+        not_a_tool = typing.cast(typing.Any, object())
+        self.assertEqual([], mcp.required_permissions(not_a_tool))


### PR DESCRIPTION
## Summary

Exposes the Imbi API's read operations as MCP tools, and filters each caller's `tools/list` down to the operations that caller actually has permission to invoke.

## Problem

The MCP server mapped every `GET` to an MCP **resource** or **resource template**, so only mutating operations became tools:

```python
_SEMANTIC_ROUTE_MAPS = [
    RouteMap(methods=['GET'], pattern=r'.*\{.*\}.*',
             mcp_type=MCPType.RESOURCE_TEMPLATE),
    RouteMap(methods=['GET'], pattern=r'.*', mcp_type=MCPType.RESOURCE),
]
```

Support for MCP resources is uneven across clients — many wire up only `tools/*` and never call `resources/read`. An app connected to the Imbi MCP therefore saw a mutation-only toolset: nothing to retrieve an entity or a collection, nothing to return release information or ops log entries.

`imbi-assistant` never had this problem; it passes only `EXCLUDED_ROUTE_MAPS` and so gets fastmcp's default all-routes-become-tools behavior. The MCP server was the only consumer that diverged.

Exposing reads roughly doubles the tool count (~134 `GET` vs ~152 mutating routes), which is a real context cost and surfaces a second problem: the toolset was never scoped to the caller, so an agent is offered many tools that can only ever return `403`.

## Solution

**Reads become tools.** Drop the semantic route maps so `GET`s fall through to fastmcp's default `TOOL` mapping, matching `imbi-assistant`.

**Permissions become visible to the schema.** Permission checks are FastAPI dependency closures and are invisible to `app.openapi()`. `require_permission` now tags the closure it returns, and the schema build walks each route's dependency tree to recover the value and stamp `x-imbi-permission` on the operation. The tree walk matters: permissions declared on a *router* rather than an operation are only found by recursing.

**Toolsets become per-caller.** `PermissionFilterMiddleware` narrows `tools/list` using `/users/me`, cached per credential with a bounded TTL/LRU (mirroring the API's existing `_api_key_cache`). Admins bypass filtering, matching the API's own bypass.

Filtering is **advisory** and **fails open** — the API remains the sole enforcement point, so a failed profile lookup returns the unfiltered list rather than an empty toolset. A caller who invokes a hidden tool still gets a `403`.

Permissions ride on each component's public `meta` via an `mcp_component_fn`, not fastmcp's private `_route` attribute, so a fastmcp upgrade can't silently break the filter. As a side benefit `meta` round-trips over the protocol, so permissions are readable client-side too.

## Notable details for review

- Matching uses `route.path_format`, not `route.path`. FastAPI publishes `/refs/{ref:path}` as `/refs/{ref}`, so matching on `path` silently skipped every converter-typed route — leaving e.g. `list_commits` (guarded by `project:deployment:read`) unstamped and therefore indistinguishable from an unguarded operation. Covered by `test_stamps_route_with_path_converter`.
- `PermissionFilterMiddleware` requires `copy_permissions_to_meta` as the `mcp_component_fn`. Without it nothing carries permission metadata and every tool is returned. Called out in both docstrings and the docs.
- The `admin` sentinel is rejected outright rather than checked by subset, so a caller who literally holds a permission named `admin` cannot thereby unlock admin-only tools.
- Stamping happens inside `_build_schema`, behind the existing `_schema_cache`, so the route walk is a one-time cost per process rather than per request.

## Not included

- **`imbi-assistant` is not wired up.** The middleware lives in `libraries/common` and the assistant's client already forwards per-caller auth, so adopting it is a one-line change — but it alters a second consumer's behavior and was out of scope here. Until then the assistant still offers an unfiltered toolset.
- **No cache invalidation hook.** Permission changes take effect within the TTL; there is no equivalent of `clear_api_key_cache()` because nothing would call it yet.
- **A coverage test asserting every permission-guarded route carries the tag.** The silent failure mode is a future endpoint adding a permission dependency without one; it would then look unguarded to the filter. Checking this needs the live app and therefore a database.

## Testing

85 tests pass (`apps/api/tests/test_openapi.py`, `libraries/common/tests/test_mcp.py`, `apps/mcp/tests`, `apps/api/tests/auth/test_permissions.py`), 24 of them new, covering per-caller filtering, admin bypass, fail-open on both HTTP and transport errors, cache hit/isolation/expiry/bounding, router-level and converter-typed permission stamping, and that reads surface as tools with no resources or templates remaining. `pre-commit` (ruff, ruff-format, mypy) passes on all changed files.

Not verified against a live server: the stamping tests build small FastAPI apps and the filtering tests use a synthetic spec, since generating the real schema needs a database. Worth confirming `x-imbi-permission` appears in `/openapi.json` after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UJX17VMtL347wTRfABqZ5y
