### PR TITLE
Create repos at a visibility the org allows

### DIFF
--- a/plugins/github/src/imbi/plugins/github/README.md
+++ b/plugins/github/src/imbi/plugins/github/README.md
@@ -109,6 +109,7 @@ Scoped to one capability and delivered on
 | `lifecycle` | `archive_target_org` | Org to transfer repos to before archiving; blank archives in place.                     |
 | `lifecycle` | `create_org`         | Default org for repo creation when no `org_mapping` entry matches.                       |
 | `lifecycle` | `org_mapping`        | Per-project-type-slug org overrides; the first match wins over `create_org`.             |
+| `lifecycle` | `create_visibility`  | Visibility for created repos: `private`, `internal`, or `public`. Blank follows the flavor — `internal` for `ghec`/`ghes`, `public` for `github`. |
 
 ## Credentials
 

--- a/plugins/github/src/imbi/plugins/github/lifecycle.py
+++ b/plugins/github/src/imbi/plugins/github/lifecycle.py
@@ -75,6 +75,39 @@ _HTTP_TIMEOUT_SECONDS = 10.0
 # hanging the operator's archive request.
 _TRANSFER_ARCHIVE_BACKOFFS: tuple[float, ...] = (0.5, 1.0, 2.0)
 
+# Visibilities accepted by the ``create_visibility`` option.  ``internal``
+# is only meaningful on a GHEC tenant or GHES appliance.
+_VISIBILITIES = frozenset({'private', 'internal', 'public'})
+
+
+def _error_detail(response: httpx.Response) -> str:
+    """Flatten a GitHub error body into one operator-facing string.
+
+    Keeps the top-level ``message`` and each entry of the ``errors``
+    array (``field: message``) so a validation failure names the field
+    that GitHub rejected.
+    """
+    try:
+        body = response.json()
+    except ValueError:
+        body = None
+    if not isinstance(body, dict):
+        return f'HTTP {response.status_code}: {response.text[:200]}'
+    payload = typing.cast(dict[str, object], body)
+    parts = [str(payload.get('message') or f'HTTP {response.status_code}')]
+    errors = payload.get('errors')
+    if isinstance(errors, list):
+        for item in typing.cast(list[object], errors):
+            if not isinstance(item, dict):
+                continue
+            entry = typing.cast(dict[str, object], item)
+            text = entry.get('message') or entry.get('code')
+            if not text:
+                continue
+            field = entry.get('field')
+            parts.append(f'{field}: {text}' if field else str(text))
+    return ' - '.join(parts)
+
 
 async def _raise_on_401(response: httpx.Response) -> None:
     """Convert a 401 from GitHub into :class:`PluginAuthenticationFailed`.
@@ -143,6 +176,35 @@ class GitHubLifecycle(LifecycleCapability):
         if isinstance(raw, str) and raw.strip():
             return raw.strip()
         return None
+
+    @staticmethod
+    def _default_visibility(ctx: PluginContext) -> str:
+        """Pick the create visibility when the option is unset.
+
+        The right default differs per host, so it can't be a manifest
+        constant: enterprise hosts (a GHEC tenant or a GHES appliance)
+        get ``internal`` -- readable across the enterprise, and the only
+        useful non-public choice on orgs that forbid public repos --
+        while github.com has no ``internal`` visibility at all and gets
+        ``public``.  Never *silently* narrower than that on enterprise
+        and never wider on github.com; operators who want something
+        else set ``create_visibility`` explicitly.
+        """
+        flavor = str(ctx.integration_options.get('flavor') or '').strip()
+        return 'public' if flavor == 'github' else 'internal'
+
+    def _resolve_visibility(self, ctx: PluginContext) -> str:
+        """Resolve the visibility new repos are created with.
+
+        An explicit ``create_visibility`` option wins; anything unset or
+        unrecognized falls back to the host-appropriate default rather
+        than inheriting GitHub's create API default of *public*, which
+        an enterprise org that forbids public repos rejects with a 422.
+        """
+        raw = ctx.capability_options.get('create_visibility')
+        if isinstance(raw, str) and raw.strip().lower() in _VISIBILITIES:
+            return raw.strip().lower()
+        return self._default_visibility(ctx)
 
     @staticmethod
     def _resolve_create_org(ctx: PluginContext) -> str | None:
@@ -616,15 +678,31 @@ class GitHubLifecycle(LifecycleCapability):
         org: str,
         ctx: PluginContext,
     ) -> dict[str, typing.Any]:
+        visibility = self._resolve_visibility(ctx)
         resp = await client.post(
             f'/orgs/{org}/repos',
             json={
                 'name': ctx.project_slug,
                 'description': ctx.project_description or '',
                 'homepage': ctx.project_ui_url or '',
+                # ``visibility`` is authoritative where it's supported;
+                # ``private`` rides along so a host that only honors the
+                # older field degrades to private instead of silently
+                # creating a public repo.
+                'visibility': visibility,
+                'private': visibility != 'public',
             },
         )
-        resp.raise_for_status()
+        try:
+            resp.raise_for_status()
+        except httpx.HTTPStatusError as exc:
+            # ``raise_for_status`` reports only the status line, hiding
+            # the ``message``/``errors`` body that says *why* -- e.g. an
+            # org whose policy forbids the requested visibility.
+            raise RuntimeError(
+                f'GitHub refused to create {org}/{ctx.project_slug} with '
+                f'visibility={visibility}: {_error_detail(exc.response)}'
+            ) from exc
         return typing.cast(dict[str, typing.Any], resp.json())
 
     async def _patch_repo_attrs(

--- a/plugins/github/src/imbi/plugins/github/plugin.py
+++ b/plugins/github/src/imbi/plugins/github/plugin.py
@@ -175,6 +175,21 @@ _LIFECYCLE_OPTIONS: list[PluginOption] = [
         required=False,
     ),
     PluginOption(
+        name='create_visibility',
+        label='Visibility for created repos',
+        description=(
+            'Visibility applied to repos created by project creation.  '
+            'Leave blank to follow the Integration flavor: ``internal`` '
+            'on a GHEC tenant or GHES appliance, ``public`` on '
+            'github.com, which has no internal visibility.  Set a value '
+            'to override -- note that an org forbidding public repos '
+            'rejects ``public`` with a 422.'
+        ),
+        type='string',
+        choices=['private', 'internal', 'public'],
+        required=False,
+    ),
+    PluginOption(
         name='org_mapping',
         label='Project-type to org overrides',
         description=(

--- a/plugins/github/tests/test_lifecycle.py
+++ b/plugins/github/tests/test_lifecycle.py
@@ -7,6 +7,7 @@ archived repo, the rename-on-transfer case, repo-resolution failure
 from absent links, and the 401 -> PluginAuthenticationFailed path.
 """
 
