### PR TITLE
Render timestamps in the viewer's timezone consistently

### DIFF
--- a/apps/api/src/imbi/api/endpoints/project_deployments.py
+++ b/apps/api/src/imbi/api/endpoints/project_deployments.py
@@ -2156,6 +2156,20 @@ def _release_tag_order_key(
     return (key is not None, key or (0, 0, 0), when_key)
 
 
+def _tag_timestamp(
+    row: dict[str, typing.Any],
+) -> datetime.datetime | None:
+    """When a ``tags`` row was published, as an aware UTC timestamp.
+
+    Falls back to ``recorded_at`` for rows synced without a tag date.
+    ClickHouse returns these columns naive, so ``as_utc`` tags the offset
+    on before Pydantic serializes them.
+    """
+    return clickhouse.as_utc_or_none(
+        row.get('tagged_at') or row.get('recorded_at')
+    )
+
+
 def _latest_release_tag(
     rows: list[dict[str, typing.Any]],
 ) -> dict[str, typing.Any] | None:
@@ -2527,7 +2541,7 @@ def _recent_commit_from_row(row: dict[str, typing.Any]) -> RecentCommit:
         message=str(row.get('message') or ''),
         author=str(author) if author else None,
         author_email=str(author_email) if author_email else None,
-        authored_at=row['authored_at'],
+        authored_at=clickhouse.as_utc(row['authored_at']),
         ci_status=str(row.get('ci_status') or 'unknown'),
         url=str(url) if url else None,
     )
