### PR TITLE
Show only tagged releases in the dependencies selector

### DIFF
--- a/ui/src/components/dependencies/DependenciesTab.tsx
+++ b/ui/src/components/dependencies/DependenciesTab.tsx
@@ -14,7 +14,7 @@ import {
 } from '@/components/ui/select'
 import { Sk } from '@/components/ui/skeleton'
 import { cn } from '@/lib/utils'
-import type { Project, ReleaseDependencyComponent } from '@/types'
+import type { Project, Release, ReleaseDependencyComponent } from '@/types'
 
 interface DependenciesTabProps {
   orgSlug: string
@@ -118,7 +118,15 @@ export function DependenciesTab({ orgSlug, project }: DependenciesTabProps) {
     queryKey: ['project-releases', orgSlug, project.id],
   })
 
-  const releases = useMemo(() => releasesQuery.data ?? [], [releasesQuery.data])
+  // Only tagged releases are selectable — untagged committishes are noise
+  // in the dropdown.
+  const releases = useMemo(
+    () =>
+      (releasesQuery.data ?? []).filter(
+        (release): release is Release & { tag: string } => Boolean(release.tag),
+      ),
+    [releasesQuery.data],
+  )
 
   const [selectedReleaseId, setSelectedReleaseId] = useState<null | string>(
     null,
@@ -165,8 +173,8 @@ export function DependenciesTab({ orgSlug, project }: DependenciesTabProps) {
     return (
       <Card>
         <CardContent className="text-muted-foreground p-8 text-center">
-          No releases yet. Once a release is created and a CycloneDX SBoM is
-          ingested, its dependencies will appear here.
+          No tagged releases yet. Once a tagged release is created and a
+          CycloneDX SBoM is ingested, its dependencies will appear here.
         </CardContent>
       </Card>
     )
@@ -197,7 +205,7 @@ export function DependenciesTab({ orgSlug, project }: DependenciesTabProps) {
           <SelectContent>
             {releases.map((release) => (
               <SelectItem key={release.id} value={release.id}>
-                {release.tag ?? release.committish}
+                {release.tag}
               </SelectItem>
             ))}
           </SelectContent>

--- a/ui/src/components/dependencies/__tests__/DependenciesTab.test.tsx
+++ b/ui/src/components/dependencies/__tests__/DependenciesTab.test.tsx
@@ -96,13 +96,16 @@ describe('DependenciesTab', () => {
   })
 
   it('ignores untagged releases entirely', async () => {
+    const user = userEvent.setup()
     vi.spyOn(endpoints, 'listProjectReleases').mockResolvedValue([
       makeRelease({
+        committish: 'deadbee',
         created_at: '2026-06-01T00:00:00Z',
         id: 'rel-untagged',
         tag: null,
       }),
       makeRelease({
+        committish: 'abc1234',
         created_at: '2026-05-01T00:00:00Z',
         id: 'rel-tagged',
         tag: '1.0.0',
@@ -124,6 +127,13 @@ describe('DependenciesTab', () => {
       'rel-tagged',
       expect.any(AbortSignal),
     )
+
+    // The dropdown offers the tag alone — no committish label, and no
+    // entry at all for the untagged release.
+    await user.click(screen.getByRole('combobox', { name: /release/i }))
+    const options = await screen.findAllByRole('option')
+    expect(options.map((option) => option.textContent)).toEqual(['1.0.0'])
+    expect(screen.queryByText(/abc1234|deadbee/)).not.toBeInTheDocument()
   })
 
   it('renders the dependencies of the most recent release by default', async () => {

--- a/ui/src/components/dependencies/__tests__/DependenciesTab.test.tsx
+++ b/ui/src/components/dependencies/__tests__/DependenciesTab.test.tsx
@@ -78,18 +78,52 @@ beforeEach(() => {
 })
 
 describe('DependenciesTab', () => {
-  it('shows the empty state when the project has no releases', async () => {
-    vi.spyOn(endpoints, 'listProjectReleases').mockResolvedValue([])
-    const depsSpy = vi
-      .spyOn(endpoints, 'listReleaseDependencies')
-      .mockResolvedValue(makeDeps('rel-1', { components: [] }))
+  it.each([
+    ['the project has no releases', []],
+    ['every release is untagged', [makeRelease({ tag: null })]],
+  ])('shows the empty state when %s', async (_label, releases) => {
+    vi.spyOn(endpoints, 'listProjectReleases').mockResolvedValue(releases)
+    const depsSpy = vi.spyOn(endpoints, 'listReleaseDependencies')
 
     render(<DependenciesTab orgSlug="org" project={PROJECT} />, {
       wrapper: wrapper(qc),
     })
 
-    expect(await screen.findByText(/No releases yet/i)).toBeInTheDocument()
+    expect(
+      await screen.findByText(/No tagged releases yet/i),
+    ).toBeInTheDocument()
     expect(depsSpy).not.toHaveBeenCalled()
+  })
+
+  it('ignores untagged releases entirely', async () => {
+    vi.spyOn(endpoints, 'listProjectReleases').mockResolvedValue([
+      makeRelease({
+        created_at: '2026-06-01T00:00:00Z',
+        id: 'rel-untagged',
+        tag: null,
+      }),
+      makeRelease({
+        created_at: '2026-05-01T00:00:00Z',
+        id: 'rel-tagged',
+        tag: '1.0.0',
+      }),
+    ])
+    const depsSpy = vi
+      .spyOn(endpoints, 'listReleaseDependencies')
+      .mockResolvedValue(makeDeps('rel-tagged'))
+
+    render(<DependenciesTab orgSlug="org" project={PROJECT} />, {
+      wrapper: wrapper(qc),
+    })
+
+    // The newest release is untagged, so the tagged one is selected.
+    expect(await screen.findByText('express')).toBeInTheDocument()
+    expect(depsSpy).toHaveBeenCalledWith(
+      'org',
+      'proj-1',
+      'rel-tagged',
+      expect.any(AbortSignal),
+    )
   })
 
   it('renders the dependencies of the most recent release by default', async () => {


### PR DESCRIPTION
## Summary
The Release selector on the project Dependencies tab now lists only tagged releases, not raw commitishes.

## Problem
The dropdown rendered every `Release` node returned by `listProjectReleases`, labelling untagged ones with their committish (`1b97478`, `ad99fc1`, …) interleaved with real version tags. Those untagged nodes are residue from the deployment-resync path — a deploy whose ref was a bare SHA with no tagged release for that commit. The SBoM ingest path always resolves or creates its release with a `tag`, so an untagged release can never have dependencies: picking one always rendered an empty table.

## Solution
Filter the releases query to entries that have a `tag`. The filter uses a type predicate so the compiler enforces the invariant at the render site, which let the now-dead `tag ?? committish` label fallback go away. The empty state was reworded to say no *tagged* releases exist, so a project holding only resync residue reads accurately instead of claiming it has no releases.

The filter is deliberately client-side. `DependenciesTab` is the only caller of `listProjectReleases`, and its `['project-releases', orgSlug, projectId]` query key is shared with the invalidations in `useCutReleaseMutation` and `useReleaseBlockMutation` — a server-side `tagged=` param would fork that cache entry and cost an extra request. `list_releases` also only supports exact-match `tag=`/`committish=` today, so this would have meant a new API param for a single tab's display concern.

## Impact
UI only, no API or schema changes. Users lose nothing selectable that showed real data — every hidden entry rendered an empty dependency table. Projects whose releases are all untagged now show the empty state instead of a populated dropdown over empty tables.

## Testing
`vitest` for `src/components/dependencies` passes (10 tests), including new coverage for an untagged newest release falling through to the newest tagged one, and for the all-untagged empty state. `tsc --noEmit`, `oxlint`, and `oxfmt --check` are clean.