### PR TITLE
Diagnose and repair SonarQube's tracked main branch

### DIFF
--- a/plugins/sonarqube/src/imbi/plugins/sonarqube/README.md
+++ b/plugins/sonarqube/src/imbi/plugins/sonarqube/README.md
@@ -39,7 +39,8 @@ should switch.
 
 ## Project Doctor
 
-The `analysis` capability checks two things and offers a fix for each:
+The `analysis` capability checks three things, offering a fix for the
+first two:
 
 1. **The `EXISTS_IN` edge** — that the component key
    (`<team-slug>:<project-slug>`, or the edge's own identifier) exists in

--- a/plugins/sonarqube/src/imbi/plugins/sonarqube/README.md
+++ b/plugins/sonarqube/src/imbi/plugins/sonarqube/README.md
@@ -46,13 +46,17 @@ The `analysis` capability checks two things and offers a fix for each:
    SonarQube, and that the edge's canonical URL and `sonarqube` dashboard link
    match it. The fix searches for the component, creates it when absent, and
    writes the edge.
-2. **The main branch** — SonarQube reports a project's state from the single
-   branch flagged `isMain`, so a repository that moved from `master` to `main`
-   keeps syncing measures from an analysis that stopped running. When
-   `/api/project_branches/list` shows the expected branch and it is *not* the
-   main branch, the finding fails and the fix `POST`s
-   `/api/project_branches/set_main`. A component that does not have the
-   expected branch at all is left alone — there is nothing to switch to.
+2. **The main branch** (`main-branch`) — SonarQube reports a project's state
+   from the single branch flagged `isMain`, so a repository that moved from
+   `master` to `main` keeps syncing measures from an analysis that stopped
+   running. When `/api/project_branches/list` shows the expected branch and it
+   is *not* the main branch, the finding fails and the fix `POST`s
+   `/api/project_branches/set_main`.
+3. **The main branch is missing** (`main-branch-missing`) — when SonarQube has
+   no such branch at all, the finding fails with **no** fix offered: SonarQube
+   only records a branch once an analysis has run on it, so nothing this plugin
+   can call will create one. Either CI needs to analyze that branch, or the
+   project genuinely uses a different one and `main_branch` should say so.
 
 The expected branch is the capability's `main_branch` option, defaulting to
 `main`. Set it on the Integration's *Project doctor* capability for the

--- a/plugins/sonarqube/src/imbi/plugins/sonarqube/README.md
+++ b/plugins/sonarqube/src/imbi/plugins/sonarqube/README.md
@@ -34,7 +34,32 @@ scanner uses and answer `403` to every request this plugin makes, including
 restriction rides on the token *type*, so issuing an analysis token from an
 administrator account does not help. Grant the token's account Browse on the
 projects being read, plus Create Projects if the Project Doctor should create
-missing SonarQube projects.
+missing SonarQube projects and Administer on a project whose main branch it
+should switch.
+
+## Project Doctor
+
+The `analysis` capability checks two things and offers a fix for each:
+
+1. **The `EXISTS_IN` edge** — that the component key
+   (`<team-slug>:<project-slug>`, or the edge's own identifier) exists in
+   SonarQube, and that the edge's canonical URL and `sonarqube` dashboard link
+   match it. The fix searches for the component, creates it when absent, and
+   writes the edge.
+2. **The main branch** — SonarQube reports a project's state from the single
+   branch flagged `isMain`, so a repository that moved from `master` to `main`
+   keeps syncing measures from an analysis that stopped running. When
+   `/api/project_branches/list` shows the expected branch and it is *not* the
+   main branch, the finding fails and the fix `POST`s
+   `/api/project_branches/set_main`. A component that does not have the
+   expected branch at all is left alone — there is nothing to switch to.
+
+The expected branch is the capability's `main_branch` option, defaulting to
+`main`. Set it on the Integration's *Project doctor* capability for the
+org-wide convention; because the host layers capability options
+(Integration < project-type `USES` edge < project `USES` edge), a project
+type or single project whose trunk is named something else can override it
+without changing the default.
 
 A typical webhook rule:
 

--- a/plugins/sonarqube/src/imbi/plugins/sonarqube/client.py
+++ b/plugins/sonarqube/src/imbi/plugins/sonarqube/client.py
@@ -130,6 +130,95 @@ async def search_project(
     return None
 
 
+async def list_branches(
+    *,
+    base_url: str,
+    api_token: str,
+    key: str,
+    timeout: float = 15.0,
+) -> list[dict[str, typing.Any]]:
+    """Return the branches SonarQube holds for project ``key``.
+
+    Calls ``GET {base_url}/api/project_branches/list``.  Exactly one entry
+    carries ``isMain: true`` -- the branch whose analysis SonarQube reports
+    as the project's state.  A project with no analysis yet yields an empty
+    list.  Raises :class:`SonarqubeClientError` on transport / non-2xx
+    failure.
+    """
+    url = base_url.rstrip('/') + '/api/project_branches/list'
+    params = {'project': key}
+    try:
+        async with httpx.AsyncClient(timeout=timeout) as http_client:
+            response = await http_client.get(
+                url, params=params, headers=_headers(api_token)
+            )
+    except httpx.RequestError as exc:
+        raise SonarqubeClientError(f'SonarQube request failed: {exc}') from exc
+    if response.is_error:
+        LOGGER.warning(
+            'SonarQube %s %s returned %d: %s',
+            response.request.method,
+            response.request.url,
+            response.status_code,
+            response.text,
+        )
+        raise SonarqubeClientError(
+            f'SonarQube returned status {response.status_code}'
+        )
+    try:
+        payload = typing.cast('dict[str, typing.Any]', response.json())
+    except ValueError as exc:
+        raise SonarqubeClientError(
+            'SonarQube returned non-JSON response'
+        ) from exc
+    branches_obj = payload.get('branches', [])
+    if not isinstance(branches_obj, list):
+        return []
+    return [
+        typing.cast('dict[str, typing.Any]', branch)
+        for branch in typing.cast('list[object]', branches_obj)
+        if isinstance(branch, dict)
+    ]
+
+
+async def set_main_branch(
+    *,
+    base_url: str,
+    api_token: str,
+    key: str,
+    branch: str,
+    timeout: float = 15.0,
+) -> None:
+    """Make ``branch`` the main branch of project ``key``.
+
+    Calls ``POST {base_url}/api/project_branches/set_main``, which answers
+    ``204`` with no body.  The branch SonarQube tracked before becomes an
+    ordinary branch.  Raises :class:`SonarqubeClientError` on transport /
+    non-2xx failure -- notably an unknown branch, or a token whose account
+    lacks Administer on the project.
+    """
+    url = base_url.rstrip('/') + '/api/project_branches/set_main'
+    params = {'project': key, 'branch': branch}
+    try:
+        async with httpx.AsyncClient(timeout=timeout) as http_client:
+            response = await http_client.post(
+                url, params=params, headers=_headers(api_token)
+            )
+    except httpx.RequestError as exc:
+        raise SonarqubeClientError(f'SonarQube request failed: {exc}') from exc
+    if response.is_error:
+        LOGGER.warning(
+            'SonarQube %s %s returned %d: %s',
+            response.request.method,
+            response.request.url,
+            response.status_code,
+            response.text,
+        )
+        raise SonarqubeClientError(
+            f'SonarQube returned status {response.status_code}'
+        )
+
+
 async def create_project(
     *,
     base_url: str,

--- a/plugins/sonarqube/src/imbi/plugins/sonarqube/doctor.py
+++ b/plugins/sonarqube/src/imbi/plugins/sonarqube/doctor.py
@@ -6,6 +6,16 @@ and, when none is found, **creates** it — then writes the ``EXISTS_IN``
 edge so the gateway's webhook routing (which matches the component key
 against ``EXISTS_IN.identifier``) resolves for future measure syncs.
 
+It also checks which branch SonarQube tracks as the component's main
+branch. SonarQube reports the project's state from that one branch, and a
+repository that moved from ``master`` to ``main`` leaves the abandoned
+branch flagged ``isMain`` — so the measures Imbi syncs come from an
+analysis that stopped running. The repair points the main branch at the
+expected one, which is the ``main_branch`` capability option (default
+``main``): set on the Integration for the org-wide convention and
+overridden per project-type / project by the ``USES`` edge, for the
+repository whose trunk is named something else.
+
 The component key convention is ``<owning-team-slug>:<project-slug>``.
 An existing edge's identifier wins over the derived default so a
 manually-configured key is never overwritten.
@@ -20,6 +30,7 @@ from __future__ import annotations
 import logging
 import typing
 import urllib.parse
+from collections import abc
 
 from imbi.common.plugins.base import (
     AnalysisCapability,
@@ -44,9 +55,22 @@ _REPAIR_EDGE = 'repair-edge'
 #: has since vanished, it fails rather than silently creating one.
 _RECONCILE_EDGE = 'reconcile-edge'
 
+#: Points SonarQube's main branch at the expected branch. Destructive: the
+#: branch SonarQube reports on today stops driving the project's state.
+_SET_MAIN_BRANCH = 'set-main-branch'
+
 #: SonarQube's dashboard link uses the integration slug as its key (unlike
 #: GitHub's bespoke ``github-repository`` key).
 _LINK_KEY = 'sonarqube'
+
+#: Capability option naming the branch SonarQube is expected to track. It
+#: is capability- rather than integration-scoped so the host's option
+#: layering (Integration < project-type edge < project edge) lets a single
+#: repository dissent from the org-wide convention.
+MAIN_BRANCH_OPTION = 'main_branch'
+
+#: Value of :data:`MAIN_BRANCH_OPTION` when the operator sets none.
+DEFAULT_MAIN_BRANCH = 'main'
 
 
 def _item(
@@ -84,6 +108,19 @@ def _reconcile_offer() -> RemediationOffer:
     )
 
 
+def _set_main_branch_offer(branch: str) -> RemediationOffer:
+    return RemediationOffer(
+        id=_SET_MAIN_BRANCH,
+        label=f'Track {branch!r} as the main branch',
+        confirm=(
+            f'This makes {branch!r} the main branch in SonarQube. The branch '
+            'it tracks today becomes an ordinary branch and its analysis '
+            "stops driving the project's reported state."
+        ),
+        destructive=True,
+    )
+
+
 def _find_connection(
     ctx: PluginContext, slug: str
 ) -> ServiceConnection | None:
@@ -96,6 +133,19 @@ def _find_connection(
 def _service_url(ctx: PluginContext) -> str | None:
     raw = ctx.integration_options.get('service_url')
     return str(raw).strip() if raw and str(raw).strip() else None
+
+
+def _main_branch(ctx: PluginContext) -> str:
+    """Resolve the branch SonarQube is expected to track.
+
+    The host has already layered the Integration's value under any
+    project-type / project ``USES``-edge override, so this only has to
+    supply :data:`DEFAULT_MAIN_BRANCH` when the option is unset — which
+    covers every Integration created before the option existed.
+    """
+    raw = ctx.capability_options.get(MAIN_BRANCH_OPTION)
+    branch = str(raw).strip() if raw is not None else ''
+    return branch or DEFAULT_MAIN_BRANCH
 
 
 def _component_key(
@@ -160,6 +210,65 @@ def _canonical_url(base_url: str, key: str) -> str:
 def _dashboard_url(base_url: str, key: str) -> str:
     quoted = urllib.parse.quote(key, safe='')
     return f'{base_url.rstrip("/")}/dashboard?id={quoted}'
+
+
+def _named_branch(
+    branches: abc.Sequence[dict[str, typing.Any]], name: str
+) -> dict[str, typing.Any] | None:
+    return next((b for b in branches if b.get('name') == name), None)
+
+
+def _tracked_phrase(branches: abc.Sequence[dict[str, typing.Any]]) -> str:
+    """Phrase the branch SonarQube currently reports the project's state from.
+
+    A component with no analysis yet has no branch flagged ``isMain``, so
+    the findings have to read sensibly without one.
+    """
+    for branch in branches:
+        if branch.get('isMain') is True:
+            return f'it reports on {branch.get("name")!r}'
+    return 'no branch is flagged as its main branch'
+
+
+class _Unconfigured(Exception):
+    """Raised when the Integration lacks something a remediation needs."""
+
+
+class _Target(typing.NamedTuple):
+    """What every remediation needs resolved before it can call SonarQube."""
+
+    base_url: str
+    api_token: str
+    key: str
+    connection: ServiceConnection | None
+
+
+def _remediation_target(
+    ctx: PluginContext, credentials: dict[str, str]
+) -> _Target:
+    """Resolve the SonarQube target, or raise :class:`_Unconfigured`.
+
+    The message carried by the exception is the one the Doctor panel shows,
+    so each guard explains what to configure rather than that something is
+    missing.
+    """
+    slug = ctx.integration_slug
+    if slug is None:
+        raise _Unconfigured('Capability is not bound to an Integration.')
+    base_url = _service_url(ctx)
+    if not base_url:
+        raise _Unconfigured('The Integration has no service_url configured.')
+    api_token = credentials.get('api_token')
+    if not api_token:
+        raise _Unconfigured('No api_token credential configured.')
+    connection = _find_connection(ctx, slug)
+    key = _component_key(ctx, connection)
+    if key is None:
+        raise _Unconfigured(
+            'Cannot derive the SonarQube component key: no EXISTS_IN edge '
+            'and no owning team.'
+        )
+    return _Target(base_url, api_token, key, connection)
 
 
 class SonarQubeDoctor(AnalysisCapability):
@@ -234,10 +343,71 @@ class SonarQubeDoctor(AnalysisCapability):
             ]
 
         if connection is not None:
-            return self._analyze_existing_edge(
+            results = self._analyze_existing_edge(
                 ctx, connection, base_url, key, component
             )
-        return self._analyze_no_edge(key, component)
+        else:
+            results = self._analyze_no_edge(key, component)
+        # The branch check needs a live component, but not an edge: a
+        # stale main branch reports stale measures whether or not Imbi has
+        # linked the component yet.
+        if component is not None:
+            results.append(
+                await self._analyze_main_branch(
+                    base_url, api_token, key, _main_branch(ctx)
+                )
+            )
+        return results
+
+    async def _analyze_main_branch(
+        self, base_url: str, api_token: str, key: str, branch: str
+    ) -> AnalysisResultItem:
+        """Check that SonarQube tracks ``branch`` as the main branch.
+
+        A repository that migrated from ``master`` to ``main`` keeps the
+        abandoned branch flagged ``isMain`` in SonarQube, which goes on
+        reporting the analysis it last ran. Only a component that *has*
+        ``branch`` can be repaired, so one that never adopted it (still on
+        ``master``) passes rather than nagging.
+        """
+        try:
+            branches = await client.list_branches(
+                base_url=base_url, api_token=api_token, key=key
+            )
+        except client.SonarqubeClientError as exc:
+            return _item(
+                'main-branch',
+                'Main branch',
+                'warn',
+                f'Could not list the branches of component {key!r}: '
+                f'{exc}{_token_type_hint(exc, api_token)}',
+            )
+        main = _named_branch(branches, branch)
+        if main is None:
+            return _item(
+                'main-branch',
+                'Main branch',
+                'pass',
+                f'SonarQube has no {branch!r} branch for {key!r}; '
+                f'{_tracked_phrase(branches)}.',
+            )
+        if main.get('isMain') is True:
+            return _item(
+                'main-branch',
+                'Main branch',
+                'pass',
+                f'SonarQube tracks {branch!r} as the main branch.',
+            )
+        return _item(
+            'main-branch',
+            'Main branch',
+            'fail',
+            f'SonarQube does not track {branch!r} as the main branch of '
+            f'{key!r} -- {_tracked_phrase(branches)}, so the measures synced '
+            'from this project are those of an abandoned branch. Use the Fix '
+            f'action to make {branch!r} the main branch.',
+            _set_main_branch_offer(branch),
+        )
 
     def _analyze_existing_edge(
         self,
@@ -343,48 +513,38 @@ class SonarQubeDoctor(AnalysisCapability):
         credentials: dict[str, str],
         remediation_id: str,
     ) -> RemediationResult:
-        """Search for the component, create it if missing, and link it.
+        """Apply one of this capability's three repairs.
 
-        Only the destructive ``_REPAIR_EDGE`` offer may create; the
-        non-destructive ``_RECONCILE_EDGE`` offer fails if the component has
-        vanished since ``analyze`` rather than silently creating one.
+        ``_SET_MAIN_BRANCH`` points SonarQube's main branch at the expected
+        branch and touches no Imbi state; the other two reconcile the
+        ``EXISTS_IN``
+        edge by searching for the component and, for ``_REPAIR_EDGE`` only,
+        creating it when it is missing. The non-destructive
+        ``_RECONCILE_EDGE`` offer fails if the component has vanished since
+        ``analyze`` rather than silently creating one.
 
         Idempotent: returns ``noop`` when the edge already matches a live
         component. The component key is the existing edge identifier or the
         ``<team>:<project>`` default, and is written verbatim to
         ``EXISTS_IN.identifier`` so the gateway's webhook match resolves.
         """
-        if remediation_id not in (_REPAIR_EDGE, _RECONCILE_EDGE):
+        if remediation_id not in (
+            _REPAIR_EDGE,
+            _RECONCILE_EDGE,
+            _SET_MAIN_BRANCH,
+        ):
             return await super().remediate(ctx, credentials, remediation_id)
+        try:
+            base_url, api_token, key, connection = _remediation_target(
+                ctx, credentials
+            )
+        except _Unconfigured as exc:
+            return RemediationResult(status='failed', message=str(exc))
+        if remediation_id == _SET_MAIN_BRANCH:
+            return await self._set_main_branch(
+                base_url, api_token, key, _main_branch(ctx)
+            )
         allow_create = remediation_id == _REPAIR_EDGE
-        slug = ctx.integration_slug
-        if slug is None:
-            return RemediationResult(
-                status='failed',
-                message='Capability is not bound to an Integration.',
-            )
-        base_url = _service_url(ctx)
-        if not base_url:
-            return RemediationResult(
-                status='failed',
-                message='The Integration has no service_url configured.',
-            )
-        api_token = credentials.get('api_token')
-        if not api_token:
-            return RemediationResult(
-                status='failed',
-                message='No api_token credential configured.',
-            )
-        connection = _find_connection(ctx, slug)
-        key = _component_key(ctx, connection)
-        if key is None:
-            return RemediationResult(
-                status='failed',
-                message=(
-                    'Cannot derive the SonarQube component key: no EXISTS_IN '
-                    'edge and no owning team.'
-                ),
-            )
 
         try:
             component = await client.search_project(
@@ -441,4 +601,54 @@ class SonarQubeDoctor(AnalysisCapability):
         return RemediationResult(
             status='fixed',
             message=f'{verb} SonarQube component {key!r}.',
+        )
+
+    async def _set_main_branch(
+        self, base_url: str, api_token: str, key: str, branch: str
+    ) -> RemediationResult:
+        """Make ``branch`` the main branch of the SonarQube component.
+
+        Re-reads the branch list rather than trusting the report: if the
+        main branch has moved since, this is a ``noop`` instead of a
+        redundant write, and if ``branch`` has vanished it fails rather
+        than asking SonarQube to track a branch it does not have.
+        """
+        try:
+            branches = await client.list_branches(
+                base_url=base_url, api_token=api_token, key=key
+            )
+            main = _named_branch(branches, branch)
+            if main is None:
+                return RemediationResult(
+                    status='failed',
+                    message=(
+                        f'SonarQube component {key!r} has no {branch!r} '
+                        'branch to track.'
+                    ),
+                )
+            if main.get('isMain') is True:
+                return RemediationResult(
+                    status='noop',
+                    message=(
+                        f'SonarQube already tracks {branch!r} as the main '
+                        f'branch of {key!r}.'
+                    ),
+                )
+            await client.set_main_branch(
+                base_url=base_url,
+                api_token=api_token,
+                key=key,
+                branch=branch,
+            )
+        except client.SonarqubeClientError as exc:
+            return RemediationResult(
+                status='failed',
+                message=f'SonarQube request failed: {exc}',
+            )
+        return RemediationResult(
+            status='fixed',
+            message=(
+                f'SonarQube now tracks {branch!r} as the main branch of '
+                f'{key!r}.'
+            ),
         )

--- a/plugins/sonarqube/src/imbi/plugins/sonarqube/doctor.py
+++ b/plugins/sonarqube/src/imbi/plugins/sonarqube/doctor.py
@@ -14,7 +14,9 @@ analysis that stopped running. The repair points the main branch at the
 expected one, which is the ``main_branch`` capability option (default
 ``main``): set on the Integration for the org-wide convention and
 overridden per project-type / project by the ``USES`` edge, for the
-repository whose trunk is named something else.
+repository whose trunk is named something else. A component that has no
+such branch at all is a separate, unrepairable finding — there is nothing
+to switch to until an analysis runs on that branch.
 
 The component key convention is ``<owning-team-slug>:<project-slug>``.
 An existing edge's identifier wins over the derived default so a
@@ -62,6 +64,17 @@ _SET_MAIN_BRANCH = 'set-main-branch'
 #: SonarQube's dashboard link uses the integration slug as its key (unlike
 #: GitHub's bespoke ``github-repository`` key).
 _LINK_KEY = 'sonarqube'
+
+#: Finding slug for "the expected branch is not the one SonarQube tracks",
+#: which ``_SET_MAIN_BRANCH`` fixes.
+_MAIN_BRANCH_SLUG = 'main-branch'
+
+#: Finding slug for "SonarQube has no such branch". Deliberately separate
+#: from :data:`_MAIN_BRANCH_SLUG`: it carries no remediation because no
+#: SonarQube call can conjure the branch, and keeping the two apart lets
+#: an operator sweeping the fleet tell "one click away" from "needs a CI
+#: run" without reading every description.
+_MAIN_BRANCH_MISSING_SLUG = 'main-branch-missing'
 
 #: Capability option naming the branch SonarQube is expected to track. It
 #: is capability- rather than integration-scoped so the host's option
@@ -364,11 +377,15 @@ class SonarQubeDoctor(AnalysisCapability):
     ) -> AnalysisResultItem:
         """Check that SonarQube tracks ``branch`` as the main branch.
 
-        A repository that migrated from ``master`` to ``main`` keeps the
-        abandoned branch flagged ``isMain`` in SonarQube, which goes on
-        reporting the analysis it last ran. Only a component that *has*
-        ``branch`` can be repaired, so one that never adopted it (still on
-        ``master``) passes rather than nagging.
+        Two distinct defects, reported under their own slugs because they
+        need different work: a repository that migrated from ``master`` to
+        ``main`` keeps the abandoned branch flagged ``isMain``, which is
+        one ``set_main`` call away from correct
+        (:data:`_MAIN_BRANCH_SLUG`); a component that has no ``branch`` at
+        all cannot be switched to it at any price
+        (:data:`_MAIN_BRANCH_MISSING_SLUG`) — SonarQube only records a
+        branch once an analysis runs on it, so that one is CI's to fix, or
+        the operator's if ``main_branch`` names the wrong branch.
         """
         try:
             branches = await client.list_branches(
@@ -376,7 +393,7 @@ class SonarQubeDoctor(AnalysisCapability):
             )
         except client.SonarqubeClientError as exc:
             return _item(
-                'main-branch',
+                _MAIN_BRANCH_SLUG,
                 'Main branch',
                 'warn',
                 f'Could not list the branches of component {key!r}: '
@@ -385,21 +402,25 @@ class SonarQubeDoctor(AnalysisCapability):
         main = _named_branch(branches, branch)
         if main is None:
             return _item(
-                'main-branch',
+                _MAIN_BRANCH_MISSING_SLUG,
                 'Main branch',
-                'pass',
-                f'SonarQube has no {branch!r} branch for {key!r}; '
-                f'{_tracked_phrase(branches)}.',
+                'fail',
+                f'SonarQube has no {branch!r} branch for {key!r} -- '
+                f'{_tracked_phrase(branches)}. There is no branch to switch '
+                'to: SonarQube only records a branch once an analysis runs '
+                f'on it, so CI has to analyze {branch!r} -- or, if this '
+                'project deliberately uses another branch, name it in the '
+                f'{MAIN_BRANCH_OPTION} option.',
             )
         if main.get('isMain') is True:
             return _item(
-                'main-branch',
+                _MAIN_BRANCH_SLUG,
                 'Main branch',
                 'pass',
                 f'SonarQube tracks {branch!r} as the main branch.',
             )
         return _item(
-            'main-branch',
+            _MAIN_BRANCH_SLUG,
             'Main branch',
             'fail',
             f'SonarQube does not track {branch!r} as the main branch of '

--- a/plugins/sonarqube/src/imbi/plugins/sonarqube/plugin.py
+++ b/plugins/sonarqube/src/imbi/plugins/sonarqube/plugin.py
@@ -11,7 +11,11 @@ SonarQube component binding.
 import logging
 
 from imbi.common import plugins
-from imbi.plugins.sonarqube.doctor import SonarQubeDoctor
+from imbi.plugins.sonarqube.doctor import (
+    DEFAULT_MAIN_BRANCH,
+    MAIN_BRANCH_OPTION,
+    SonarQubeDoctor,
+)
 
 LOGGER = logging.getLogger(__name__)
 
@@ -89,7 +93,8 @@ class SonarQubePlugin(plugins.Plugin):
                         'permissions the issuing account holds. The token '
                         'needs Browse on the projects being read, plus '
                         'Create Projects if the Project Doctor should create '
-                        'missing SonarQube projects.'
+                        'missing SonarQube projects and Administer on a '
+                        'project whose main branch it should switch.'
                     ),
                 }
             ],
@@ -107,9 +112,30 @@ class SonarQubePlugin(plugins.Plugin):
                     'label': 'Project doctor',
                     'description': (
                         'Validate the SonarQube project component '
-                        '(EXISTS_IN edge) against the live API and offer a '
-                        'one-click search-and-create repair.'
+                        '(EXISTS_IN edge) and the branch SonarQube tracks as '
+                        'its main branch against the live API, and offer '
+                        'one-click repairs for both.'
                     ),
+                    'options': [
+                        {
+                            'name': MAIN_BRANCH_OPTION,
+                            'label': 'Expected main branch',
+                            'description': (
+                                'Branch SonarQube should track as a '
+                                "project's main branch -- the one whose "
+                                'analysis it reports as the project state. '
+                                'The doctor fails, and offers to switch, '
+                                'when this branch exists in SonarQube but '
+                                'is not the main one; a project without it '
+                                'is left alone. Override it on a project '
+                                'type or project whose trunk is named '
+                                'something else.'
+                            ),
+                            'type': 'string',
+                            'required': False,
+                            'default': DEFAULT_MAIN_BRANCH,
+                        }
+                    ],
                     'handler': SonarQubeDoctor,
                 },
             ],

--- a/plugins/sonarqube/tests/test_client.py
+++ b/plugins/sonarqube/tests/test_client.py
@@ -254,3 +254,129 @@ class CreateProjectTests(unittest.IsolatedAsyncioTestCase):
                 key='team:demo',
                 name='demo',
             )
+
+
+class ListBranchesTests(unittest.IsolatedAsyncioTestCase):
+    url = 'https://sonarqube.example.com/api/project_branches/list'
+
+    @respx.mock
+    async def test_returns_branches(self) -> None:
+        route = respx.get(self.url).mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    'branches': [
+                        {'name': 'master', 'isMain': True},
+                        {'name': 'main', 'isMain': False},
+                    ]
+                },
+            )
+        )
+        result = await client.list_branches(
+            base_url='https://sonarqube.example.com/',
+            api_token='t',
+            key='team:demo',
+        )
+        self.assertEqual(['master', 'main'], [b['name'] for b in result])
+        self.assertEqual(
+            'team:demo', route.calls.last.request.url.params.get('project')
+        )
+
+    @respx.mock
+    async def test_missing_branches_returns_empty(self) -> None:
+        respx.get(self.url).mock(return_value=httpx.Response(200, json={}))
+        result = await client.list_branches(
+            base_url='https://sonarqube.example.com',
+            api_token='t',
+            key='team:demo',
+        )
+        self.assertEqual([], result)
+
+    @respx.mock
+    async def test_non_dict_entries_are_dropped(self) -> None:
+        respx.get(self.url).mock(
+            return_value=httpx.Response(
+                200, json={'branches': ['nope', {'name': 'main'}]}
+            )
+        )
+        result = await client.list_branches(
+            base_url='https://sonarqube.example.com',
+            api_token='t',
+            key='team:demo',
+        )
+        self.assertEqual([{'name': 'main'}], result)
+
+    @respx.mock
+    async def test_non_2xx_raises(self) -> None:
+        respx.get(self.url).mock(
+            return_value=httpx.Response(403, text='forbidden')
+        )
+        with pytest.raises(client.SonarqubeClientError):
+            await client.list_branches(
+                base_url='https://sonarqube.example.com',
+                api_token='t',
+                key='team:demo',
+            )
+
+    @respx.mock
+    async def test_transport_error_raises(self) -> None:
+        respx.get(self.url).mock(side_effect=httpx.ConnectError('refused'))
+        with pytest.raises(client.SonarqubeClientError):
+            await client.list_branches(
+                base_url='https://sonarqube.example.com',
+                api_token='t',
+                key='team:demo',
+            )
+
+    @respx.mock
+    async def test_non_json_raises(self) -> None:
+        respx.get(self.url).mock(
+            return_value=httpx.Response(200, text='not-json')
+        )
+        with pytest.raises(client.SonarqubeClientError):
+            await client.list_branches(
+                base_url='https://sonarqube.example.com',
+                api_token='t',
+                key='team:demo',
+            )
+
+
+class SetMainBranchTests(unittest.IsolatedAsyncioTestCase):
+    url = 'https://sonarqube.example.com/api/project_branches/set_main'
+
+    @respx.mock
+    async def test_posts_project_and_branch(self) -> None:
+        route = respx.post(self.url).mock(return_value=httpx.Response(204))
+        await client.set_main_branch(
+            base_url='https://sonarqube.example.com/',
+            api_token='t',
+            key='team:demo',
+            branch='main',
+        )
+        params = route.calls.last.request.url.params
+        self.assertEqual('team:demo', params.get('project'))
+        self.assertEqual('main', params.get('branch'))
+
+    @respx.mock
+    async def test_non_2xx_raises(self) -> None:
+        respx.post(self.url).mock(
+            return_value=httpx.Response(400, text='unknown branch')
+        )
+        with pytest.raises(client.SonarqubeClientError):
+            await client.set_main_branch(
+                base_url='https://sonarqube.example.com',
+                api_token='t',
+                key='team:demo',
+                branch='main',
+            )
+
+    @respx.mock
+    async def test_transport_error_raises(self) -> None:
+        respx.post(self.url).mock(side_effect=httpx.ConnectError('refused'))
+        with pytest.raises(client.SonarqubeClientError):
+            await client.set_main_branch(
+                base_url='https://sonarqube.example.com',
+                api_token='t',
+                key='team:demo',
+                branch='main',
+            )

--- a/plugins/sonarqube/tests/test_doctor.py
+++ b/plugins/sonarqube/tests/test_doctor.py
@@ -242,7 +242,13 @@ class MainBranchAnalyzeTestCase(unittest.IsolatedAsyncioTestCase):
             capability_options=capability_options,
         )
         results = await SonarQubeDoctor().analyze(ctx, _CREDS)
-        return _by_slug(results).get('main-branch')
+        # The check reports under one of two slugs depending on what is
+        # wrong, and exactly one of them is ever emitted.
+        branch_findings = [
+            i for i in results if i.slug.startswith('main-branch')
+        ]
+        self.assertLessEqual(len(branch_findings), 1)
+        return branch_findings[0] if branch_findings else None
 
     @respx.mock
     async def test_stale_main_branch_offers_the_switch(self) -> None:
@@ -265,23 +271,39 @@ class MainBranchAnalyzeTestCase(unittest.IsolatedAsyncioTestCase):
         self.assertIsNone(finding.remediation)
 
     @respx.mock
-    async def test_project_without_a_main_branch_passes(self) -> None:
-        # Never migrated: there is no 'main' branch to switch to, so
-        # nagging about it would be noise.
+    async def test_project_without_the_branch_fails_unfixably(self) -> None:
+        # Never migrated. Reported apart from the switchable case and with
+        # no Fix button: no SonarQube call creates a branch.
         finding = await self._finding(_branch_list(('master', True)))
         assert finding is not None
-        self.assertEqual(finding.status, 'pass')
+        self.assertEqual(finding.slug, 'main-branch-missing')
+        self.assertEqual(finding.status, 'fail')
+        self.assertIsNone(finding.remediation)
         self.assertIn("no 'main' branch", finding.description)
         self.assertIn("'master'", finding.description)
+        # Both escapes are named: run CI on it, or fix the option.
+        self.assertIn('CI', finding.description)
+        self.assertIn(MAIN_BRANCH_OPTION, finding.description)
 
     @respx.mock
-    async def test_unanalyzed_project_passes(self) -> None:
+    async def test_unanalyzed_project_fails_unfixably(self) -> None:
         # A created-but-never-scanned component has no branches at all,
         # and the finding still has to read sensibly.
         finding = await self._finding(_branch_list())
         assert finding is not None
-        self.assertEqual(finding.status, 'pass')
+        self.assertEqual(finding.slug, 'main-branch-missing')
+        self.assertEqual(finding.status, 'fail')
         self.assertIn('no branch is flagged', finding.description)
+
+    @respx.mock
+    async def test_missing_configured_branch_names_it(self) -> None:
+        finding = await self._finding(
+            _branch_list(('main', True)), {MAIN_BRANCH_OPTION: 'trunk'}
+        )
+        assert finding is not None
+        self.assertEqual(finding.slug, 'main-branch-missing')
+        self.assertEqual(finding.status, 'fail')
+        self.assertIn("no 'trunk' branch", finding.description)
 
     @respx.mock
     async def test_branch_list_failure_degrades_to_warn(self) -> None:
@@ -304,7 +326,9 @@ class MainBranchAnalyzeTestCase(unittest.IsolatedAsyncioTestCase):
         respx.get(_SEARCH).mock(return_value=_components())
         branches = respx.get(_BRANCHES)
         results = await SonarQubeDoctor().analyze(_ctx(), _CREDS)
-        self.assertNotIn('main-branch', _by_slug(results))
+        self.assertEqual(
+            [], [i for i in results if i.slug.startswith('main-branch')]
+        )
         self.assertFalse(branches.called)
 
     @respx.mock

--- a/plugins/sonarqube/tests/test_doctor.py
+++ b/plugins/sonarqube/tests/test_doctor.py
@@ -14,6 +14,8 @@ from imbi.common.plugins.errors import PluginRemediationNotSupported
 from imbi.plugins.sonarqube.doctor import (
     _RECONCILE_EDGE,
     _REPAIR_EDGE,
+    _SET_MAIN_BRANCH,
+    MAIN_BRANCH_OPTION,
     SonarQubeDoctor,
 )
 
@@ -26,6 +28,8 @@ _DASHBOARD = f'{_URL}/dashboard?id=platform%3Ademo'
 _LINK_KEY = 'sonarqube'
 _SEARCH = f'{_URL}/api/projects/search'
 _CREATE = f'{_URL}/api/projects/create'
+_BRANCHES = f'{_URL}/api/project_branches/list'
+_SET_MAIN = f'{_URL}/api/project_branches/set_main'
 
 
 def _conn(
@@ -42,6 +46,7 @@ def _ctx(
     connections: list[ServiceConnection] | None = None,
     links: dict[str, str] | None = None,
     options: dict[str, object] | None = None,
+    capability_options: dict[str, object] | None = None,
     team_slug: str | None = 'platform',
 ) -> PluginContext:
     return PluginContext(
@@ -53,6 +58,7 @@ def _ctx(
         integration_options=options
         if options is not None
         else {'service_url': _URL},
+        capability_options=capability_options or {},
         service_connections=connections or [],
         project_links=links or {},
     )
@@ -68,6 +74,27 @@ def _components(*keys: str) -> httpx.Response:
     return httpx.Response(
         200, json={'components': [{'key': k, 'name': k} for k in keys]}
     )
+
+
+def _branch_list(*branches: tuple[str, bool]) -> httpx.Response:
+    """Build a ``project_branches/list`` payload from (name, isMain) pairs."""
+    return httpx.Response(
+        200,
+        json={
+            'branches': [
+                {'name': name, 'isMain': is_main, 'type': 'BRANCH'}
+                for name, is_main in branches
+            ]
+        },
+    )
+
+
+#: The healthy shape: SonarQube tracks ``main``.
+_MAIN_TRACKED = (('main', True),)
+
+#: The shape this doctor exists for: a project migrated off ``master`` whose
+#: abandoned branch is still the one SonarQube reports on.
+_MAIN_STALE = (('master', True), ('main', False))
 
 
 class AnalyzeTestCase(unittest.IsolatedAsyncioTestCase):
@@ -140,12 +167,15 @@ class AnalyzeTestCase(unittest.IsolatedAsyncioTestCase):
     @respx.mock
     async def test_edge_present_all_pass(self) -> None:
         respx.get(_SEARCH).mock(return_value=_components(_KEY))
+        respx.get(_BRANCHES).mock(return_value=_branch_list(*_MAIN_TRACKED))
         ctx = _ctx(connections=[_conn()], links={_LINK_KEY: _DASHBOARD})
         results = await SonarQubeDoctor().analyze(ctx, _CREDS)
         by_slug = _by_slug(results)
         self.assertEqual(by_slug['component'].status, 'pass')
         self.assertEqual(by_slug['canonical-url'].status, 'pass')
         self.assertEqual(by_slug['dashboard-link'].status, 'pass')
+        self.assertEqual(by_slug['main-branch'].status, 'pass')
+        self.assertIsNone(by_slug['main-branch'].remediation)
 
     @respx.mock
     async def test_edge_present_component_missing_offers_create(self) -> None:
@@ -160,6 +190,7 @@ class AnalyzeTestCase(unittest.IsolatedAsyncioTestCase):
     @respx.mock
     async def test_edge_present_canonical_and_link_drift(self) -> None:
         respx.get(_SEARCH).mock(return_value=_components(_KEY))
+        respx.get(_BRANCHES).mock(return_value=_branch_list(*_MAIN_TRACKED))
         ctx = _ctx(
             connections=[_conn(canonical='https://old/url')],
             links={_LINK_KEY: 'https://old/dash'},
@@ -172,6 +203,7 @@ class AnalyzeTestCase(unittest.IsolatedAsyncioTestCase):
     @respx.mock
     async def test_no_edge_component_found(self) -> None:
         respx.get(_SEARCH).mock(return_value=_components(_KEY))
+        respx.get(_BRANCHES).mock(return_value=_branch_list(*_MAIN_TRACKED))
         results = await SonarQubeDoctor().analyze(_ctx(), _CREDS)
         finding = _by_slug(results)['exists-in']
         self.assertEqual(finding.status, 'warn')
@@ -192,6 +224,123 @@ class AnalyzeTestCase(unittest.IsolatedAsyncioTestCase):
         respx.get(_SEARCH).mock(return_value=httpx.Response(401, text='no'))
         results = await SonarQubeDoctor().analyze(_ctx(), _CREDS)
         self.assertEqual(_by_slug(results)['component'].status, 'warn')
+
+
+class MainBranchAnalyzeTestCase(unittest.IsolatedAsyncioTestCase):
+    """The branch SonarQube reports the project's state from."""
+
+    async def _finding(
+        self,
+        branches: httpx.Response,
+        capability_options: dict[str, object] | None = None,
+    ) -> AnalysisResultItem | None:
+        respx.get(_SEARCH).mock(return_value=_components(_KEY))
+        respx.get(_BRANCHES).mock(return_value=branches)
+        ctx = _ctx(
+            connections=[_conn()],
+            links={_LINK_KEY: _DASHBOARD},
+            capability_options=capability_options,
+        )
+        results = await SonarQubeDoctor().analyze(ctx, _CREDS)
+        return _by_slug(results).get('main-branch')
+
+    @respx.mock
+    async def test_stale_main_branch_offers_the_switch(self) -> None:
+        finding = await self._finding(_branch_list(*_MAIN_STALE))
+        assert finding is not None
+        self.assertEqual(finding.status, 'fail')
+        # The operator needs to know which branch is being abandoned.
+        self.assertIn("'master'", finding.description)
+        assert finding.remediation is not None
+        self.assertEqual(finding.remediation.id, _SET_MAIN_BRANCH)
+        self.assertTrue(finding.remediation.destructive)
+
+    @respx.mock
+    async def test_main_branch_tracked_passes(self) -> None:
+        finding = await self._finding(
+            _branch_list(('main', True), ('master', False))
+        )
+        assert finding is not None
+        self.assertEqual(finding.status, 'pass')
+        self.assertIsNone(finding.remediation)
+
+    @respx.mock
+    async def test_project_without_a_main_branch_passes(self) -> None:
+        # Never migrated: there is no 'main' branch to switch to, so
+        # nagging about it would be noise.
+        finding = await self._finding(_branch_list(('master', True)))
+        assert finding is not None
+        self.assertEqual(finding.status, 'pass')
+        self.assertIn("no 'main' branch", finding.description)
+        self.assertIn("'master'", finding.description)
+
+    @respx.mock
+    async def test_unanalyzed_project_passes(self) -> None:
+        # A created-but-never-scanned component has no branches at all,
+        # and the finding still has to read sensibly.
+        finding = await self._finding(_branch_list())
+        assert finding is not None
+        self.assertEqual(finding.status, 'pass')
+        self.assertIn('no branch is flagged', finding.description)
+
+    @respx.mock
+    async def test_branch_list_failure_degrades_to_warn(self) -> None:
+        finding = await self._finding(httpx.Response(403))
+        assert finding is not None
+        self.assertEqual(finding.status, 'warn')
+        self.assertIn('status 403', finding.description)
+
+    @respx.mock
+    async def test_checked_without_an_exists_in_edge(self) -> None:
+        # A stale main branch reports stale measures whether or not Imbi
+        # has linked the component yet.
+        respx.get(_SEARCH).mock(return_value=_components(_KEY))
+        respx.get(_BRANCHES).mock(return_value=_branch_list(*_MAIN_STALE))
+        results = await SonarQubeDoctor().analyze(_ctx(), _CREDS)
+        self.assertEqual(_by_slug(results)['main-branch'].status, 'fail')
+
+    @respx.mock
+    async def test_skipped_when_component_is_missing(self) -> None:
+        respx.get(_SEARCH).mock(return_value=_components())
+        branches = respx.get(_BRANCHES)
+        results = await SonarQubeDoctor().analyze(_ctx(), _CREDS)
+        self.assertNotIn('main-branch', _by_slug(results))
+        self.assertFalse(branches.called)
+
+    @respx.mock
+    async def test_configured_branch_replaces_the_default(self) -> None:
+        # A repository whose trunk is 'trunk' must be judged against it,
+        # not against 'main' -- which here is a stale side branch.
+        finding = await self._finding(
+            _branch_list(('main', True), ('trunk', False)),
+            {MAIN_BRANCH_OPTION: 'trunk'},
+        )
+        assert finding is not None
+        self.assertEqual(finding.status, 'fail')
+        assert finding.remediation is not None
+        self.assertIn("'trunk'", finding.remediation.label)
+        assert finding.remediation.confirm is not None
+        self.assertIn("'trunk'", finding.remediation.confirm)
+
+    @respx.mock
+    async def test_configured_branch_tracked_passes(self) -> None:
+        finding = await self._finding(
+            _branch_list(('trunk', True), ('main', False)),
+            {MAIN_BRANCH_OPTION: 'trunk'},
+        )
+        assert finding is not None
+        self.assertEqual(finding.status, 'pass')
+
+    @respx.mock
+    async def test_blank_option_falls_back_to_the_default(self) -> None:
+        # An option cleared in the admin UI arrives as '' rather than
+        # absent, and must not turn into a search for a branch named ''.
+        finding = await self._finding(
+            _branch_list(*_MAIN_STALE), {MAIN_BRANCH_OPTION: '   '}
+        )
+        assert finding is not None
+        self.assertEqual(finding.status, 'fail')
+        self.assertIn("'main'", finding.description)
 
 
 class RemediateTestCase(unittest.IsolatedAsyncioTestCase):
@@ -288,3 +437,78 @@ class RemediateTestCase(unittest.IsolatedAsyncioTestCase):
             _ctx(), _CREDS, _REPAIR_EDGE
         )
         self.assertEqual(result.status, 'failed')
+
+
+class SetMainBranchTestCase(unittest.IsolatedAsyncioTestCase):
+    async def test_no_token_failed(self) -> None:
+        result = await SonarQubeDoctor().remediate(
+            _ctx(), {}, _SET_MAIN_BRANCH
+        )
+        self.assertEqual(result.status, 'failed')
+
+    @respx.mock
+    async def test_stale_main_branch_is_switched(self) -> None:
+        respx.get(_BRANCHES).mock(return_value=_branch_list(*_MAIN_STALE))
+        set_main = respx.post(_SET_MAIN).mock(return_value=httpx.Response(204))
+        ctx = _ctx(connections=[_conn()])
+        result = await SonarQubeDoctor().remediate(
+            ctx, _CREDS, _SET_MAIN_BRANCH
+        )
+        self.assertEqual(result.status, 'fixed')
+        self.assertTrue(set_main.called)
+        request = set_main.calls.last.request
+        self.assertEqual(request.url.params['project'], _KEY)
+        self.assertEqual(request.url.params['branch'], 'main')
+        # This repair lives entirely in SonarQube -- no Imbi state moves.
+        self.assertIsNone(ctx.service_writeback)
+
+    @respx.mock
+    async def test_already_tracked_is_noop(self) -> None:
+        # The report may be stale by the time Fix is clicked; re-reading
+        # keeps a redundant write off the wire.
+        respx.get(_BRANCHES).mock(return_value=_branch_list(*_MAIN_TRACKED))
+        set_main = respx.post(_SET_MAIN)
+        result = await SonarQubeDoctor().remediate(
+            _ctx(connections=[_conn()]), _CREDS, _SET_MAIN_BRANCH
+        )
+        self.assertEqual(result.status, 'noop')
+        self.assertFalse(set_main.called)
+
+    @respx.mock
+    async def test_vanished_main_branch_fails(self) -> None:
+        respx.get(_BRANCHES).mock(return_value=_branch_list(('master', True)))
+        set_main = respx.post(_SET_MAIN)
+        result = await SonarQubeDoctor().remediate(
+            _ctx(connections=[_conn()]), _CREDS, _SET_MAIN_BRANCH
+        )
+        self.assertEqual(result.status, 'failed')
+        self.assertFalse(set_main.called)
+
+    @respx.mock
+    async def test_configured_branch_is_the_one_posted(self) -> None:
+        respx.get(_BRANCHES).mock(
+            return_value=_branch_list(('main', True), ('trunk', False))
+        )
+        set_main = respx.post(_SET_MAIN).mock(return_value=httpx.Response(204))
+        result = await SonarQubeDoctor().remediate(
+            _ctx(
+                connections=[_conn()],
+                capability_options={MAIN_BRANCH_OPTION: 'trunk'},
+            ),
+            _CREDS,
+            _SET_MAIN_BRANCH,
+        )
+        self.assertEqual(result.status, 'fixed')
+        self.assertEqual(
+            set_main.calls.last.request.url.params['branch'], 'trunk'
+        )
+
+    @respx.mock
+    async def test_rejected_write_failed(self) -> None:
+        respx.get(_BRANCHES).mock(return_value=_branch_list(*_MAIN_STALE))
+        respx.post(_SET_MAIN).mock(return_value=httpx.Response(403))
+        result = await SonarQubeDoctor().remediate(
+            _ctx(connections=[_conn()]), _CREDS, _SET_MAIN_BRANCH
+        )
+        self.assertEqual(result.status, 'failed')
+        self.assertIn('status 403', result.message)


### PR DESCRIPTION
## Summary

Adds two Project Doctor findings and one one-click repair to the SonarQube
plugin, covering the branch SonarQube tracks as a project's main branch.

## Problem

SonarQube reports a project's state from the single branch flagged `isMain`.
We migrated from `master` to `main` about a year ago, but many projects still
have `master` tracked, so the measures Imbi syncs (`coverage`, `ncloc`, …) come
from an analysis that stopped running when the default branch moved. Nothing
surfaced this — the project looked healthy in Imbi while its numbers were
frozen.

`cp:geoip` is in this state today: `master` is `isMain` with an analysis from
2025-04-30, while `main` has been analyzed continuously since.

## Solution

Two client calls wrapping `/api/project_branches/list` and
`/api/project_branches/set_main`, and two findings:

- **`main-branch`** — the expected branch exists but is not the main one.
  Fails, and offers a destructive one-click fix that `POST`s `set_main`. The
  fix re-reads the branch list first, so a main branch that has since moved is
  a `noop` rather than a redundant write, and one that has vanished fails
  instead of asking SonarQube to track a branch it does not have.
- **`main-branch-missing`** — SonarQube has no such branch at all. Fails with
  **no** fix offered, because no API call creates a branch: SonarQube only
  records one once an analysis has run on it. Kept under its own slug so a
  fleet-wide sweep separates "one click away" from "needs a CI run", and so
  remediate-all only touches the fixable population.

The check runs whenever the component resolves, with or without an `EXISTS_IN`
edge — stale measures do not depend on the Imbi link.

The expected branch is the `analysis` capability's `main_branch` option,
defaulting to `main`. Because the host layers capability options (Integration <
project-type `USES` edge < project `USES` edge), the org-wide convention is set
once on the Integration while a single repo whose trunk is named something else
can override it.

## Impact

- **Scoring** — findings feed the `analysis_result` category, so projects that
  never migrated off `master` now fail `main-branch-missing` and lose score the
  first time the doctor runs. That is intentional (their SonarQube data is
  permanently stale) but it lands fleet-wide at once. Softening it to `warn` is
  a one-word change if we would rather stage it.
- **Permissions** — `set_main` needs **Administer** on the SonarQube project,
  beyond the Browse / Create Projects the token needed before. The `api_token`
  account may need widening before the fix works; the credential description
  and README now say so.
- **Remediate-all** — `remediate_all_for_project` applies every fixable
  finding including destructive ones, so a single sweep switches main branches
  for every affected project. Probably what we want given how many are
  affected, but worth knowing before running it.
- No API or UI changes: capability options already render generically in the
  Integration admin form.

## Testing

- `moon run sonarqube:lint sonarqube:typecheck sonarqube:test` — 83 pass,
  `doctor.py` at 99% coverage
- New unit tests cover both findings, the configurable branch name (including a
  blank option falling back to `main`), the `noop` / vanished-branch /
  rejected-write remediation paths, and that the check is skipped entirely when
  the component does not exist
- Rendered both findings against the real `cp:geoip` payload and the two
  missing-branch shapes to confirm the descriptions read correctly
- No writes were made against production SonarQube — `set_main` has not been
  called for `cp:geoip`