@@ -2671,11 +2685,7 @@ async def get_release_drift(
     latest = _latest_release_tag(tag_rows)
     latest_tag = str(latest['name']) if latest else None
     latest_tag_sha = str(latest['sha']) if latest else None
-    latest_tag_at = (
-        (latest.get('tagged_at') or latest.get('recorded_at'))
-        if latest
-        else None
-    )
+    latest_tag_at = _tag_timestamp(latest) if latest else None
 
     head_rows = await clickhouse.query(
         'SELECT sha FROM commits FINAL '
@@ -2788,7 +2798,7 @@ async def get_release_history(
                 tag=name,
                 sha=sha,
                 short_sha=sha[:7],
-                published_at=row.get('tagged_at') or row.get('recorded_at'),
+                published_at=_tag_timestamp(row),
                 author=str(tagger) if tagger else (created_by or None),
                 author_email=(
                     str(created_by)

--- a/apps/api/src/imbi/api/endpoints/projects.py
+++ b/apps/api/src/imbi/api/endpoints/projects.py
@@ -995,13 +995,13 @@ async def _fetch_release_summaries(
         head_author = str(raw_author) if raw_author else None
         raw_login = head_row.get('author_user') if head_row else None
         head_author_login = str(raw_login) if raw_login else None
-        head_authored_at: datetime.datetime | None = (
+        head_authored_at = clickhouse.as_utc_or_none(
             head_row.get('authored_at') if head_row else None
         )
         latest_tag = str(latest['name']) if latest else None
         latest_tag_sha = str(latest['sha']) if latest else None
-        latest_tag_at: datetime.datetime | None = (
-            latest.get('tagged_at') or latest.get('recorded_at')
+        latest_tag_at = clickhouse.as_utc_or_none(
+            (latest.get('tagged_at') or latest.get('recorded_at'))
             if latest
             else None
         )

--- a/apps/api/src/imbi/api/endpoints/scoring.py
+++ b/apps/api/src/imbi/api/endpoints/scoring.py
@@ -28,6 +28,19 @@ _GRANULARITY_EXPR = {
 }
 
 
+def _ts(value: typing.Any) -> str:
+    """Render a ClickHouse timestamp column for a ``str`` model field.
+
+    The score-history models carry timestamps as strings, so they bypass
+    Pydantic's datetime serializer; ``iso_utc`` supplies the UTC offset
+    that ``str(datetime)`` would drop. Row values are loosely typed, so
+    anything already stringified is passed through as-is.
+    """
+    if isinstance(value, datetime.datetime):
+        return clickhouse.iso_utc(value) or ''
+    return str(value or '')
+
+
 @scoring_router.get(
     '/organizations/{org_slug}/projects/{project_id}/score/history'
 )
@@ -86,7 +99,7 @@ async def get_score_history(
         if granularity == 'raw':
             points.append(
                 scoring_models.ScoreHistoryPoint(
-                    timestamp=str(row['timestamp']),
+                    timestamp=_ts(row['timestamp']),
                     score=float(row['score']),
                     previous_score=(
                         float(row['previous_score'])
@@ -99,7 +112,7 @@ async def get_score_history(
         else:
             points.append(
                 scoring_models.ScoreHistoryPoint(
-                    timestamp=str(row['ts']),
+                    timestamp=_ts(row['ts']),
                     score=float(row['score']),
                 )
             )
@@ -230,7 +243,7 @@ async def score_rollup(
             continue
         latest = float(row.get('latest_score') or 0.0)
         last_upd = (
-            str(row['last_updated']) if row.get('last_updated') else None
+            _ts(row['last_updated']) if row.get('last_updated') else None
         )
         scores_by_key.setdefault(dim_key, []).append(latest)
         existing_upd = last_updated_by_key.get(dim_key)
@@ -414,7 +427,7 @@ async def score_history_by_team(
         team = project_team.get(pid)
         if not team:
             continue
-        ts = str(row['ts'])
+        ts = _ts(row['ts'])
         score = float(row['score'])
         team_ts_scores.setdefault(team, {}).setdefault(ts, []).append(score)
     teams: list[scoring_models.TeamScoreSeries] = []
@@ -495,7 +508,7 @@ async def score_history_feed(
         project_name, team_key = info
         out.append(
             scoring_models.GlobalScoreEvent(
-                timestamp=str(row['timestamp']),
+                timestamp=_ts(row['timestamp']),
                 project_id=pid,
                 project_name=project_name,
                 team_key=team_key,

--- a/apps/api/tests/endpoints/test_project_deployments.py
+++ b/apps/api/tests/endpoints/test_project_deployments.py
@@ -2150,6 +2150,98 @@ class ReleasesTabEndpointsTestCase(ProjectDeploymentsTestCase):
             recorded,
         )
 
+    # --- ClickHouse naive-timestamp serialization ---------------------
+    #
+    # DateTime64 columns come back naive even though they hold UTC. Passed
+    # straight into a Pydantic model the JSON carries no offset, and the
+    # browser then reads the value in its own zone — commit and release
+    # dates drifted by that zone's offset.
+
+    # Naive on purpose: ClickHouse returns naive DateTime64 values.
+    _NAIVE = datetime.datetime(2026, 1, 1, 12, 0, 0)  # noqa: DTZ001
+
+    def _assert_utc(self, value: str) -> None:
+        parsed = datetime.datetime.fromisoformat(value)
+        self.assertIsNotNone(parsed.tzinfo, f'{value!r} carries no offset')
+        self.assertEqual(parsed.utcoffset(), datetime.timedelta(0))
+        self.assertEqual(parsed, self._NAIVE.replace(tzinfo=datetime.UTC))
+
+    def test_recent_commits_authored_at_carries_utc_offset(self) -> None:
+        row = self._commit_row('abc1234def')
+        row['authored_at'] = self._NAIVE
+        self._patch_query([[row]])
+        with testclient.TestClient(self.test_app) as client:
+            response = client.get(f'{self._BASE}/recent-commits')
+        self.assertEqual(response.status_code, 200, response.text)
+        self._assert_utc(response.json()[0]['authored_at'])
+
+    def test_release_history_published_at_carries_utc_offset(self) -> None:
+        self._patch_query(
+            [
+                [
+                    {
+                        'name': 'v1.0.0',
+                        'sha': 'sha10',
+                        'tagged_at': self._NAIVE,
+                        'tagger_name': 'Rel Bot',
+                        'url': '',
+                        'recorded_at': None,
+                    }
+                ],
+                [{'sha': 'sha10', 'ci_status': 'pass'}],
+            ]
+        )
+        self.mock_db.execute = mock.AsyncMock(return_value=[])
+        with testclient.TestClient(self.test_app) as client:
+            response = client.get(f'{self._BASE}/release-history')
+        self.assertEqual(response.status_code, 200, response.text)
+        self._assert_utc(response.json()[0]['published_at'])
+
+    def test_release_history_falls_back_to_recorded_at(self) -> None:
+        """No tag date recorded -> recorded_at, still offset-bearing."""
+        self._patch_query(
+            [
+                [
+                    {
+                        'name': 'v1.0.0',
+                        'sha': 'sha10',
+                        'tagged_at': None,
+                        'tagger_name': '',
+                        'url': '',
+                        'recorded_at': self._NAIVE,
+                    }
+                ],
+                [],
+            ]
+        )
+        self.mock_db.execute = mock.AsyncMock(return_value=[])
+        with testclient.TestClient(self.test_app) as client:
+            response = client.get(f'{self._BASE}/release-history')
+        self.assertEqual(response.status_code, 200, response.text)
+        self._assert_utc(response.json()[0]['published_at'])
+
+    def test_release_history_published_at_null_when_undated(self) -> None:
+        self._patch_query(
+            [
+                [
+                    {
+                        'name': 'v1.0.0',
+                        'sha': 'sha10',
+                        'tagged_at': None,
+                        'tagger_name': '',
+                        'url': '',
+                        'recorded_at': None,
+                    }
+                ],
+                [],
+            ]
+        )
+        self.mock_db.execute = mock.AsyncMock(return_value=[])
+        with testclient.TestClient(self.test_app) as client:
+            response = client.get(f'{self._BASE}/release-history')
+        self.assertEqual(response.status_code, 200, response.text)
+        self.assertIsNone(response.json()[0]['published_at'])
+
     def test_release_history_joins_tags_and_nodes(self) -> None:
         when = datetime.datetime(2026, 1, 1, tzinfo=datetime.UTC)
         self._patch_query(

--- a/apps/api/tests/endpoints/test_projects.py
+++ b/apps/api/tests/endpoints/test_projects.py
@@ -2547,3 +2547,90 @@ class EmitChangeEventsTestCase(unittest.IsolatedAsyncioTestCase):
             await projects._emit_change_events(
                 'p1', 'alice', {'name': 'A'}, {'name': 'B'}
             )
+
+
+class ReleaseSummaryTimestampTestCase(unittest.IsolatedAsyncioTestCase):
+    """The projects-list release summary must emit offset-bearing times.
+
+    ``_fetch_release_summaries`` reads ``tagged_at``/``recorded_at`` from
+    the ClickHouse ``tags`` table and ``authored_at`` from ``commits``.
+    DateTime64 columns come back naive, so passing them straight into
+    ``ReleaseSummary`` serialized them without an offset and the browser
+    read them in its own zone — head-commit and latest-tag dates on the
+    projects list drifted by that zone's offset.
+    """
+
+    # Naive on purpose: ClickHouse returns naive DateTime64 values.
+    NAIVE = datetime.datetime(2026, 1, 1, 12, 0, 0)  # noqa: DTZ001
+
+    async def _summaries(
+        self, tag_row: dict[str, typing.Any] | None
+    ) -> typing.Any:
+        from imbi.api.endpoints import projects
+
+        tag_rows = [tag_row] if tag_row else []
+        head_rows = [
+            {
+                'project_id': 'p1',
+                'sha': 'a' * 40,
+                'short_sha': 'aaaaaaa',
+                'author_name': 'Alice',
+                'author_user': 'alice',
+                'authored_at': self.NAIVE,
+            }
+        ]
+        with mock.patch(
+            'imbi.api.endpoints.projects.clickhouse.query',
+            mock.AsyncMock(side_effect=[tag_rows, head_rows, []]),
+        ):
+            result = await projects._fetch_release_summaries(['p1'])
+        return result['p1']
+
+    def _assert_utc(self, value: datetime.datetime | None) -> None:
+        self.assertIsNotNone(value)
+        assert value is not None
+        self.assertEqual(value.utcoffset(), datetime.timedelta(0))
+        self.assertEqual(value, self.NAIVE.replace(tzinfo=datetime.UTC))
+
+    async def test_head_authored_at_carries_utc_offset(self) -> None:
+        summary = await self._summaries(None)
+        self._assert_utc(summary.head_authored_at)
+
+    async def test_latest_tag_at_carries_utc_offset(self) -> None:
+        summary = await self._summaries(
+            {
+                'project_id': 'p1',
+                'name': 'v1.0.0',
+                'sha': 'b' * 40,
+                'tagged_at': self.NAIVE,
+                'recorded_at': None,
+                'tagger_name': 'Rel Bot',
+            }
+        )
+        self._assert_utc(summary.latest_tag_at)
+
+    async def test_latest_tag_at_falls_back_to_recorded_at(self) -> None:
+        summary = await self._summaries(
+            {
+                'project_id': 'p1',
+                'name': 'v1.0.0',
+                'sha': 'b' * 40,
+                'tagged_at': None,
+                'recorded_at': self.NAIVE,
+                'tagger_name': '',
+            }
+        )
+        self._assert_utc(summary.latest_tag_at)
+
+    async def test_latest_tag_at_is_none_when_undated(self) -> None:
+        summary = await self._summaries(
+            {
+                'project_id': 'p1',
+                'name': 'v1.0.0',
+                'sha': 'b' * 40,
+                'tagged_at': None,
+                'recorded_at': None,
+                'tagger_name': '',
+            }
+        )
+        self.assertIsNone(summary.latest_tag_at)

--- a/apps/api/tests/endpoints/test_scoring.py
+++ b/apps/api/tests/endpoints/test_scoring.py
@@ -685,3 +685,56 @@ class ScoringEndpointsTestCase(support.SharedAppTestCase):
         self.assertEqual(len(body), 1)
         self.assertIsNone(body[0]['previous_score'])
         self.assertEqual(body[0]['change_reason'], 'initial')
+
+    # --- ClickHouse naive-timestamp serialization ---------------------
+    #
+    # The score-history models type ``timestamp`` as ``str``, so they skip
+    # Pydantic's datetime serializer. These endpoints used to render it
+    # with ``str(value)``, which drops the UTC offset and emits a space
+    # separator instead of ``T`` — the browser then read the value in its
+    # own zone and every score-history chart was shifted by that offset.
+
+    # Naive on purpose: ClickHouse returns naive DateTime64 values.
+    NAIVE = datetime.datetime(2026, 4, 1, 12, 0, 0)  # noqa: DTZ001
+    EXPECTED = '2026-04-01T12:00:00+00:00'
+
+    def _history(self, granularity: str, rows: list[dict]) -> dict:
+        self.mock_db.execute = mock.AsyncMock(return_value=[{'id': 'p1'}])
+        with mock.patch(
+            'imbi.api.endpoints.scoring.clickhouse.query',
+            mock.AsyncMock(return_value=rows),
+        ):
+            response = self.client.get(
+                '/organizations/eng/projects/p1/score/history',
+                params={'granularity': granularity},
+            )
+        self.assertEqual(response.status_code, 200, response.text)
+        return response.json()
+
+    def test_raw_history_timestamp_carries_utc_offset(self) -> None:
+        body = self._history(
+            'raw',
+            [
+                {
+                    'timestamp': self.NAIVE,
+                    'score': 80.0,
+                    'previous_score': 70.0,
+                    'change_reason': 'attribute_change',
+                }
+            ],
+        )
+        ts = body['points'][0]['timestamp']
+        self.assertEqual(ts, self.EXPECTED)
+        self.assertEqual(
+            datetime.datetime.fromisoformat(ts).utcoffset(),
+            datetime.timedelta(0),
+        )
+
+    def test_bucketed_history_timestamp_carries_utc_offset(self) -> None:
+        body = self._history('day', [{'ts': self.NAIVE, 'score': 80.0}])
+        self.assertEqual(body['points'][0]['timestamp'], self.EXPECTED)
+
+    def test_aware_timestamp_is_left_alone(self) -> None:
+        aware = self.NAIVE.replace(tzinfo=datetime.UTC)
+        body = self._history('day', [{'ts': aware, 'score': 80.0}])
+        self.assertEqual(body['points'][0]['timestamp'], self.EXPECTED)

--- a/libraries/common/src/imbi/common/clickhouse/__init__.py
+++ b/libraries/common/src/imbi/common/clickhouse/__init__.py
@@ -1,3 +1,4 @@
+import datetime
 import typing
 
 import orjson
@@ -10,11 +11,47 @@ from .client import SchemataQuery
 __all__ = [
     'SchemataQuery',
     'aclose',
+    'as_utc',
+    'as_utc_or_none',
     'initialize',
     'insert',
+    'iso_utc',
     'query',
     'setup_schema',
 ]
+
+
+def as_utc(value: datetime.datetime) -> datetime.datetime:
+    """Attach UTC to a naive timestamp read back from ClickHouse.
+
+    ``DateTime``/``DateTime64`` columns store UTC but the driver hands
+    back naive ``datetime`` objects. Serialized without an offset, a
+    client parses them in its *own* zone and the value shifts by that
+    zone's offset, so tag the tzinfo on before the value leaves the API.
+    Already-aware values pass through untouched.
+    """
+    return (
+        value.replace(tzinfo=datetime.UTC) if value.tzinfo is None else value
+    )
+
+
+def as_utc_or_none(value: typing.Any) -> datetime.datetime | None:
+    """``as_utc`` for optional row values; ``None`` when absent.
+
+    Row dicts are loosely typed, so callers reading a nullable timestamp
+    column would otherwise repeat the ``isinstance`` narrowing.
+    """
+    return as_utc(value) if isinstance(value, datetime.datetime) else None
+
+
+def iso_utc(value: datetime.datetime | None) -> str | None:
+    """Render a ClickHouse timestamp as an offset-bearing ISO string.
+
+    Returns ``None`` for a missing value. Use in place of ``str(value)``,
+    which drops the offset *and* emits a space separator rather than
+    ``T`` — a form ``Date.parse`` is not required to accept.
+    """
+    return as_utc(value).isoformat() if value is not None else None
 
 
 def _dump(

--- a/ui/src/components/ProjectActivityLog.tsx
+++ b/ui/src/components/ProjectActivityLog.tsx
@@ -27,6 +27,7 @@ import { UserIdentity } from '@/components/ui/user-identity'
 import { usePluginOpsLogTemplates } from '@/hooks/usePluginOpsLogTemplates'
 import type { PluginOpsLogTemplateMap } from '@/hooks/usePluginOpsLogTemplates'
 import { useUserDisplayNames } from '@/hooks/useUserDisplayNames'
+import { parseServerTs, toDateOnlyIso } from '@/lib/formatDate'
 import { formatFieldKey } from '@/lib/project-field-formatting'
 import type { Environment, Integration, OperationsLogRecord } from '@/types'
 
@@ -133,12 +134,12 @@ export function ProjectActivityLog({ orgSlug, projectId, projectSlug }: Props) {
     const events: ActivityItem[] = (eventsPage?.entries ?? []).map((e) => ({
       data: e,
       kind: 'event' as const,
-      ts: new Date(e.recorded_at),
+      ts: parseServerTs(e.recorded_at),
     }))
     const ops: ActivityItem[] = (opsPage?.entries ?? []).map((o) => ({
       data: o,
       kind: 'ops' as const,
-      ts: new Date(o.occurred_at),
+      ts: parseServerTs(o.occurred_at),
     }))
     return [...events, ...ops]
       .sort((a, b) => b.ts.getTime() - a.ts.getTime())
@@ -148,7 +149,7 @@ export function ProjectActivityLog({ orgSlug, projectId, projectSlug }: Props) {
   const groups = useMemo(() => {
     const map = new Map<string, { items: ActivityItem[]; label: string }>()
     for (const item of merged) {
-      const key = dayKey(item.ts)
+      const key = toDateOnlyIso(item.ts)
       if (!map.has(key)) map.set(key, { items: [], label: dayLabel(item.ts) })
       map.get(key)!.items.push(item)
     }
@@ -245,15 +246,11 @@ function commentHref(projectId: string, payload: unknown): string | undefined {
     : base
 }
 
-function dayKey(d: Date): string {
-  return d.toISOString().slice(0, 10)
-}
-
 function dayLabel(d: Date): string {
   const today = new Date()
-  if (dayKey(d) === dayKey(today)) return 'TODAY'
+  if (toDateOnlyIso(d) === toDateOnlyIso(today)) return 'TODAY'
   return d
-    .toLocaleDateString('en-US', { day: 'numeric', month: 'short' })
+    .toLocaleDateString(undefined, { day: 'numeric', month: 'short' })
     .toUpperCase()
 }
 

--- a/ui/src/components/ScoreHistoryTab.tsx
+++ b/ui/src/components/ScoreHistoryTab.tsx
@@ -22,6 +22,7 @@ import {
   ScoreHistoryPoint,
 } from '@/api/endpoints'
 import { Sk } from '@/components/ui/skeleton'
+import { parseServerTs, toDateOnlyIso } from '@/lib/formatDate'
 import { formatFieldKey } from '@/lib/project-field-formatting'
 import { computeScoreYAxis } from '@/lib/score-chart'
 
@@ -169,7 +170,7 @@ export function ScoreHistoryTab({ orgSlug, projectId }: Props) {
     if (pts.length === 0) return pts
     const last = pts[pts.length - 1]
     const now = new Date()
-    const lastMs = new Date(toUtc(last.timestamp)).getTime()
+    const lastMs = parseServerTs(last.timestamp).getTime()
     // Only append if the last point is more than a minute old
     if (now.getTime() - lastMs > 60_000) {
       return [
@@ -201,7 +202,7 @@ export function ScoreHistoryTab({ orgSlug, projectId }: Props) {
       rawEvents.forEach((e) => {
         if (e.change_reason == null) return
         const i = nearestChartPointIndex(
-          new Date(toUtc(e.timestamp)).getTime(),
+          parseServerTs(e.timestamp).getTime(),
           chartPoints,
         )
         if (!m.has(i)) m.set(i, e.change_reason)
@@ -219,7 +220,7 @@ export function ScoreHistoryTab({ orgSlug, projectId }: Props) {
     )
       return null
     return nearestChartPointIndex(
-      new Date(toUtc(rawEvents[hoveredEvent].timestamp)).getTime(),
+      parseServerTs(rawEvents[hoveredEvent].timestamp).getTime(),
       chartPoints,
     )
   }, [hoveredEvent, rawEvents, chartPoints])
@@ -442,7 +443,7 @@ function EventTimeline({
                 {fmtRel(e.timestamp)}
               </div>
               <div className="text-tertiary mt-0.5 font-mono text-[11px]">
-                {fmtISODate(e.timestamp)}
+                {toDateOnlyIso(parseServerTs(e.timestamp))}
               </div>
             </div>
             <div>
@@ -535,32 +536,24 @@ function EventTimelineSkeleton() {
 }
 
 function fmtDate(iso: string, withTime = false): string {
-  const d = new Date(toUtc(iso))
+  const d = parseServerTs(iso)
   if (withTime) {
-    return d.toLocaleString('en-US', {
+    return d.toLocaleString(undefined, {
       day: 'numeric',
       hour: 'numeric',
       minute: '2-digit',
       month: 'short',
     })
   }
-  return d.toLocaleString('en-US', {
+  return d.toLocaleString(undefined, {
     day: 'numeric',
     month: 'short',
     year: 'numeric',
   })
 }
 
-function fmtISODate(iso: string): string {
-  const d = new Date(toUtc(iso))
-  const y = d.getFullYear()
-  const m = String(d.getMonth() + 1).padStart(2, '0')
-  const day = String(d.getDate()).padStart(2, '0')
-  return `${y}-${m}-${day}`
-}
-
 function fmtRel(iso: string): string {
-  const ms = Date.now() - new Date(toUtc(iso)).getTime()
+  const ms = Date.now() - parseServerTs(iso).getTime()
   const min = Math.round(ms / 60000)
   if (min < 60) return `${min}m ago`
   const hr = Math.round(min / 60)
@@ -589,7 +582,7 @@ function nearestChartPointIndex(
   let bestI = 0
   let bestDiff = Infinity
   pts.forEach((p, i) => {
-    const d = Math.abs(new Date(toUtc(p.timestamp)).getTime() - timestampMs)
+    const d = Math.abs(parseServerTs(p.timestamp).getTime() - timestampMs)
     if (d < bestDiff) {
       bestDiff = d
       bestI = i
@@ -603,11 +596,11 @@ function nearestProjectChange(
   events: EventRecord[],
   attributedTo?: string,
 ): null | ProjectChangePayload {
-  const scoreMs = new Date(toUtc(scoreTimestamp)).getTime()
+  const scoreMs = parseServerTs(scoreTimestamp).getTime()
   let best: null | ProjectChangePayload = null
   let bestDiff = 90_000 // 90s look-back window
   for (const e of events) {
-    const peMs = new Date(toUtc(e.recorded_at)).getTime()
+    const peMs = parseServerTs(e.recorded_at).getTime()
     const diff = scoreMs - peMs
     if (diff >= 0 && diff < bestDiff) {
       // If reason is a user email, prefer events attributed to that same user
@@ -623,10 +616,6 @@ function nearestProjectChange(
 }
 
 // Ensure bare ISO strings (no tz offset) are treated as UTC
-function toUtc(iso: string): string {
-  return /[Z+]|\d{2}:\d{2}$/.test(iso) ? iso : iso + 'Z'
-}
-
 // Reasons that represent bulk/policy operations — correlating these with a
 // specific attribute change would produce false positives.
 const NON_ATTRIBUTE_REASONS = new Set([

--- a/ui/src/components/activityFeed/grouping.ts
+++ b/ui/src/components/activityFeed/grouping.ts
@@ -6,6 +6,8 @@
 // an expandable group. See docs note in RecentActivity.tsx for where a
 // backend `group_id` would replace this heuristic.
 
+import { toDateOnlyIso } from '@/lib/formatDate'
+
 export interface ActivityCluster<T> {
   /** Cluster members, preserving the input (newest-first) order. */
   items: T[]
@@ -78,7 +80,7 @@ export function sectionByDay<T>(
   const byKey = new Map<string, DaySection<T>>()
   for (const item of items) {
     const day = new Date(options.timeOf(item))
-    const key = dayKey(day)
+    const key = toDateOnlyIso(day)
     let section = byKey.get(key)
     if (!section) {
       section = { clusters: [], key, label: dayLabel(day, now) }
@@ -97,18 +99,12 @@ export function sectionByDay<T>(
   return sections
 }
 
-function dayKey(d: Date): string {
-  const m = `${d.getMonth() + 1}`.padStart(2, '0')
-  const day = `${d.getDate()}`.padStart(2, '0')
-  return `${d.getFullYear()}-${m}-${day}`
-}
-
 function dayLabel(d: Date, now: number): string {
   const today = new Date(now)
-  if (dayKey(d) === dayKey(today)) return 'Today'
+  if (toDateOnlyIso(d) === toDateOnlyIso(today)) return 'Today'
   const yesterday = new Date(now)
   yesterday.setDate(yesterday.getDate() - 1)
-  if (dayKey(d) === dayKey(yesterday)) return 'Yesterday'
+  if (toDateOnlyIso(d) === toDateOnlyIso(yesterday)) return 'Yesterday'
   return d.toLocaleDateString(undefined, {
     day: 'numeric',
     month: 'short',

--- a/ui/src/components/admin/WebhookHistoryRow.tsx
+++ b/ui/src/components/admin/WebhookHistoryRow.tsx
@@ -7,6 +7,7 @@ import { CheckCircle2, Clipboard, ClockIcon, XCircle } from 'lucide-react'
 import type { EventHandlerOutcome, EventRecord } from '@/api/endpoints'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
+import { formatDateTime } from '@/lib/formatDate'
 
 interface DispositionMeta {
   label: string
@@ -63,7 +64,7 @@ export function WebhookHistoryRow({
       >
         <ClockIcon className="text-tertiary size-4" />
         <span className="text-secondary text-sm tabular-nums">
-          {new Date(event.recorded_at).toLocaleString()}
+          {formatDateTime(event.recorded_at)}
         </span>
         <Badge variant="secondary">{event.integration}</Badge>
         <span className="text-primary text-sm font-medium">

--- a/ui/src/components/documents/DocumentsFeed.tsx
+++ b/ui/src/components/documents/DocumentsFeed.tsx
@@ -2,6 +2,7 @@ import { FileText, FolderKanban, MessageSquare, Pin } from 'lucide-react'
 
 import { Card } from '@/components/ui/card'
 import { UserIdentity } from '@/components/ui/user-identity'
+import { parseServerTs } from '@/lib/formatDate'
 import type { Document } from '@/types'
 
 import {
@@ -141,7 +142,7 @@ function FeedCard({
 function feedDate(document: Document): string {
   const iso = document.updated_at ?? document.created_at
   try {
-    return new Date(iso).toLocaleDateString(undefined, {
+    return parseServerTs(iso).toLocaleDateString(undefined, {
       day: 'numeric',
       month: 'short',
       year: 'numeric',

--- a/ui/src/components/documents/documentsHelpers.ts
+++ b/ui/src/components/documents/documentsHelpers.ts
@@ -1,4 +1,5 @@
 import { LABEL_SWATCHES } from '@/lib/chip-colors'
+import { parseServerTs } from '@/lib/formatDate'
 import type { Document, DocumentTemplate, TagRef } from '@/types'
 
 /**
@@ -70,7 +71,7 @@ export function documentTitle(document: Document): string {
 export function formatFull(iso: null | string | undefined): string {
   if (!iso) return ''
   try {
-    return new Date(iso).toLocaleString(undefined, {
+    return parseServerTs(iso).toLocaleString(undefined, {
       dateStyle: 'medium',
       timeStyle: 'short',
     })
@@ -86,7 +87,7 @@ export function formatUpdated(document: Document): string {
 
 function relativeShort(iso: null | string | undefined): string {
   if (!iso) return ''
-  const then = new Date(iso).getTime()
+  const then = parseServerTs(iso).getTime()
   if (!Number.isFinite(then)) return ''
   const diff = Date.now() - then
   const m = Math.round(diff / 60000)
@@ -98,7 +99,7 @@ function relativeShort(iso: null | string | undefined): string {
   if (d < 14) return `${d}d ago`
   const w = Math.round(d / 7)
   if (w < 8) return `${w}w ago`
-  return new Date(iso).toLocaleDateString(undefined, {
+  return parseServerTs(iso).toLocaleDateString(undefined, {
     day: 'numeric',
     month: 'short',
   })

--- a/ui/src/components/operations-log/OperationsLogEntryDetails.tsx
+++ b/ui/src/components/operations-log/OperationsLogEntryDetails.tsx
@@ -20,6 +20,7 @@ import {
   TooltipTrigger,
 } from '@/components/ui/tooltip'
 import { UserIdentity } from '@/components/ui/user-identity'
+import { parseServerTs } from '@/lib/formatDate'
 import type { OperationsLogRecord } from '@/types'
 
 import { parseDescription } from './parseDescription'
@@ -197,7 +198,7 @@ function cleanNotes(notes: string): string {
 
 function formatAbsolute(iso: string): string {
   try {
-    return parseUtcIso(iso).toLocaleString(undefined, {
+    return parseServerTs(iso).toLocaleString(undefined, {
       dateStyle: 'medium',
       timeStyle: 'short',
     })
@@ -221,9 +222,4 @@ function MetaChip({
       <span className="text-primary">{children}</span>
     </span>
   )
-}
-
-function parseUtcIso(iso: string): Date {
-  const hasOffset = /(Z|[+-]\d\d:?\d\d)$/.test(iso)
-  return new Date(hasOffset ? iso : iso + 'Z')
 }

--- a/ui/src/components/operations-log/__tests__/opsLogHelpers.test.ts
+++ b/ui/src/components/operations-log/__tests__/opsLogHelpers.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest'
 
 import type { OperationsLogRecord } from '@/types'
 
-import { groupReleases } from '../opsLogHelpers'
+import { bucketByDay, type FeedItem, groupReleases } from '../opsLogHelpers'
 
 const SHA = 'c67213d'
 
@@ -208,5 +208,44 @@ describe('groupReleases', () => {
       makeEntry({ id: 'other', project_slug: 'messages-client' }),
     ])
     expect(items).toHaveLength(2)
+  })
+})
+
+// bucketByDay used to call a local parseUtcIso() stub that was a plain
+// `new Date(iso)`, so an offset-less timestamp landed in the viewer's zone
+// and could bucket under the wrong day. Both spellings must agree.
+describe('bucketByDay', () => {
+  const NOON_UTC = Date.UTC(2026, 6, 29, 12, 0, 0)
+
+  function single(occurredAt: string): FeedItem {
+    return { entry: makeEntry({ occurred_at: occurredAt }), kind: 'single' }
+  }
+
+  it('reads a naive occurred_at as UTC', () => {
+    const naive = bucketByDay([single('2026-07-29T12:00:00')], NOON_UTC)
+    const explicit = bucketByDay([single('2026-07-29T12:00:00Z')], NOON_UTC)
+    expect(naive[0].key).toBe(explicit[0].key)
+    expect(naive[0].date.getTime()).toBe(explicit[0].date.getTime())
+  })
+
+  it('labels the current local day Today', () => {
+    const now = new Date(2026, 6, 29, 12, 0, 0)
+    const iso = new Date(2026, 6, 29, 9, 0, 0).toISOString()
+    const buckets = bucketByDay([single(iso)], now.getTime())
+    expect(buckets[0].label).toBe('Today')
+  })
+
+  it('splits entries that fall on different local days', () => {
+    const now = new Date(2026, 6, 29, 12, 0, 0)
+    const buckets = bucketByDay(
+      [
+        single(new Date(2026, 6, 29, 9, 0, 0).toISOString()),
+        single(new Date(2026, 6, 28, 9, 0, 0).toISOString()),
+      ],
+      now.getTime(),
+    )
+    expect(buckets).toHaveLength(2)
+    expect(buckets[0].label).toBe('Today')
+    expect(buckets[1].label).toBe('Yesterday')
   })
 })

--- a/ui/src/components/operations-log/opsLogHelpers.ts
+++ b/ui/src/components/operations-log/opsLogHelpers.ts
@@ -1,4 +1,4 @@
-import { absTime } from '@/lib/formatDate'
+import { absTime, parseServerTs } from '@/lib/formatDate'
 import type { OperationsLogRecord } from '@/types'
 
 export { absTime }
@@ -70,7 +70,7 @@ export function bucketByDay(
       it.kind === 'release'
         ? it.group.latestEntry.occurred_at
         : it.entry.occurred_at
-    const dk = dayKeyFromDate(parseUtcIso(iso), todayMs)
+    const dk = dayKeyFromDate(parseServerTs(iso), todayMs)
     if (!current || current.key !== dk.key) {
       current = { date: dk.date, items: [], key: dk.key, label: dk.label }
       buckets.push(current)
@@ -255,8 +255,4 @@ function mergeBuckets(
     if (bucket === drop) byKey.set(key, keep)
   }
   return keep
-}
-
-function parseUtcIso(iso: string): Date {
-  return new Date(iso)
 }

--- a/ui/src/components/project/ConfigurationTab.tsx
+++ b/ui/src/components/project/ConfigurationTab.tsx
@@ -42,6 +42,7 @@ import { Sk } from '@/components/ui/skeleton'
 import { useTheme } from '@/contexts/ThemeContext'
 import { extractApiErrorDetail } from '@/lib/apiError'
 import { deriveChipColors } from '@/lib/chip-colors'
+import { parseServerTs } from '@/lib/formatDate'
 import { cn, sortEnvironments } from '@/lib/utils'
 import type { ConfigKeyResponse, Environment } from '@/types'
 
@@ -1014,7 +1015,7 @@ function DetailPane({
             {selected?.last_modified && (
               <span className="text-tertiary text-xs">
                 Last modified{' '}
-                {new Date(selected.last_modified).toLocaleString()}
+                {parseServerTs(selected.last_modified).toLocaleString()}
               </span>
             )}
           </>

--- a/ui/src/components/project/IncidentsTab.tsx
+++ b/ui/src/components/project/IncidentsTab.tsx
@@ -10,6 +10,7 @@ import {
   SegmentedControlItem,
 } from '@/components/ui/segmented-control'
 import { Sk } from '@/components/ui/skeleton'
+import { formatDateTime } from '@/lib/formatDate'
 import type { IncidentView } from '@/types'
 
 interface IncidentsTabProps {
@@ -177,12 +178,6 @@ export function IncidentsTab({ orgSlug, projectId }: IncidentsTabProps) {
   )
 }
 
-function formatTimestamp(value: null | string | undefined): string {
-  if (!value) return '—'
-  const date = new Date(value)
-  return Number.isNaN(date.getTime()) ? '—' : date.toLocaleString()
-}
-
 // fallow-ignore-next-line complexity
 function IncidentRow({ incident }: { incident: IncidentView }) {
   return (
@@ -207,10 +202,10 @@ function IncidentRow({ incident }: { incident: IncidentView }) {
         {incident.urgency ?? '—'}
       </td>
       <td className="text-muted-foreground px-3 py-2">
-        {formatTimestamp(incident.created_at)}
+        {formatDateTime(incident.created_at)}
       </td>
       <td className="text-muted-foreground px-3 py-2">
-        {formatTimestamp(incident.resolved_at)}
+        {formatDateTime(incident.resolved_at)}
       </td>
     </tr>
   )

--- a/ui/src/components/reports/ScoreHistoryReport.tsx
+++ b/ui/src/components/reports/ScoreHistoryReport.tsx
@@ -20,6 +20,7 @@ import {
 } from '@/api/endpoints'
 import { Sk } from '@/components/ui/skeleton'
 import { useOrganization } from '@/contexts/OrganizationContext'
+import { parseServerTs, toDateOnlyIso } from '@/lib/formatDate'
 import { Team } from '@/types'
 
 interface ChartSeries {
@@ -196,24 +197,16 @@ function DeltaBadge({ delta }: { delta: number }) {
 }
 
 function fmtDate(iso: string): string {
-  const d = new Date(toUtc(iso))
-  return d.toLocaleString('en-US', {
+  const d = parseServerTs(iso)
+  return d.toLocaleString(undefined, {
     day: 'numeric',
     month: 'short',
     year: 'numeric',
   })
 }
 
-function fmtISODate(iso: string): string {
-  const d = new Date(toUtc(iso))
-  const y = d.getFullYear()
-  const m = String(d.getMonth() + 1).padStart(2, '0')
-  const day = String(d.getDate()).padStart(2, '0')
-  return `${y}-${m}-${day}`
-}
-
 function fmtRel(iso: string): string {
-  const ms = Date.now() - new Date(toUtc(iso)).getTime()
+  const ms = Date.now() - parseServerTs(iso).getTime()
   const min = Math.round(ms / 60000)
   if (min < 60) return `${min}m ago`
   const hr = Math.round(min / 60)
@@ -264,7 +257,7 @@ function GlobalEventFeed({
                 {fmtRel(e.timestamp)}
               </div>
               <div className="text-tertiary mt-0.5 font-mono text-[11px]">
-                {fmtISODate(e.timestamp)}
+                {toDateOnlyIso(parseServerTs(e.timestamp))}
               </div>
             </div>
 
@@ -336,22 +329,20 @@ function MultiLineChart({ series }: { series: ChartSeries[] }) {
 
   const minTsMs = useMemo(
     () =>
-      allTimestamps.length > 0
-        ? new Date(toUtc(allTimestamps[0])).getTime()
-        : 0,
+      allTimestamps.length > 0 ? parseServerTs(allTimestamps[0]).getTime() : 0,
     [allTimestamps],
   )
   const maxTsMs = useMemo(
     () =>
       allTimestamps.length > 0
-        ? new Date(toUtc(allTimestamps[allTimestamps.length - 1])).getTime()
+        ? parseServerTs(allTimestamps[allTimestamps.length - 1]).getTime()
         : 1,
     [allTimestamps],
   )
   const tsRangeMs = maxTsMs - minTsMs || 1
 
   const xForTs = (ts: string) => {
-    const t = new Date(toUtc(ts)).getTime()
+    const t = parseServerTs(ts).getTime()
     return padL + ((t - minTsMs) / tsRangeMs) * innerW
   }
 
@@ -693,10 +684,6 @@ function Segmented({
       ))}
     </div>
   )
-}
-
-function toUtc(iso: string): string {
-  return /[Z+]|\d{2}:\d{2}$/.test(iso) ? iso : iso + 'Z'
 }
 
 const REASON_META: Record<

--- a/ui/src/components/reports/TeamKPIReport.tsx
+++ b/ui/src/components/reports/TeamKPIReport.tsx
@@ -6,6 +6,7 @@ import { RefreshCw } from 'lucide-react'
 import { getScoreRollup, listTeams, ScoreRollupRow } from '@/api/endpoints'
 import { Sk } from '@/components/ui/skeleton'
 import { useOrganization } from '@/contexts/OrganizationContext'
+import { parseServerTs } from '@/lib/formatDate'
 import { Team } from '@/types'
 
 interface BarChartProps {
@@ -210,8 +211,7 @@ export function TeamKPIReport() {
 
 function fmtRelative(iso: null | string): string {
   if (!iso) return '—'
-  const ms =
-    Date.now() - new Date(iso.endsWith('Z') ? iso : iso + 'Z').getTime()
+  const ms = Date.now() - parseServerTs(iso).getTime()
   const min = Math.round(ms / 60000)
   if (min < 60) return `${min}m ago`
   const hr = Math.round(min / 60)

--- a/ui/src/components/settings/SettingsConnections.tsx
+++ b/ui/src/components/settings/SettingsConnections.tsx
@@ -29,6 +29,7 @@ import { useOrganization } from '@/contexts/OrganizationContext'
 import type { ConnectableIdentity } from '@/hooks/useConnectableIdentities'
 import { useConnectableIdentities } from '@/hooks/useConnectableIdentities'
 import { extractApiErrorDetail } from '@/lib/apiError'
+import { formatDateTime } from '@/lib/formatDate'
 import { useIcon } from '@/lib/icons'
 import type {
   IdentityConnectionResponse,
@@ -417,7 +418,7 @@ export function SettingsConnections() {
                       </Badge>
                     </TableCell>
                     <TableCell className="text-secondary text-sm">
-                      {formatRelative(connection?.last_used_at ?? null)}
+                      {formatDateTime(connection?.last_used_at ?? null)}
                     </TableCell>
                     <TableCell className="text-right">
                       <ConnectionActions
@@ -635,13 +636,6 @@ function ConnectionsSkeleton() {
       </Card>
     </div>
   )
-}
-
-function formatRelative(value: null | string): string {
-  if (!value) return '—'
-  const ts = new Date(value)
-  if (Number.isNaN(ts.getTime())) return '—'
-  return ts.toLocaleString()
 }
 
 // The primary label is the integration's name, since that's what tells two

--- a/ui/src/components/ui/RelativeTime.tsx
+++ b/ui/src/components/ui/RelativeTime.tsx
@@ -6,7 +6,12 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from '@/components/ui/tooltip'
-import { absTime, formatRelativeDate, relTime } from '@/lib/formatDate'
+import {
+  absTime,
+  formatRelativeDate,
+  parseServerTs,
+  relTime,
+} from '@/lib/formatDate'
 import { cn } from '@/lib/utils'
 
 interface RelativeTimeProps {
@@ -68,7 +73,7 @@ function formatValue(
   try {
     if (variant === 'narrow') return relTime(value)
     if (variant === 'long') {
-      return formatDistanceToNow(new Date(value), { addSuffix: true })
+      return formatDistanceToNow(parseServerTs(value), { addSuffix: true })
     }
     return formatRelativeDate(
       typeof value === 'number' ? new Date(value).toISOString() : value,

--- a/ui/src/components/ui/attribute-value.tsx
+++ b/ui/src/components/ui/attribute-value.tsx
@@ -7,6 +7,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from '@/components/ui/tooltip'
+import { formatByFormat } from '@/lib/formatDate'
 import { getIcon } from '@/lib/icons'
 import {
   applyDisplayFormat,
@@ -57,9 +58,11 @@ export function AttributeValue({
     : 'text-primary'
 
   const isDate = def?.format === 'date-time' || def?.format === 'date'
+  // A `date` field names a calendar day, so it gets no clock time — and
+  // must not be shifted into the viewer's zone the way `date-time` is.
   const title =
     isDate && rawValue != null
-      ? new Date(String(rawValue)).toLocaleString()
+      ? formatByFormat(String(rawValue), def?.format)
       : undefined
 
   return (

--- a/ui/src/components/ui/inline-edit/InlineDate.tsx
+++ b/ui/src/components/ui/inline-edit/InlineDate.tsx
@@ -9,6 +9,7 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from '@/components/ui/popover'
+import { parseServerTs, toDateOnlyIso } from '@/lib/formatDate'
 
 import { InlineDisplay } from './InlineDisplay'
 
@@ -34,7 +35,10 @@ export function InlineDate({
   value,
 }: InlineDateProps) {
   const [open, setOpen] = useState(false)
-  const current = value ? new Date(value) : undefined
+  // parseServerTs keeps a date-only value on the day it names: DayPicker
+  // works in local time, so parsing "2026-07-29" as UTC midnight would
+  // select (and display) the 28th for any viewer west of Greenwich.
+  const current = value ? parseServerTs(value) : undefined
   const hasValid = !!current && !Number.isNaN(current.getTime())
 
   return (
@@ -73,6 +77,8 @@ export function InlineDate({
 }
 
 function toIso(d: Date, mode: 'date' | 'date-time'): string {
-  if (mode === 'date') return d.toISOString().slice(0, 10)
+  // DayPicker hands back local midnight, so `toISOString()` would roll a
+  // date-only pick to the previous day east of Greenwich.
+  if (mode === 'date') return toDateOnlyIso(d)
   return d.toISOString()
 }

--- a/ui/src/components/ui/inline-edit/__tests__/InlineDate.test.tsx
+++ b/ui/src/components/ui/inline-edit/__tests__/InlineDate.test.tsx
@@ -18,4 +18,39 @@ describe('InlineDate', () => {
       ),
     )
   })
+
+  // A date-only value names a calendar day. Routing it through
+  // toISOString() shifted the day in one direction on display and the
+  // other on commit, so both ends are pinned here.
+  it('displays a date-only value on the day it names', () => {
+    render(<InlineDate mode="date" onCommit={vi.fn()} value="2026-05-10" />)
+    const expected = new Date(2026, 4, 10).toLocaleDateString()
+    expect(screen.getByText(expected)).toBeInTheDocument()
+  })
+
+  it('commits the selected day without shifting it', async () => {
+    const onCommit = vi.fn().mockResolvedValue(undefined)
+    render(<InlineDate mode="date" onCommit={onCommit} value="2026-05-10" />)
+    await userEvent.click(screen.getByText(/2026/))
+    await userEvent.click(await screen.findByRole('button', { name: /15/ }))
+    await waitFor(() => expect(onCommit).toHaveBeenCalledWith('2026-05-15'))
+  })
+
+  it('still commits a full ISO instant in date-time mode', async () => {
+    const onCommit = vi.fn().mockResolvedValue(undefined)
+    render(
+      <InlineDate
+        mode="date-time"
+        onCommit={onCommit}
+        value="2026-05-10T12:00:00Z"
+      />,
+    )
+    await userEvent.click(screen.getByText(/2026/))
+    await userEvent.click(await screen.findByRole('button', { name: /15/ }))
+    await waitFor(() =>
+      expect(onCommit).toHaveBeenCalledWith(
+        expect.stringMatching(/^2026-05-1[45]T.*Z$/),
+      ),
+    )
+  })
 })

--- a/ui/src/lib/__tests__/formatDate.test.ts
+++ b/ui/src/lib/__tests__/formatDate.test.ts
@@ -2,9 +2,13 @@ import { describe, expect, it } from 'vitest'
 
 import {
   absTime,
+  formatByFormat,
   formatDate,
+  formatDateTime,
   formatRelativeDate,
+  parseServerTs,
   relTime,
+  toDateOnlyIso,
 } from '@/lib/formatDate'
 
 // Fixed reference instant so relative-time math stays deterministic
@@ -172,5 +176,144 @@ describe('absTime', () => {
 
   it('returns em-dash for an unparseable input', () => {
     expect(absTime('not-a-date')).toBe('—')
+  })
+})
+
+// The API is not consistent about offsets: ClickHouse-backed endpoints have
+// serialized naive UTC timestamps, and `str(datetime)` adds a space
+// separator. These assert on epoch milliseconds rather than rendered text so
+// they hold in whatever zone CI runs under.
+describe('parseServerTs', () => {
+  const EXPECTED = Date.UTC(2026, 6, 29, 12, 0, 0)
+
+  it('reads a naive timestamp as UTC, not local', () => {
+    expect(parseServerTs('2026-07-29T12:00:00').getTime()).toBe(EXPECTED)
+  })
+
+  it('reads the space-separated form Python str() emits', () => {
+    expect(parseServerTs('2026-07-29 12:00:00').getTime()).toBe(EXPECTED)
+  })
+
+  it('reads naive fractional seconds as UTC', () => {
+    expect(parseServerTs('2026-07-29T12:00:00.500').getTime()).toBe(
+      EXPECTED + 500,
+    )
+  })
+
+  it('reads six-digit fractional seconds as UTC', () => {
+    expect(parseServerTs('2026-07-29 12:00:00.500000').getTime()).toBe(
+      EXPECTED + 500,
+    )
+  })
+
+  it('honours an explicit Z', () => {
+    expect(parseServerTs('2026-07-29T12:00:00Z').getTime()).toBe(EXPECTED)
+  })
+
+  it('honours an explicit +00:00 offset', () => {
+    expect(parseServerTs('2026-07-29T12:00:00+00:00').getTime()).toBe(EXPECTED)
+  })
+
+  it('honours a non-UTC offset', () => {
+    expect(parseServerTs('2026-07-29T08:00:00-04:00').getTime()).toBe(EXPECTED)
+  })
+
+  it('honours a colon-less offset', () => {
+    expect(parseServerTs('2026-07-29T08:00:00-0400').getTime()).toBe(EXPECTED)
+  })
+
+  it('passes a millisecond timestamp straight through', () => {
+    expect(parseServerTs(EXPECTED).getTime()).toBe(EXPECTED)
+  })
+
+  // A date-only value names a calendar day, so it must anchor to local
+  // midnight — parsing it as UTC midnight renders the previous day for any
+  // viewer west of Greenwich.
+  it('anchors a date-only value at local midnight', () => {
+    const d = parseServerTs('2026-07-29')
+    expect(d.getFullYear()).toBe(2026)
+    expect(d.getMonth()).toBe(6)
+    expect(d.getDate()).toBe(29)
+    expect(d.getHours()).toBe(0)
+  })
+
+  it('yields an invalid date for unparseable input', () => {
+    expect(Number.isNaN(parseServerTs('not-a-date').getTime())).toBe(true)
+  })
+})
+
+describe('toDateOnlyIso', () => {
+  it('uses local calendar fields, not UTC ones', () => {
+    expect(toDateOnlyIso(new Date(2026, 6, 29, 23, 30))).toBe('2026-07-29')
+  })
+
+  it('zero-pads month and day', () => {
+    expect(toDateOnlyIso(new Date(2026, 0, 5))).toBe('2026-01-05')
+  })
+
+  // The round trip is what the InlineDate editor does: display a stored
+  // date-only value, then write back whatever day the picker returns.
+  it('round-trips a date-only value unchanged', () => {
+    expect(toDateOnlyIso(parseServerTs('2026-07-29'))).toBe('2026-07-29')
+  })
+})
+
+describe('formatDate with a date-only value', () => {
+  it('renders the day it names rather than shifting a day', () => {
+    expect(formatDate('2026-07-29')).toBe(
+      new Date(2026, 6, 29).toLocaleDateString(undefined, {
+        day: 'numeric',
+        month: 'short',
+        year: 'numeric',
+      }),
+    )
+  })
+
+  it('returns the fallback for unparseable input', () => {
+    expect(formatDate('not-a-date')).toBe('—')
+  })
+})
+
+describe('formatDateTime', () => {
+  it('treats a naive timestamp as UTC', () => {
+    expect(formatDateTime('2026-07-29T12:00:00')).toBe(
+      formatDateTime('2026-07-29T12:00:00Z'),
+    )
+  })
+
+  it('returns the fallback for unparseable input', () => {
+    expect(formatDateTime('not-a-date')).toBe('—')
+  })
+})
+
+describe('formatByFormat', () => {
+  it('renders a date-only field with no clock time', () => {
+    expect(formatByFormat('2026-07-29', 'date')).toBe(formatDate('2026-07-29'))
+  })
+
+  it('renders a date-time field with a clock time', () => {
+    expect(formatByFormat('2026-07-29T12:00:00Z', 'date-time')).toBe(
+      formatDateTime('2026-07-29T12:00:00Z'),
+    )
+  })
+
+  it('defaults to date-time when the format is unknown', () => {
+    expect(formatByFormat('2026-07-29T12:00:00Z')).toBe(
+      formatDateTime('2026-07-29T12:00:00Z'),
+    )
+  })
+})
+
+describe('relTime with server timestamps', () => {
+  it('treats a naive timestamp as UTC', () => {
+    const now = Date.UTC(2026, 6, 29, 14, 0, 0)
+    expect(relTime('2026-07-29T12:00:00', now)).toBe('2h')
+  })
+
+  it('agrees with the Z-suffixed form', () => {
+    const now = Date.UTC(2026, 6, 29, 14, 0, 0)
+    expect(relTime('2026-07-29 12:00:00', now)).toBe(
+      relTime('2026-07-29T12:00:00Z', now),
+    )
   })
 })

--- a/ui/src/lib/formatDate.ts
+++ b/ui/src/lib/formatDate.ts
@@ -5,13 +5,19 @@ interface DateFormatOptions {
   month?: 'long' | 'short'
 }
 
+/** A bare calendar date with no time component: "2026-07-29". */
+const DATE_ONLY_RE = /^\d{4}-\d{2}-\d{2}$/
+
+/** A trailing UTC designator or numeric offset: "Z", "+00:00", "-0500". */
+const HAS_OFFSET_RE = /(Z|[+-]\d{2}:?\d{2})$/i
+
 /**
  * Full absolute timestamp for tooltip reveals: "Jan 15, 2025, 3:45 PM".
  * Accepts an ISO string or millisecond timestamp.
  */
 export function absTime(iso: number | string): string {
   try {
-    const d = new Date(iso)
+    const d = parseServerTs(iso)
     if (!Number.isFinite(d.getTime())) return '—'
     return d.toLocaleString(undefined, {
       day: 'numeric',
@@ -26,6 +32,18 @@ export function absTime(iso: number | string): string {
 }
 
 /**
+ * Format a value by its schema format: `date` renders as a calendar date
+ * with no time, `date-time` as a localized date + time. Keeps date-only
+ * fields from being shifted a day by timezone conversion.
+ */
+export function formatByFormat(
+  value?: null | string,
+  format?: null | string,
+): string {
+  return format === 'date' ? formatDate(value) : formatDateTime(value)
+}
+
+/**
  * Format an ISO date string as a localized short date.
  * Returns the configured fallback (default '—') for null/undefined/invalid.
  */
@@ -35,7 +53,9 @@ export function formatDate(
 ): string {
   if (!dateString) return fallback
   try {
-    return new Date(dateString).toLocaleDateString(undefined, {
+    const d = parseServerTs(dateString)
+    if (!Number.isFinite(d.getTime())) return fallback
+    return d.toLocaleDateString(undefined, {
       day: 'numeric',
       month,
       year: 'numeric',
@@ -56,7 +76,9 @@ export function formatDateTime(
 ): string {
   if (!dateString) return fallback
   try {
-    return new Date(dateString).toLocaleString(undefined, {
+    const d = parseServerTs(dateString)
+    if (!Number.isFinite(d.getTime())) return fallback
+    return d.toLocaleString(undefined, {
       day: 'numeric',
       hour: '2-digit',
       minute: '2-digit',
@@ -83,6 +105,29 @@ export function formatRelativeDate(dateString?: null | string): string {
 }
 
 /**
+ * Parse a timestamp as the API means it, not as `new Date()` guesses.
+ *
+ * ClickHouse DateTime64 columns hold UTC but some endpoints serialize
+ * them without an offset — "2026-07-29T12:00:00", or the space-separated
+ * "2026-07-29 12:00:00" that Python's `str(datetime)` emits. `new Date()`
+ * reads a bare timestamp as *local*, shifting it by the viewer's UTC
+ * offset, so a missing offset is treated as UTC here.
+ *
+ * Date-only values are the opposite case: they name a calendar day, not
+ * an instant, so they parse to local midnight. Reading "2026-07-29" as
+ * UTC midnight would render it as the 28th anywhere west of Greenwich.
+ */
+export function parseServerTs(value: number | string): Date {
+  if (typeof value === 'number') return new Date(value)
+  const raw = value.trim()
+  // A date-time form with no offset is spec-mandated to parse as local,
+  // which is exactly what a calendar day should mean.
+  if (DATE_ONLY_RE.test(raw)) return new Date(`${raw}T00:00:00`)
+  const iso = raw.replace(' ', 'T')
+  return new Date(HAS_OFFSET_RE.test(iso) ? iso : `${iso}Z`)
+}
+
+/**
  * Compact relative time for dense UI: "3m", "2h", "5d", "2w", "3mo", "1y".
  * Accepts an ISO string or millisecond timestamp.
  */
@@ -91,7 +136,7 @@ export function relTime(
   iso: number | string,
   now: number = Date.now(),
 ): string {
-  const t = typeof iso === 'number' ? iso : Date.parse(iso)
+  const t = parseServerTs(iso).getTime()
   if (!Number.isFinite(t)) return 'now'
   const diff = Math.max(0, now - t)
   const m = Math.floor(diff / 60_000)
@@ -104,4 +149,14 @@ export function relTime(
   if (d < 30) return `${Math.floor(d / 7)}w`
   if (d < 365) return `${Math.floor(d / 30)}mo`
   return `${Math.floor(d / 365)}y`
+}
+
+/**
+ * Render a `Date` as a "YYYY-MM-DD" calendar date using its *local*
+ * fields. Use for date-only API values; `toISOString().slice(0, 10)`
+ * would shift the day for any non-UTC viewer.
+ */
+export function toDateOnlyIso(date: Date): string {
+  const pad = (n: number) => String(n).padStart(2, '0')
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}`
 }

--- a/ui/src/lib/project-field-formatting.ts
+++ b/ui/src/lib/project-field-formatting.ts
@@ -1,6 +1,7 @@
 import { formatDistanceToNow } from 'date-fns'
 
 import type { ProjectSchemaSection } from '@/api/endpoints'
+import { parseServerTs } from '@/lib/formatDate'
 import type { Project } from '@/types'
 
 export const COLOR_TEXT: Record<string, string> = {
@@ -103,9 +104,11 @@ export function formatFieldValue(
     return raw === 'true' ? 'True' : 'False'
   }
 
-  // Dates and datetimes — display as relative time
+  // Dates and datetimes — display as relative time. parseServerTs anchors
+  // a date-only value at local midnight rather than UTC midnight, so the
+  // relative reading no longer swings by the viewer's offset.
   if (format === 'date-time' || format === 'date') {
-    const d = new Date(raw)
+    const d = parseServerTs(raw)
     if (!isNaN(d.getTime())) {
       return formatDistanceToNow(d, { addSuffix: true })
     }

--- a/ui/src/lib/ui-maps.ts
+++ b/ui/src/lib/ui-maps.ts
@@ -18,6 +18,8 @@ interface ThresholdEntry {
 
 type ThresholdMap = Record<string, string>
 
+import { parseServerTs } from '@/lib/formatDate'
+
 const OP_REGEX = /^(>=|>|<=|<|==)\s*(.+)$/
 
 const DURATION_UNITS: Record<string, number> = {
@@ -160,7 +162,7 @@ function parseThresholds(
  */
 function resolveAge(map: ThresholdMap, rawValue: unknown): string | undefined {
   if (rawValue == null) return undefined
-  const date = new Date(String(rawValue))
+  const date = parseServerTs(String(rawValue))
   if (isNaN(date.getTime())) return undefined
   const elapsedSeconds = (Date.now() - date.getTime()) / 1000
   const entries = parseThresholds(map, parseDuration)


### PR DESCRIPTION
## Summary

Timestamps are now rendered in the viewer's timezone everywhere in the UI. Previously several surfaces were off by the viewer's UTC offset, and date-only fields rendered — and saved — the wrong calendar day.

## Problem

Two defect classes, pulling in opposite directions.

**Under-coercion.** ClickHouse's driver returns *naive* `datetime` objects even for columns declared `DateTime64(3, 'UTC')`. Verified against a live instance:

```
SELECT toDateTime64('2026-04-01 12:00:00', 3, 'UTC') AS tz_col,
       toDateTime64('2026-04-01 12:00:00', 3)        AS bare_col

tz_col    type=datetime  tzinfo=None  str()='2026-04-01 12:00:00'
bare_col  type=datetime  tzinfo=None  str()='2026-04-01 12:00:00'
```

Endpoints that serialized those values without attaching `tzinfo` emitted `2026-04-01T12:00:00` with no offset. `new Date()` reads a bare timestamp as **local**, so every rendered value shifted by the viewer's offset — four hours in US Eastern.

**Over-coercion.** Date-only values (`YYYY-MM-DD`) went through `new Date()` + `toLocale*`, which reads them as UTC midnight and then converts to local. `2026-07-29` rendered as `7/28/2026` in US Eastern; on write, picking Jul 29 in Tokyo saved `2026-07-28`.

Three of the four UI helpers written to work around this were themselves broken:

- Both copies of `toUtc` used `/[Z+]|\d{2}:\d{2}$/`, which matches the trailing `00:00` of `2026-07-29T12:00:00` — so it appended nothing and was a no-op for exactly the input it existed to fix.
- `opsLogHelpers`' `parseUtcIso` was a stub (`return new Date(iso)`) shadowing the one correct implementation of the same name.
- `TeamKPIReport`'s `endsWith('Z')` variant appended `Z` to a real `-04:00` offset, producing an Invalid Date and rendering `"NaN m ago"`.

## Solution

**API — attach UTC before serializing.** Added `as_utc` / `as_utc_or_none` / `iso_utc` to `imbi.common.clickhouse`, then applied them where naive values reached the wire:

- `scoring.py` rendered timestamps with `str(naive)`, dropping the offset *and* emitting a space separator (`2026-04-01 12:00:00`) that `Date.parse` is not required to accept — V8 tolerates it, JSC is not guaranteed to.
- `project_deployments.py` (`authored_at`, `latest_tag_at`, `published_at`) and `projects.py` (`head_authored_at`, `latest_tag_at`) passed naive datetimes straight into Pydantic `datetime` fields.

**UI — parse timestamps as the API means them.** Added `parseServerTs` to `lib/formatDate.ts`: a missing offset is treated as UTC, the space-separated form is accepted, and a date-only value anchors at *local* midnight (it names a calendar day, not an instant). `absTime` / `formatDate` / `formatDateTime` / `relTime` all route through it, so the fix reaches every existing caller.

Then the cleanup that follows from having one helper: four ad-hoc coercion copies deleted, and three `dayKey` implementations collapsed onto `toDateOnlyIso` — one used `toISOString()`, so activity day headers and the `TODAY` label flipped at UTC midnight rather than local. Date-only handling fixed in `InlineDate` (display *and* commit), `attribute-value`, `project-field-formatting` and `ui-maps`.

## Impact

**User-visible.** Score history charts, operations-log day grouping, project activity day headers, the projects-list release summary, and recent-commit and release dates all now show the viewer's local time. Date-only project fields show the day they name.

**Two behaviour changes worth flagging to reviewers:**

1. Timestamps that were previously displayed shifted will now move by the viewer's UTC offset. That is the fix, but screenshots and any saved expectations will differ.
2. Four date formatters had a hardcoded `'en-US'` locale and now pass `undefined` (browser locale), matching the rest of the codebase. This alters rendered output for non-en-US viewers. It rode along with the timezone work; happy to split it out if you'd rather.

`LogsTab` is deliberately left all-UTC — it is internally consistent and its range label says `UTC`. Whether to keep that or make it local is an open question, not addressed here.

**No schema, migration, or API-contract changes.** Response fields gain a UTC offset where they previously had none; every UI consumer already parses through `parseServerTs`, which handles both spellings.

## Testing

`moon ci` green: **4911 Python tests**, **626 UI tests**, 89% coverage, lint/format/typecheck clean.

36 regression tests added. Each was confirmed to fail against the pre-fix code (9 UI and 7 API initially, plus 4 more for the `projects.py` case) rather than merely passing after it. UI assertions are epoch-based where possible, and the suite passes under `TZ=UTC`, `America/New_York`, `Asia/Tokyo` and `Pacific/Kiritimati` — UTC-14 through UTC+14.

## Follow-up (not in this PR)

The naive→UTC coercion is now hand-rolled in seven endpoints, three of them behind *field allowlists* — so a newly-selected timestamp column is uncoerced by default. That is precisely the mechanism that hid the `projects.py` case until review caught it. Moving the coercion into `clickhouse.query()`, the single funnel every read passes through, would retire all seven (roughly +5/−60 lines).

Two supporting facts, from reading the driver rather than running it: `format_query_value` does `astimezone(server_tz)` then `strftime`, so re-binding an already-UTC read value as a query param is a no-op and sub-second precision was already dropped for naive values; and there is no naive `now()` anywhere in `apps/api` or `libraries/common` to collide with. Worth pairing with retyping the four `str`-typed scoring timestamp fields as `datetime`, which would delete the `_ts` adapter and remove the two wire spellings this PR currently produces (`...Z` from Pydantic vs `...+00:00` from `iso_utc` — both parse identically in the browser, so cosmetic).

Held back because it changes every ClickHouse read across seven files of working code, which deserves its own review.
