### PR TITLE
Key identity connections by integration, not plugin

### DIFF
--- a/ui/src/components/Dashboard.tsx
+++ b/ui/src/components/Dashboard.tsx
@@ -27,14 +27,13 @@ import {
   getOrgPullRequests,
   getProjects,
 } from '@/api/endpoints'
-import { pluginIsIdentity } from '@/components/plugin-packages'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Sk } from '@/components/ui/skeleton'
 import { useOrganization } from '@/contexts/OrganizationContext'
 import { useConnectableIdentities } from '@/hooks/useConnectableIdentities'
 import { useRecentDeployments } from '@/hooks/useRecentDeployments'
-import type { IdentityConnectionResponse } from '@/types'
+import type { IdentityConnectionResponse, PluginPackage } from '@/types'
 
 import { MyPullRequestCountsWidget } from './dashboard/widgets/MyPullRequestCountsWidget'
 import { MyPullRequestsWidget } from './dashboard/widgets/MyPullRequestsWidget'
@@ -59,8 +58,9 @@ interface ViewChangeEvent {
 }
 
 const WIDGET_STORAGE_KEY = 'imbi-dashboard-widgets-v4'
-// Plugin slugs whose "connect your account" tile the actor has dismissed.
-const DISMISSED_INTEGRATIONS_KEY = 'imbi-dashboard-dismissed-integrations-v1'
+// Integration ids whose "connect your account" tile the actor has dismissed.
+// v2 because v1 stored plugin slugs, which no longer match anything.
+const DISMISSED_INTEGRATIONS_KEY = 'imbi-dashboard-dismissed-integrations-v2'
 
 type WidgetId =
   | 'my-pull-request-counts'
@@ -202,6 +202,15 @@ interface SortableWidgetProps {
   id: string
 }
 
