### PR TITLE
Make projects-list drift badges deep-link to their targets

### DIFF
--- a/ui/src/components/ProjectsView.tsx
+++ b/ui/src/components/ProjectsView.tsx
@@ -54,6 +54,7 @@ interface DriftPair {
   from: string
   to: string
   toLabelColor?: null | string
+  toSlug: string
 }
 
 interface FilterHeaderProps {
@@ -871,6 +872,7 @@ function computeDriftPairs(
       from: a.name,
       to: b.name,
       toLabelColor: b.label_color ?? null,
+      toSlug: b.slug,
     })
   }
   return pairs
@@ -962,6 +964,7 @@ function DriftCell({
           slug: string
           sort_order?: null | number
         }[]
+    id: string
     project_types?: null | object[]
     release_summary?: null | {
       commits_since_tag: number
@@ -970,9 +973,11 @@ function DriftCell({
   }
 }) {
   const { isDarkMode } = useTheme()
+  // z-10 lifts the badges above the row/card overlay Link so their own
+  // deep-links win the click.
   const containerCls = inline
-    ? 'flex flex-row flex-wrap items-center gap-1'
-    : 'flex flex-col items-center gap-1.5'
+    ? 'relative z-10 flex flex-row flex-wrap items-center gap-1'
+    : 'relative z-10 flex flex-col items-center gap-1.5'
   const badgeBaseCls = inline
     ? 'inline-flex items-center rounded-md px-1.5 py-0.5 text-xs font-mono text-xs'
     : 'inline-flex items-center gap-1.5 rounded-md px-2 py-1 font-mono text-xs'
@@ -997,7 +1002,8 @@ function DriftCell({
           ? deriveChipColors(p.toLabelColor, isDarkMode)
           : null
         return (
-          <span
+          <Link
+            aria-label={`Deploy ${p.from} to ${p.to}`}
             className={
               derived
                 ? `${badgeBaseCls} border`
@@ -1013,21 +1019,26 @@ function DriftCell({
                   }
                 : undefined
             }
+            to={`/projects/${project.id}/deployments?env=${encodeURIComponent(p.toSlug)}`}
           >
             <span className="font-medium">Δ</span>
             <span>{abbreviateEnvName(p.from)}</span>
             <span>→</span>
             <span>{abbreviateEnvName(p.to)}</span>
-          </span>
+          </Link>
         )
       })}
       {releaseDrifted && (
-        <span className={`${badgeBaseCls} ${fallbackCls}`}>
+        <Link
+          aria-label="Cut a release"
+          className={`${badgeBaseCls} ${fallbackCls}`}
+          to={`/projects/${project.id}/releases`}
+        >
           <span className="font-medium">Δ</span>
           <span>C</span>
           <span>→</span>
           <span>R</span>
-        </span>
+        </Link>
       )}
     </div>
   )

--- a/ui/src/components/deployments/DeploymentsTab.tsx
+++ b/ui/src/components/deployments/DeploymentsTab.tsx
@@ -1,4 +1,6 @@
-import { useMemo, useState } from 'react'
+import { useMemo } from 'react'
+
+import { useSearchParams } from 'react-router-dom'
 
 import { useQuery } from '@tanstack/react-query'
 
@@ -92,11 +94,19 @@ export function DeploymentsTab({
     [environments, currentReleases, history, recentCommits],
   )
 
-  const [selectedSlug, setSelectedSlug] = useState<null | string>(null)
+  // `?env=<slug>` deep-links a specific stage (e.g. from the projects
+  // list's drift badges); an in-tab selection takes over from there.
+  const [searchParams, setSearchParams] = useSearchParams()
+  const requestedSlug = searchParams.get('env')
   const effectiveSlug =
-    selectedSlug && stages.some((s) => s.env.slug === selectedSlug)
-      ? selectedSlug
+    requestedSlug && stages.some((s) => s.env.slug === requestedSlug)
+      ? requestedSlug
       : defaultStageSlug(stages)
+  const selectStage = (slug: string) => {
+    const next = new URLSearchParams(searchParams)
+    next.set('env', slug)
+    setSearchParams(next, { replace: true })
+  }
   const selectedStage = stages.find((s) => s.env.slug === effectiveSlug) ?? null
 
   const actions = useDeploymentActions({ onRunStarted, orgSlug, projectId })
@@ -126,7 +136,7 @@ export function DeploymentsTab({
         connectLabel={connectLabel}
         isDarkMode={isDarkMode}
         isSyncing={isSyncing}
-        onSelect={setSelectedSlug}
+        onSelect={selectStage}
         onSync={sync}
         readiness={readiness}
         selectedSlug={effectiveSlug}


### PR DESCRIPTION
## Summary
Drift badges on the projects list are now clickable deep links: environment-drift badges open the project's Deployments tab with the target stage preselected, and the commits-since-release badge opens the Releases tab.

## Problem
The drift badges (`Δ staging → production`, `Δ C → R`) signal actionable work, but they were inert `<span>`s. Acting on drift meant clicking through to the project, finding the Deployments tab, and manually selecting the right stage.

## Solution
- Badges are rendered as `Link`s with `aria-label`s; env-drift badges link to `/projects/:id/deployments?env=<target-slug>`, the release badge to `/projects/:id/releases`.
- `DeploymentsTab` now reads and writes the selected stage through the `env` search param (replacing local `useState`), so stage selection is deep-linkable and in-tab selection updates the URL with `replace`.
- Badge containers get `relative z-10` so their links win the click over the row/card overlay link.

## Impact
UI-only. Stage selection in the Deployments tab now persists in the URL, so refreshes and shared links land on the same stage.

## Testing
- `npm run lint`: 0 errors (warnings are pre-existing Tailwind class-order noise)
- `vitest run src/components/deployments`: 45/45 passed