+import json
 import unittest
 import unittest.mock
 
@@ -97,6 +98,18 @@ class ManifestTestCase(unittest.TestCase):
         self.assertEqual(opts['create_org'].type, 'string')
         self.assertIn('org_mapping', opts)
         self.assertEqual(opts['org_mapping'].type, 'mapping')
+
+    def test_create_visibility_option_has_no_manifest_default(self) -> None:
+        # The default is flavor-dependent, so it must be resolved by the
+        # handler -- a manifest default gets pre-filled into the stored
+        # options by the admin wizard and would defeat that.
+        opts = {opt.name: opt for opt in _lifecycle_cap().options}
+        self.assertIn('create_visibility', opts)
+        self.assertIsNone(opts['create_visibility'].default)
+        self.assertEqual(
+            opts['create_visibility'].choices,
+            ['private', 'internal', 'public'],
+        )
 
     def test_no_host_option(self) -> None:
         # Host now comes from the Integration's flavor/host options, not a
@@ -826,9 +839,16 @@ class CreateTestCase(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(result.status, 'ok')
         self.assertEqual(create_route.calls.call_count, 1)
         self.assertEqual(
-            create_route.calls.last.request.read(),
-            b'{"name":"demo","description":"An example API",'
-            b'"homepage":"https://imbi.example.com/projects/p"}',
+            json.loads(create_route.calls.last.request.read()),
+            {
+                'name': 'demo',
+                'description': 'An example API',
+                'homepage': 'https://imbi.example.com/projects/p',
+                # ``github`` flavor, no option set -> public, the only
+                # visibility github.com shares with the enterprise hosts.
+                'visibility': 'public',
+                'private': False,
+            },
         )
         self.assertIsNotNone(ctx.link_writeback)
         assert ctx.link_writeback is not None
@@ -866,6 +886,126 @@ class CreateTestCase(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(result.status, 'ok')
         self.assertEqual(create_route.calls.call_count, 1)
+
+    @respx.mock
+    async def test_create_honors_configured_visibility(self) -> None:
+        respx.get('https://api.github.com/repos/aweber-apis/demo').mock(
+            return_value=httpx.Response(404, json={'message': 'Not Found'})
+        )
+        create_route = respx.post(
+            'https://api.github.com/orgs/aweber-apis/repos'
+        ).mock(
+            return_value=httpx.Response(
+                201,
+                json={
+                    'name': 'demo',
+                    'html_url': 'https://github.com/aweber-apis/demo',
+                },
+            )
+        )
+        ctx = _ctx(
+            options={
+                'org_mapping': {'api-service': 'aweber-apis'},
+                'create_visibility': 'private',
+            },
+            project_links={},
+            project_type_slugs=['api-service'],
+        )
+        plugin = GitHubLifecycle()
+        result = await plugin.on_project_created(ctx, _CREDS)
+
+        self.assertEqual(result.status, 'ok')
+        body = json.loads(create_route.calls.last.request.read())
+        # The option overrides the ``internal`` default.
+        self.assertEqual(body['visibility'], 'private')
+        self.assertIs(body['private'], True)
+
+    async def _create_on(
+        self, flavor: str, host: str, api_base: str
+    ) -> dict[str, object]:
+        """Run a create against one flavor, returning the POST body."""
+        respx.get(f'{api_base}/repos/aweber-apis/demo').mock(
+            return_value=httpx.Response(404, json={'message': 'Not Found'})
+        )
+        create_route = respx.post(f'{api_base}/orgs/aweber-apis/repos').mock(
+            return_value=httpx.Response(
+                201,
+                json={
+                    'name': 'demo',
+                    'html_url': f'https://{host}/aweber-apis/demo',
+                },
+            )
+        )
+        ctx = _ctx(
+            options={'org_mapping': {'api-service': 'aweber-apis'}},
+            project_links={},
+            project_type_slugs=['api-service'],
+            connection=_connection(flavor, host),
+        )
+        result = await GitHubLifecycle().on_project_created(ctx, _CREDS)
+        self.assertEqual(result.status, 'ok')
+        body: dict[str, object] = json.loads(
+            create_route.calls.last.request.read()
+        )
+        return body
+
+    @respx.mock
+    async def test_create_defaults_to_internal_on_ghec(self) -> None:
+        # An unset option on an enterprise host means ``internal``, not
+        # the ``public`` default that github.com gets.
+        body = await self._create_on(
+            'ghec', 'tenant.ghe.com', 'https://api.tenant.ghe.com'
+        )
+        self.assertEqual(body['visibility'], 'internal')
+        self.assertIs(body['private'], True)
+
+    @respx.mock
+    async def test_create_defaults_to_internal_on_ghes(self) -> None:
+        body = await self._create_on(
+            'ghes', 'github.example.com', 'https://github.example.com/api/v3'
+        )
+        self.assertEqual(body['visibility'], 'internal')
+        self.assertIs(body['private'], True)
+
+    @respx.mock
+    async def test_create_surfaces_github_validation_detail(self) -> None:
+        # A 422 from GitHub (e.g. org policy forbids the visibility) must
+        # name the reason -- ``raise_for_status`` alone hides the body.
+        respx.get('https://api.github.com/repos/aweber-apis/demo').mock(
+            return_value=httpx.Response(404, json={'message': 'Not Found'})
+        )
+        respx.post('https://api.github.com/orgs/aweber-apis/repos').mock(
+            return_value=httpx.Response(
+                422,
+                json={
+                    'message': 'Repository creation failed.',
+                    'errors': [
+                        {
+                            'resource': 'Repository',
+                            'field': 'visibility',
+                            'message': "Visibility can't be public",
+                        }
+                    ],
+                },
+            )
+        )
+        ctx = _ctx(
+            options={
+                'org_mapping': {'api-service': 'aweber-apis'},
+                'create_visibility': 'public',
+            },
+            project_links={},
+            project_type_slugs=['api-service'],
+        )
+        plugin = GitHubLifecycle()
+        with self.assertRaises(RuntimeError) as raised:
+            await plugin.on_project_created(ctx, _CREDS)
+
+        message = str(raised.exception)
+        self.assertIn('aweber-apis/demo', message)
+        self.assertIn('visibility=public', message)
+        self.assertIn('Repository creation failed.', message)
+        self.assertIn("visibility: Visibility can't be public", message)
 
     async def test_create_skips_when_no_target_org_configured(self) -> None:
         # Neither mapping nor template -> clean skip rather than HTTP.


### PR DESCRIPTION
## Summary
Project creation now asks GitHub for a visibility its org actually allows, and a rejected create says why.

## Problem
Creating a project with the GitHub lifecycle plugin failed to create the repo:

```
httpx.HTTPStatusError: Client error '422 Unprocessable Entity' for url
'https://api.aweber.ghe.com/orgs/apis/repos'
```

`_create_repo` POSTed `{name, description, homepage}` with no visibility, so GitHub applied its API default of **public**. The `apis` org — like every AWeber GHE org — forbids that (`members_can_create_public_repositories: false`), so the create was rejected. The traceback was uninformative because `raise_for_status` reports only the status line; GitHub's `message`/`errors` body naming the rejected field was discarded.

## Solution
- Send an explicit visibility on create, defaulting to the Integration's `flavor`: `internal` for a GHEC tenant or GHES appliance, `public` for `github.com`, which has no internal visibility. `internal` is the only useful non-public choice on an enterprise org that forbids public repos, and `private` there would hide repos from the rest of the enterprise.
- New `create_visibility` lifecycle option (`private` / `internal` / `public`) overrides the flavor default. It deliberately carries **no** manifest default: the admin wizard pre-fills manifest defaults into the stored capability options (`IntegrationWizard.tsx:511`), which would freeze one visibility across every flavor.
- Send `private` alongside `visibility` so a host that honors only the older field degrades to private rather than silently creating a public repo.
- New `_error_detail()` flattens GitHub's error body into the raised failure, so the operator sees `GitHub refused to create apis/demo with visibility=public: Repository creation failed. - visibility: Visibility can't be public` instead of a bare 422.

## Impact
- **Behavior change for existing integrations.** Creates that previously inherited GitHub's public default now get `internal` on GHEC/GHES and `public` on github.com. Integrations wanting something else set `create_visibility` explicitly. Stored options from before this change are blank, so they follow the flavor default.
- github.com orgs that belong to an Enterprise Cloud account do support `internal`; those operators set the option explicitly rather than taking the `public` default.
- Creation only — relocate/transfer and update still leave visibility alone.
- `on_project_created` remains idempotent, so a project whose repo failed to create can be re-driven through the lifecycle sync once this ships.

## Testing
- `uv run --frozen pytest plugins/github/tests` — 314 passed. New coverage: the flavor defaults for `ghec` (`api.tenant.ghe.com`) and `ghes` (`github.example.com/api/v3`), the `github` default, an explicit override, the absent manifest default, and the 422 detail surfacing.
- `moon run github:typecheck` clean; ruff + mypy clean via pre-commit.
- Root cause confirmed against the live host: `GET /orgs/apis` on `aweber.ghe.com` reports `members_can_create_public_repositories: false` with private and internal allowed. Dave verified internal creation works against our GHES.