+// A connectable identity integration the actor hasn't linked yet, with its id
+// already narrowed — id-less legacy integrations can't start a connect flow.
+interface UnconnectedIdentity {
+  icon: null | string | undefined
+  id: string
+  label: string
+  plugin: PluginPackage
+}
+
 // fallow-ignore-next-line complexity
 export function Dashboard({
   onProjectSelect,
@@ -213,15 +222,14 @@ export function Dashboard({
   const orgSlug = selectedOrganization?.slug || ''
   const [showWidgetSelector, setShowWidgetSelector] = useState(false)
 
-  // Identity plugins the actor hasn't connected yet drive the
+  // Identity integrations the actor hasn't connected yet drive the
   // dashboard's "unconnected integration" widgets.  They disappear
   // automatically once the connection becomes active, and the actor can
-  // dismiss one early (persisted by plugin slug in localStorage).
+  // dismiss one early (persisted by integration id in localStorage).
   const [dismissedIntegrations, setDismissedIntegrations] = useState<string[]>(
     loadDismissedIntegrations,
   )
-  const { connectableSlugs, integrationsQuery, pluginsQuery } =
-    useConnectableIdentities(orgSlug)
+  const { connectable } = useConnectableIdentities(orgSlug)
   const identitiesQuery = useQuery<IdentityConnectionResponse[]>({
     queryFn: ({ signal }) => getMyIdentities(signal),
     queryKey: ['me-identities'],
@@ -231,30 +239,30 @@ export function Dashboard({
     staleTime: 5 * 60 * 1000,
   })
 
-  // Connections key off the integration id; map back to the plugin slug so
-  // an active connection hides that plugin's "connect" tile.
-  const pluginByIntegrationId = new Map<string, string>()
-  for (const i of integrationsQuery.data ?? []) {
-    if (i.id) pluginByIntegrationId.set(i.id, i.plugin)
-  }
-  // Slugs already connected (active) or dismissed by the actor — either
-  // way, don't prompt to connect them.
-  const hiddenSlugs = new Set<string>(dismissedIntegrations)
+  // Integration ids already connected (active) or dismissed by the actor —
+  // either way, don't prompt to connect them.  Both connections and
+  // dismissals key off the integration id, so connecting one integration
+  // leaves the tiles for a sibling integration of the same plugin (e.g. a
+  // second GitHub host) in place.
+  const hiddenIntegrationIds = new Set<string>(dismissedIntegrations)
   for (const c of identitiesQuery.data ?? []) {
-    if (c.status !== 'active') continue
-    const slug = pluginByIntegrationId.get(c.integration_id)
-    if (slug) hiddenSlugs.add(slug)
+    if (c.status === 'active') hiddenIntegrationIds.add(c.integration_id)
   }
-  // Only offer to connect identity plugins that actually have a configured
-  // integration in this org — a login provider (org-less) or a merely
-  // installed-but-unconfigured plugin isn't something the actor connects to.
-  const unconnectedIdentityPlugins = (pluginsQuery.data ?? []).filter(
-    (p) =>
-      p.enabled &&
-      pluginIsIdentity(p) &&
-      connectableSlugs.has(p.slug) &&
-      !hiddenSlugs.has(p.slug),
-  )
+  // Only offer to connect integrations with a stable id — the connect flow
+  // targets it, so a legacy integration without one can't be started.  Built
+  // as a loop rather than a filter so `id` stays narrowed to a string for the
+  // tile's key, connect URL, and dismissal entry.
+  const unconnectedIdentities: UnconnectedIdentity[] = []
+  for (const { integration, plugin } of connectable) {
+    const id = integration.id
+    if (!id || hiddenIntegrationIds.has(id)) continue
+    unconnectedIdentities.push({
+      icon: integration.icon ?? plugin.icon,
+      id,
+      label: integration.name,
+      plugin,
+    })
+  }
 
   const [selectedWidgets, setSelectedWidgets] = useState<WidgetId[]>(() => {
     try {
@@ -466,19 +474,21 @@ export function Dashboard({
 
       {/* Unconnected-integration widgets — disappear automatically when
           the matching connection becomes active, or when dismissed. */}
-      {unconnectedIdentityPlugins.length > 0 && (
+      {unconnectedIdentities.length > 0 && (
         <div className="mb-4 grid grid-cols-1 gap-4 md:grid-cols-2">
-          {unconnectedIdentityPlugins.map((plugin) => (
+          {unconnectedIdentities.map(({ icon, id, label, plugin }) => (
             <UnconnectedIntegrationWidget
-              key={plugin.slug}
+              icon={icon}
+              key={id}
+              label={label}
               onConnect={() =>
                 navigate(
-                  `/settings/connections?connect=${encodeURIComponent(plugin.slug)}`,
+                  `/settings/connections?connect=${encodeURIComponent(id)}`,
                 )
               }
               onDismiss={() =>
                 setDismissedIntegrations((prev) =>
-                  prev.includes(plugin.slug) ? prev : [...prev, plugin.slug],
+                  prev.includes(id) ? prev : [...prev, id],
                 )
               }
               onManage={() => navigate('/settings/connections')}

--- a/ui/src/components/__tests__/plugin-packages.test.ts
+++ b/ui/src/components/__tests__/plugin-packages.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { identityIntegrationPluginSlugs } from '@/components/plugin-packages'
+import { identityIntegrations } from '@/components/plugin-packages'
 import type { Integration } from '@/types'
 
 const integration = (over: Partial<Integration>): Integration =>
@@ -17,28 +17,35 @@ const integration = (over: Partial<Integration>): Integration =>
     ...over,
   }) as unknown as Integration
 
-describe('identityIntegrationPluginSlugs', () => {
+describe('identityIntegrations', () => {
   it('includes only integrations with identity capability enabled', () => {
-    const slugs = identityIntegrationPluginSlugs([
+    const result = identityIntegrations([
       integration({
         capabilities: { identity: { enabled: true, options: {} } },
         plugin: 'github',
+        slug: 'github',
       }),
       // identity present but disabled — not connectable
       integration({
         capabilities: { identity: { enabled: false, options: {} } },
         plugin: 'aws',
+        slug: 'aws',
       }),
       // no identity capability at all
       integration({
         capabilities: { analysis: { enabled: true, options: {} } },
         plugin: 'sonarqube',
+        slug: 'sonarqube',
       }),
     ])
-    expect([...slugs]).toEqual(['github'])
+    expect(result.map((i) => i.slug)).toEqual(['github'])
   })
 
+  // The two-integrations-of-one-plugin regression is guarded on the hook that
+  // does the join (hooks/__tests__/useConnectableIdentities.test.tsx) — that's
+  // where the collapse-by-plugin-slug bug actually lived.
+
   it('is empty for no integrations', () => {
-    expect(identityIntegrationPluginSlugs([]).size).toBe(0)
+    expect(identityIntegrations([])).toEqual([])
   })
 })

--- a/ui/src/components/dashboard/widgets/UnconnectedIntegrationWidget.tsx
+++ b/ui/src/components/dashboard/widgets/UnconnectedIntegrationWidget.tsx
@@ -4,11 +4,19 @@ import logoDark from '@/assets/logo-dark.svg'
 import logoLight from '@/assets/logo-light.svg'
 import { pluginWidgetText } from '@/components/plugin-packages'
 import { Button } from '@/components/ui/button'
-import { EntityIcon } from '@/components/ui/entity-icon'
 import { useTheme } from '@/contexts/ThemeContext'
+import { useIcon } from '@/lib/icons'
 import type { PluginPackage } from '@/types'
 
 interface UnconnectedIntegrationWidgetProps {
+  // Provider glyph, already resolved by the caller from the integration then
+  // its plugin, so this tile and the connections table can't disagree.
+  icon: null | string | undefined
+  // Display name for the provider — the integration's name, which
+  // distinguishes two integrations of the same plugin.  Required so there is
+  // a single display-name rule rather than a plugin-name fallback that can
+  // drift from the one the connections table uses.
+  label: string
   onConnect: () => void
   // When provided, renders a dismiss control so the actor can hide this
   // tile.  Omit it for a non-dismissable widget.
@@ -23,6 +31,8 @@ interface UnconnectedIntegrationWidgetProps {
 // connection is active, and the actor can dismiss it early via the close
 // control (persisted by the caller).
 export function UnconnectedIntegrationWidget({
+  icon,
+  label,
   onConnect,
   onDismiss,
   onManage,
@@ -30,17 +40,18 @@ export function UnconnectedIntegrationWidget({
   plugin,
 }: UnconnectedIntegrationWidgetProps) {
   const { isDarkMode } = useTheme()
+  const Icon = useIcon(icon, Plug)
 
   const body =
     pluginWidgetText(plugin) ||
     plugin.description ||
-    `Imbi can act on your behalf in ${plugin.name} once you link your account.`
+    `Imbi can act on your behalf in ${label} once you link your account.`
 
   return (
     <article className="border-border bg-card relative grid min-h-60 grid-cols-1 overflow-hidden rounded-2xl border shadow-sm md:grid-cols-[1fr_160px] xl:grid-cols-[1fr_200px]">
       {onDismiss ? (
         <button
-          aria-label={`Dismiss ${plugin.name} connection prompt`}
+          aria-label={`Dismiss ${label} connection prompt`}
           className="text-tertiary hover:bg-secondary hover:text-secondary focus:ring-ring absolute top-3 right-3 z-10 rounded p-1.5 transition-colors focus:ring-2 focus:outline-none"
           onClick={onDismiss}
           type="button"
@@ -54,11 +65,11 @@ export function UnconnectedIntegrationWidget({
             <span className="bg-amber-border relative inline-block size-1.5 rounded-full">
               <span className="border-amber-border absolute -inset-0.75 animate-[imbi-pulse-ring_2s_ease-out_infinite] rounded-full border-[1.5px]" />
             </span>
-            {plugin.name} · Not connected
+            {label} · Not connected
           </span>
 
           <h3 className="text-primary mt-3.5 mb-1 text-[17px] font-semibold tracking-tight">
-            {plugin.name} isn&apos;t linked to your account
+            {label} isn&apos;t linked to your account
           </h3>
 
           <p className="text-secondary m-0 max-w-[38ch] text-[13px] leading-relaxed">
@@ -94,7 +105,7 @@ export function UnconnectedIntegrationWidget({
             onClick={onConnect}
           >
             <Plug className="size-3.5" />
-            Connect {plugin.name}
+            Connect {label}
           </Button>
           <Button
             className="text-secondary hover:text-primary h-auto gap-1 p-0 text-xs font-medium hover:no-underline"
@@ -127,11 +138,7 @@ export function UnconnectedIntegrationWidget({
               <i className="block size-1.25 animate-[imbi-bridge-travel_1.6s_ease-in-out_infinite] rounded-full bg-(--text-color-tertiary) [animation-delay:0.45s]" />
             </div>
             <div className="border-border bg-card text-primary grid size-11.5 place-items-center rounded-xl border opacity-50 shadow-sm grayscale-[0.4]">
-              {plugin.icon ? (
-                <EntityIcon className="size-[22px]" icon={plugin.icon} />
-              ) : (
-                <Plug className="size-[22px]" />
-              )}
+              <Icon className="size-[22px]" />
             </div>
           </div>
         </div>

--- a/ui/src/components/dashboard/widgets/__tests__/UnconnectedIntegrationWidget.test.tsx
+++ b/ui/src/components/dashboard/widgets/__tests__/UnconnectedIntegrationWidget.test.tsx
@@ -23,6 +23,8 @@ describe('UnconnectedIntegrationWidget', () => {
     const onDismiss = vi.fn()
     render(
       <UnconnectedIntegrationWidget
+        icon={null}
+        label="GitHub"
         onConnect={vi.fn()}
         onDismiss={onDismiss}
         onManage={vi.fn()}
@@ -42,6 +44,8 @@ describe('UnconnectedIntegrationWidget', () => {
   it('omits the dismiss control when onDismiss is not provided', () => {
     render(
       <UnconnectedIntegrationWidget
+        icon={null}
+        label="GitHub"
         onConnect={vi.fn()}
         onManage={vi.fn()}
         pending={false}

--- a/ui/src/components/plugin-packages.ts
+++ b/ui/src/components/plugin-packages.ts
@@ -4,21 +4,19 @@
 // them from `capabilities` instead of reading top-level flags.
 import type { Integration, PluginPackage } from '@/types'
 
-// Plugin slugs that have at least one configured integration with the
-// identity capability enabled — i.e. providers the actor can actually
-// connect a personal account to. Global login providers are org-less and
-// never appear in an org's integration list, so they're excluded; so are
-// identity plugins that are merely installed but not configured here.
-export function identityIntegrationPluginSlugs(
+// Configured integrations with the identity capability enabled — i.e. the
+// providers the actor can actually connect a personal account to. Global
+// login providers are org-less and never appear in an org's integration
+// list, so they're excluded; so are identity plugins that are merely
+// installed but not configured here.
+//
+// This returns integrations rather than plugin slugs because one plugin can
+// back several integrations (e.g. a `github` integration per GitHub host),
+// and each is connected independently.
+export function identityIntegrations(
   integrations: Integration[],
-): Set<string> {
-  const slugs = new Set<string>()
-  for (const integration of integrations) {
-    if (integration.capabilities?.identity?.enabled) {
-      slugs.add(integration.plugin)
-    }
-  }
-  return slugs
+): Integration[] {
+  return integrations.filter((i) => i.capabilities?.identity?.enabled)
 }
 
 // A plugin the actor can connect a personal account to (drives the

--- a/ui/src/components/settings/SettingsConnections.tsx
+++ b/ui/src/components/settings/SettingsConnections.tsx
@@ -12,12 +12,10 @@ import {
   refreshMyIdentity,
   startMyIdentity,
 } from '@/api/endpoints'
-import { pluginIsIdentity } from '@/components/plugin-packages'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent } from '@/components/ui/card'
 import { ConfirmDialog } from '@/components/ui/confirm-dialog'
-import { EntityIcon } from '@/components/ui/entity-icon'
 import { Sk } from '@/components/ui/skeleton'
 import {
   Table,
@@ -28,13 +26,14 @@ import {
   TableRow,
 } from '@/components/ui/table'
 import { useOrganization } from '@/contexts/OrganizationContext'
+import type { ConnectableIdentity } from '@/hooks/useConnectableIdentities'
 import { useConnectableIdentities } from '@/hooks/useConnectableIdentities'
 import { extractApiErrorDetail } from '@/lib/apiError'
+import { useIcon } from '@/lib/icons'
 import type {
   IdentityConnectionResponse,
   IdentityConnectionStatus,
   IdentityPollingDescriptor,
-  PluginPackage,
 } from '@/types'
 
 import { DeviceCodePollingDialog } from './DeviceCodePollingDialog'
@@ -48,14 +47,6 @@ interface ConnectionActionsProps {
   onDisconnect: () => void
   onRefresh: () => void
   pending: boolean
-}
-
-interface ConnectionRow {
-  connection: IdentityConnectionResponse | null
-  // The org integration backing this provider; null when the plugin has
-  // no configured (identity-enabled) integration the actor can connect to.
-  integrationId: null | string
-  plugin: PluginPackage
 }
 
 interface DevicePoll {
@@ -187,7 +178,7 @@ export function SettingsConnections() {
     return () => window.removeEventListener('message', handler)
   }, [queryClient])
 
-  const { connectableSlugs, integrationsQuery, pluginsQuery } =
+  const { connectable, integrationsQuery, pluginsQuery } =
     useConnectableIdentities(orgSlug)
 
   const connectionsQuery = useQuery<IdentityConnectionResponse[]>({
@@ -269,19 +260,25 @@ export function SettingsConnections() {
     },
   })
 
-  // Honor ``?connect=<slug>`` from the dashboard's
+  // Honor ``?connect=<integration id>`` from the dashboard's
   // UnconnectedIntegrationWidget — auto-kick off the connect flow on
-  // mount, then strip the param so a refresh doesn't re-trigger it.
+  // mount, then strip the param so a refresh doesn't re-trigger it. The
+  // param carries an integration id rather than a plugin slug because a
+  // plugin can back several integrations, each connected separately.
   const [searchParams, setSearchParams] = useSearchParams()
-  const autoConnectSlug = searchParams.get('connect')
+  const autoConnectId = searchParams.get('connect')
   const autoConnectFiredRef = useRef(false)
   // fallow-ignore-next-line complexity
   useEffect(() => {
-    if (!autoConnectSlug || autoConnectFiredRef.current) return
-    if (pluginsQuery.isLoading) return
-    const plugin = (pluginsQuery.data ?? []).find(
-      (p) => p.slug === autoConnectSlug && p.enabled,
-    )
+    if (!autoConnectId || autoConnectFiredRef.current) return
+    // The integrations query is disabled until an org is selected, and a
+    // disabled query reports ``isLoading === false`` — so wait on ``orgSlug``
+    // explicitly.  Without this the effect can fire before the organizations
+    // query resolves, find nothing in ``connectable``, and latch the ref
+    // (having already stripped the param) so the connect never happens.
+    if (!orgSlug || pluginsQuery.isLoading || integrationsQuery.isLoading) {
+      return
+    }
     autoConnectFiredRef.current = true
     setSearchParams(
       (prev) => {
@@ -291,23 +288,24 @@ export function SettingsConnections() {
       },
       { replace: true },
     )
-    if (!plugin) return
-    const integration = (integrationsQuery.data ?? []).find(
-      (i) => i.plugin === plugin.slug && i.capabilities?.identity?.enabled,
+    const match = connectable.find(
+      ({ integration }) => integration.id === autoConnectId,
     )
-    if (!integration?.id) {
-      toast.error(`No connectable ${plugin.name} integration is configured`)
+    if (!match) {
+      toast.error('That integration is no longer available to connect')
       return
     }
     pendingAuthWindowRef.current = window.open('', '_blank')
     startMutation.mutate({
-      integrationId: integration.id,
-      pluginLabel: plugin.name,
+      integrationId: autoConnectId,
+      pluginLabel: match.integration.name,
     })
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
-    autoConnectSlug,
+    autoConnectId,
+    orgSlug,
     pluginsQuery.isLoading,
+    integrationsQuery.isLoading,
     pluginsQuery.data,
     integrationsQuery.data,
   ])
@@ -342,15 +340,7 @@ export function SettingsConnections() {
     )
   }
 
-  // Only identity plugins that have a configured integration in this org
-  // are connectable — global login providers (org-less) and merely
-  // installed-but-unconfigured plugins are excluded (see
-  // useConnectableIdentities).
-  const identityPlugins = (pluginsQuery.data ?? []).filter(
-    (p) => p.enabled && pluginIsIdentity(p) && connectableSlugs.has(p.slug),
-  )
-
-  if (identityPlugins.length === 0) {
+  if (connectable.length === 0) {
     return (
       <Card>
         <CardContent className="py-12 text-center">
@@ -367,15 +357,10 @@ export function SettingsConnections() {
     )
   }
 
-  // The identity-enabled integration backing each plugin, keyed by plugin
-  // slug; the connect flow targets its id. Connections join to their
-  // integration by id.
-  const integrationByPluginSlug = new Map<string, string>()
-  for (const i of integrationsQuery.data ?? []) {
-    if (i.capabilities?.identity?.enabled && i.id) {
-      integrationByPluginSlug.set(i.plugin, i.id)
-    }
-  }
+  // One row per connectable integration — not per plugin. Connections and
+  // the connect flow both key off the integration id, so two integrations
+  // of the same plugin (e.g. github.com and a GHES/GHEC host) get their own
+  // row and their own connection state.
   const connectionsByIntegrationId = new Map<
     string,
     IdentityConnectionResponse
@@ -383,17 +368,6 @@ export function SettingsConnections() {
   for (const c of connectionsQuery.data ?? []) {
     connectionsByIntegrationId.set(c.integration_id, c)
   }
-
-  const rows: ConnectionRow[] = identityPlugins.map((plugin) => {
-    const integrationId = integrationByPluginSlug.get(plugin.slug) ?? null
-    return {
-      connection: integrationId
-        ? (connectionsByIntegrationId.get(integrationId) ?? null)
-        : null,
-      integrationId,
-      plugin,
-    }
-  })
 
   return (
     <div className="space-y-4">
@@ -421,13 +395,21 @@ export function SettingsConnections() {
             </TableHeader>
             <TableBody>
               {/* fallow-ignore-next-line complexity */}
-              {rows.map(({ connection, integrationId, plugin }) => {
+              {connectable.map(({ integration, plugin }) => {
+                // Legacy integrations predating stable node ids can't be the
+                // target of a connect flow — the row renders, disabled.
+                const integrationId = integration.id ?? null
+                const connection = integrationId
+                  ? (connectionsByIntegrationId.get(integrationId) ?? null)
+                  : null
                 const status: 'not_connected' | IdentityConnectionStatus =
                   connection?.status ?? 'not_connected'
                 return (
-                  <TableRow key={plugin.slug}>
+                  <TableRow
+                    key={integrationId ?? `${plugin.slug}:${integration.slug}`}
+                  >
                     <TableCell>
-                      <ProviderCell plugin={plugin} />
+                      <ProviderCell integration={integration} plugin={plugin} />
                     </TableCell>
                     <TableCell>
                       <Badge variant={STATUS_VARIANT[status]}>
@@ -456,7 +438,7 @@ export function SettingsConnections() {
                           )
                           startMutation.mutate({
                             integrationId,
-                            pluginLabel: plugin.name,
+                            pluginLabel: integration.name,
                           })
                         }}
                         onDisconnect={() =>
@@ -662,20 +644,21 @@ function formatRelative(value: null | string): string {
   return ts.toLocaleString()
 }
 
-// v3 PluginPackage carries no brand glyph, so the provider cell falls back
-// to the generic Plug icon (the v2 InstalledPlugin.icon had no v3 source).
-function ProviderCell({ plugin }: { plugin: PluginPackage }) {
+// The primary label is the integration's name, since that's what tells two
+// integrations of the same plugin apart; the plugin name is shown beneath it
+// when it differs. Neither the integration nor its v3 plugin package is
+// guaranteed to carry a glyph, so the icon falls back to a generic Plug.
+function ProviderCell({ integration, plugin }: ConnectableIdentity) {
+  const Icon = useIcon(integration.icon ?? plugin.icon, Plug)
   return (
     <div className="flex items-center gap-3">
-      {plugin.icon ? (
-        <EntityIcon
-          className="text-tertiary size-6 shrink-0"
-          icon={plugin.icon}
-        />
-      ) : (
-        <Plug className="text-tertiary size-6 shrink-0" />
-      )}
-      <div className="font-medium">{plugin.name}</div>
+      <Icon className="text-tertiary size-6 shrink-0" />
+      <div>
+        <div className="font-medium">{integration.name}</div>
+        {integration.name === plugin.name ? null : (
+          <div className="text-tertiary text-xs">{plugin.name}</div>
+        )}
+      </div>
     </div>
   )
 }

--- a/ui/src/hooks/__tests__/useConnectableIdentities.test.tsx
+++ b/ui/src/hooks/__tests__/useConnectableIdentities.test.tsx
@@ -1,0 +1,151 @@
+import React from 'react'
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { renderHook, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import * as endpoints from '@/api/endpoints'
+import type { Integration, PluginPackage } from '@/types'
+
+import { useConnectableIdentities } from '../useConnectableIdentities'
+
+function wrapper(qc: QueryClient) {
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+  )
+}
+
+const identityPlugin = (slug: string, name: string): PluginPackage =>
+  ({
+    capabilities: [{ hints: {}, kind: 'identity' }],
+    enabled: true,
+    name,
+    slug,
+  }) as unknown as PluginPackage
+
+const identityIntegration = (over: Partial<Integration>): Integration =>
+  ({
+    capabilities: { identity: { enabled: true, options: {} } },
+    credential_fields: [],
+    identifiers: {},
+    links: {},
+    options: {},
+    status: 'active',
+    ...over,
+  }) as unknown as Integration
+
+let qc: QueryClient
+
+function mount(integrations: Integration[], plugins: PluginPackage[]) {
+  vi.spyOn(endpoints, 'listIntegrations').mockResolvedValue(integrations)
+  vi.spyOn(endpoints, 'listPluginPackages').mockResolvedValue(plugins)
+  const { result } = renderHook(() => useConnectableIdentities('aweber'), {
+    wrapper: wrapper(qc),
+  })
+  return result
+}
+
+describe('useConnectableIdentities', () => {
+  beforeEach(() => {
+    qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    vi.clearAllMocks()
+  })
+
+  // Regression: the connections surfaces used to key off the plugin slug, so
+  // a second integration of the same plugin (github.com alongside a GHEC
+  // host) was collapsed away and became unreachable.
+  it('returns one entry per integration when a plugin has several', async () => {
+    const result = mount(
+      [
+        identityIntegration({
+          id: 'AeYITqrf',
+          name: 'GitHub',
+          plugin: 'github',
+          slug: 'github',
+        }),
+        identityIntegration({
+          id: 'Xxc2LuXh',
+          name: 'GitHub Enterprise Cloud',
+          plugin: 'github',
+          slug: 'github-enterprise-cloud',
+        }),
+      ],
+      [identityPlugin('github', 'GitHub')],
+    )
+
+    await waitFor(() => expect(result.current.connectable).toHaveLength(2))
+    expect(
+      result.current.connectable.map(({ integration }) => [
+        integration.id,
+        integration.name,
+      ]),
+    ).toEqual([
+      ['AeYITqrf', 'GitHub'],
+      ['Xxc2LuXh', 'GitHub Enterprise Cloud'],
+    ])
+    // Both entries resolve to the one plugin package backing them.
+    for (const { plugin } of result.current.connectable) {
+      expect(plugin.slug).toBe('github')
+    }
+  })
+
+  it('excludes integrations whose plugin is absent or not an identity plugin', async () => {
+    const result = mount(
+      [
+        identityIntegration({ id: '1', name: 'GitHub', plugin: 'github' }),
+        // Plugin package not installed/enabled — nothing to connect against.
+        identityIntegration({ id: '2', name: 'Gitlab', plugin: 'gitlab' }),
+        // Installed, but the package exposes no identity capability.
+        identityIntegration({ id: '3', name: 'Logz.io', plugin: 'logzio' }),
+      ],
+      [
+        identityPlugin('github', 'GitHub'),
+        {
+          capabilities: [{ hints: {}, kind: 'logs' }],
+          enabled: true,
+          name: 'Logz.io',
+          slug: 'logzio',
+        } as unknown as PluginPackage,
+      ],
+    )
+
+    await waitFor(() => expect(result.current.connectable).toHaveLength(1))
+    expect(result.current.connectable[0].integration.id).toBe('1')
+  })
+
+  it('excludes integrations with the identity capability disabled', async () => {
+    const result = mount(
+      [
+        identityIntegration({
+          capabilities: { identity: { enabled: false, options: {} } },
+          id: '1',
+          name: 'GitHub',
+          plugin: 'github',
+        }),
+      ],
+      [identityPlugin('github', 'GitHub')],
+    )
+
+    await waitFor(() =>
+      expect(result.current.integrationsQuery.isLoading).toBe(false),
+    )
+    expect(result.current.connectable).toEqual([])
+  })
+
+  it('keeps a stable array reference across re-renders', async () => {
+    vi.spyOn(endpoints, 'listIntegrations').mockResolvedValue([
+      identityIntegration({ id: '1', name: 'GitHub', plugin: 'github' }),
+    ])
+    vi.spyOn(endpoints, 'listPluginPackages').mockResolvedValue([
+      identityPlugin('github', 'GitHub'),
+    ])
+    const { rerender, result } = renderHook(
+      () => useConnectableIdentities('aweber'),
+      { wrapper: wrapper(qc) },
+    )
+    await waitFor(() => expect(result.current.connectable).toHaveLength(1))
+    const first = result.current.connectable
+    rerender()
+    expect(result.current.connectable).toBe(first)
+  })
+})

--- a/ui/src/hooks/useConnectableIdentities.ts
+++ b/ui/src/hooks/useConnectableIdentities.ts
@@ -1,16 +1,31 @@
+import { useMemo } from 'react'
+
 import { useQuery } from '@tanstack/react-query'
 
 import { listIntegrations, listPluginPackages } from '@/api/endpoints'
-import { identityIntegrationPluginSlugs } from '@/components/plugin-packages'
+import {
+  identityIntegrations,
+  pluginIsIdentity,
+} from '@/components/plugin-packages'
 import { queryKeys } from '@/lib/queryKeys'
-import type { PluginPackage } from '@/types'
+import type { Integration, PluginPackage } from '@/types'
+
+// One connectable provider: an identity-enabled integration paired with the
+// plugin package backing it. Keyed by integration, not plugin — a plugin can
+// have several integrations (one per host) and each connects separately. The
+// integration's own `name` is what tells two integrations of one plugin apart,
+// so it's the display label on both surfaces.
+export interface ConnectableIdentity {
+  integration: Integration
+  plugin: PluginPackage
+}
 
 // Shared data for the personal identity-connection surfaces (dashboard
-// tiles + Settings > Connections): the installed plugins and the set of
-// plugin slugs that have a configured, identity-enabled integration in the
-// selected org — i.e. providers the actor can actually connect to. Global
-// login providers are org-less (absent here) and unconfigured plugins have
-// no integration, so both are excluded.
+// tiles + Settings > Connections): the installed plugins and the
+// identity-enabled integrations in the selected org — i.e. providers the
+// actor can actually connect to. Global login providers are org-less
+// (absent here) and unconfigured plugins have no integration, so both are
+// excluded.
 export function useConnectableIdentities(orgSlug: string) {
   const pluginsQuery = useQuery<PluginPackage[]>({
     queryFn: ({ signal }) => listPluginPackages(signal),
@@ -23,8 +38,23 @@ export function useConnectableIdentities(orgSlug: string) {
     queryKey: orgSlug ? queryKeys.integrations(orgSlug) : ['integrations'],
     staleTime: 60 * 1000,
   })
-  const connectableSlugs = identityIntegrationPluginSlugs(
-    integrationsQuery.data ?? [],
-  )
-  return { connectableSlugs, integrationsQuery, pluginsQuery }
+
+  const connectable = useMemo(() => {
+    const pluginsBySlug = new Map<string, PluginPackage>()
+    for (const plugin of pluginsQuery.data ?? []) {
+      if (plugin.enabled && pluginIsIdentity(plugin)) {
+        pluginsBySlug.set(plugin.slug, plugin)
+      }
+    }
+    const out: ConnectableIdentity[] = []
+    for (const integration of identityIntegrations(
+      integrationsQuery.data ?? [],
+    )) {
+      const plugin = pluginsBySlug.get(integration.plugin)
+      if (plugin) out.push({ integration, plugin })
+    }
+    return out
+  }, [integrationsQuery.data, pluginsQuery.data])
+
+  return { connectable, integrationsQuery, pluginsQuery }
 }


### PR DESCRIPTION
## Summary

Settings > Connections and the dashboard's "connect your account" tiles now key off the integration id instead of the plugin slug, so two integrations of the same plugin — github.com and a GitHub Enterprise Cloud host — each get their own independently connectable row.

## Problem

With both a `github` integration for github.com and one for `aweber.ghe.com` configured, only a single "GitHub" row appeared in Settings > Connections, and there was no way to connect to the other host.

`SettingsConnections` built one row per identity **plugin** and collapsed integrations into a Map keyed by plugin slug:

```ts
const integrationByPluginSlug = new Map<string, string>()
for (const i of integrationsQuery.data ?? []) {
  if (i.capabilities?.identity?.enabled && i.id) {
    integrationByPluginSlug.set(i.plugin, i.id)   // second github integration clobbers the first
  }
}
```

Both integrations have `plugin: "github"`, so the last one returned by the API won. Consequences:

- One row instead of two, showing whichever integration came last (the GHEC host).
- That row was labeled from the plugin package name ("GitHub"), which is why GHEC displayed as GitHub.com.
- The github.com integration had no reachable Connect button at all.

The same per-plugin assumption made the dashboard hide the tile for *both* hosts once *either* was connected, and persisted dismissals by plugin slug.

The API already models this per-integration end to end — `IdentityConnection` nodes MERGE on `{integration_id, user_id}`, and `GET /me/identities` returns `integration_id` / `integration_slug` / `integration_name` per connection — so the UI was the only layer collapsing them.

## Solution

- `identityIntegrationPluginSlugs()` → `identityIntegrations()`: returns the identity-enabled integrations rather than a `Set` of plugin slugs. This was the lossy step.
- `useConnectableIdentities()` returns `{integration, plugin}` pairs, doing the integration → plugin join once for both consumers, memoized on the two query results (matching the convention in `useProjectsSlimMap` / `useUserDisplayNames`).
- Settings > Connections renders one row per integration, keyed on `integration.id`, labeled with the integration's name and the plugin name beneath it when the two differ. The icon resolves from the integration then its plugin, via the existing `useIcon(name, fallback)` helper.
- Dashboard tiles hide by integration id, so connecting one GitHub host leaves the other's tile in place. The dismissal storage key is bumped to `-v2` because v1 held plugin slugs.
- `?connect=` carries an integration id. The auto-connect effect now waits on `orgSlug`: the integrations query is disabled until an org is selected, and a disabled TanStack query reports `isLoading === false`, so the effect could previously fire before the organizations query resolved — false-toasting "no longer available", stripping the param, and latching its ref so the connect never happened.
- `UnconnectedIntegrationWidget` takes required `label` and `icon` props, removing a plugin-name fallback and an icon rule that could drift from the connections table.

### Behavior note for existing users

An existing GitHub connection is stored against one integration id, so after this change it shows as Connected on that integration's row only — the sibling host reads "Not connected", which is the accurate state.

## Testing

- New `ui/src/hooks/__tests__/useConnectableIdentities.test.tsx` (4 tests) guards the regression at the layer where it lived: two integrations of one plugin both survive the join, plus plugin-absent / non-identity / disabled-capability exclusion and memo stability.
- `npx tsc --noEmit` clean, `npm run lint` 0 errors, `npm run lint:fallow` clean for the touched files, `npm run format:check` clean.
- Full UI suite: 601 tests across 82 files passing.

Not yet exercised against a running environment — the reporter's screenshots are from production and no dev environment was up. The two-row rendering and independent per-host status should be confirmed in the app before merge.

## Follow-up (not in this PR)

Login providers are still one-per-plugin (`AuthProvidersManagement.tsx`, `AddAuthProviderDialog.tsx` filters out plugins already configured), so a second GitHub host can now be a *connection* provider but still cannot be a *login* provider. Same bug family, separate change.
