### PR TITLE
Link PR references in deployment commit lists

### DIFF
--- a/ui/src/components/deployments/CommitDeployCard.test.tsx
+++ b/ui/src/components/deployments/CommitDeployCard.test.tsx
@@ -141,6 +141,25 @@ describe('CommitDeployCard', () => {
     ).toBeInTheDocument()
   })
 
+  it('links the PR references in a commit subject', () => {
+    setup('bbb2222bbb2222', [
+      {
+        ...commit('aaa1111aaa1111', 'Key identity connections (#172)'),
+        url: 'https://github.com/aweber-imbi/imbi/commit/aaa1111aaa1111',
+      },
+    ])
+    expect(screen.getByRole('link', { name: '#172' })).toHaveAttribute(
+      'href',
+      'https://github.com/aweber-imbi/imbi/pull/172',
+    )
+  })
+
+  it('leaves the subject plain when the commit has no URL', () => {
+    setup('bbb2222bbb2222', [commit('aaa1111aaa1111', 'Key identities (#172)')])
+    expect(screen.queryByRole('link', { name: '#172' })).toBeNull()
+    expect(screen.getByText('Key identities (#172)')).toBeInTheDocument()
+  })
+
   it('prompts for a sync when no commits are synced', () => {
     setup('bbb2222bbb2222', [])
     expect(

--- a/ui/src/components/deployments/CommitDeployCard.tsx
+++ b/ui/src/components/deployments/CommitDeployCard.tsx
@@ -12,6 +12,7 @@ import {
 import { CiStatusDot } from '@/components/releases/CiStatusDot'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
+import { CommitSubject } from '@/components/ui/commit-subject'
 import { RelativeTime } from '@/components/ui/RelativeTime'
 import { UserIdentity } from '@/components/ui/user-identity'
 import type { ChipColors } from '@/lib/chip-colors'
@@ -219,9 +220,11 @@ function CommitRow({
     >
       <span className="shrink-0 font-mono text-xs">{commit.short_sha}</span>
       {isHead ? <Badge variant="outline">HEAD</Badge> : null}
-      <span className="min-w-0 flex-1 truncate text-sm">
-        {commit.message.split('\n')[0]}
-      </span>
+      <CommitSubject
+        className="min-w-0 flex-1 truncate text-sm"
+        commitUrl={commit.url}
+        message={commit.message}
+      />
       {commit.ci_status !== 'unknown' ? (
         <CiStatusDot status={commit.ci_status} />
       ) : null}

--- a/ui/src/components/deployments/PendingReleasesCard.test.tsx
+++ b/ui/src/components/deployments/PendingReleasesCard.test.tsx
@@ -112,13 +112,14 @@ const renderCard = (
   pending: ReleaseHistoryEntry[],
   actions = makeActions(),
   envTag = 'v6.5.0',
+  recentCommits = RECENT_COMMITS,
 ) =>
   render(
     <PendingReleasesCard
       accent={null}
       actions={actions}
       canTrigger
-      recentCommits={RECENT_COMMITS}
+      recentCommits={recentCommits}
       stage={makeStage(pending, envTag)}
     />,
   )
@@ -214,6 +215,26 @@ describe('PendingReleasesCard', () => {
     expect(
       screen.getByRole('button', { name: /Deploy v6\.5\.2 to production/ }),
     ).toBeEnabled()
+  })
+
+  it('links the PR references in the changes list', () => {
+    renderCard(
+      [entry('v6.5.1', 'bbb222bbb222', 'Cache TTL fix')],
+      makeActions(),
+      'v6.5.0',
+      [
+        {
+          ...RECENT_COMMITS[0],
+          message: 'Fix the cache TTL (#82)',
+          url: 'https://github.com/aweber-imbi/imbi/commit/bbb222bbb222',
+        },
+        RECENT_COMMITS[1],
+      ],
+    )
+    expect(screen.getByRole('link', { name: '#82' })).toHaveAttribute(
+      'href',
+      'https://github.com/aweber-imbi/imbi/pull/82',
+    )
   })
 
   it('warns when the pending release ranks below the running one', () => {

--- a/ui/src/components/deployments/PendingReleasesCard.tsx
+++ b/ui/src/components/deployments/PendingReleasesCard.tsx
@@ -14,6 +14,7 @@ import {
 import { CiStatusDot } from '@/components/releases/CiStatusDot'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
+import { CommitSubject } from '@/components/ui/commit-subject'
 import { RelativeTime } from '@/components/ui/RelativeTime'
 import type { ChipColors } from '@/lib/chip-colors'
 import { formatRelativeDate } from '@/lib/formatDate'
@@ -344,9 +345,11 @@ function SingleReleaseChanges({
               key={c.sha}
             >
               <span className="shrink-0 font-mono text-xs">{c.short_sha}</span>
-              <span className="min-w-0 flex-1 truncate text-sm">
-                {c.message.split('\n')[0]}
-              </span>
+              <CommitSubject
+                className="min-w-0 flex-1 truncate text-sm"
+                commitUrl={c.url}
+                message={c.message}
+              />
               {c.ci_status !== 'unknown' ? (
                 <CiStatusDot status={c.ci_status} />
               ) : null}

--- a/ui/src/components/releases/ReleaseCommitPicker.tsx
+++ b/ui/src/components/releases/ReleaseCommitPicker.tsx
@@ -1,7 +1,8 @@
-import { Check, ExternalLink } from 'lucide-react'
+import { Check, ExternalLink, GitPullRequest } from 'lucide-react'
 
 import { Badge } from '@/components/ui/badge'
 import type { ChipColors } from '@/lib/chip-colors'
+import { pullRequestRefs } from '@/lib/commit-refs'
 import { cn } from '@/lib/utils'
 import type { DeploymentCommitCiStatus } from '@/types'
 
@@ -142,9 +143,15 @@ function CommitRow({
           {body}
         </pre>
       ) : null}
+      {/* The row itself is the select control, so ``#N`` references can't be
+          linked inline (no anchors inside a button) — they get their own
+          affordance here, beside the commit link. */}
       {active && commit.url ? (
         <div
-          className={cn('px-3 pb-2 pl-13', !accent && 'bg-action/5')}
+          className={cn(
+            'flex flex-wrap items-center gap-x-3 gap-y-1 px-3 pb-2 pl-13',
+            !accent && 'bg-action/5',
+          )}
           style={activeBg}
         >
           <a
@@ -156,6 +163,18 @@ function CommitRow({
             <ExternalLink size={11} />
             View commit
           </a>
+          {pullRequestRefs(subject, commit.url).map((ref) => (
+            <a
+              className="text-warning inline-flex items-center gap-1 text-xs hover:underline"
+              href={ref.href}
+              key={ref.href}
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              <GitPullRequest size={11} />
+              {ref.label}
+            </a>
+          ))}
         </div>
       ) : null}
     </div>

--- a/ui/src/components/ui/commit-subject.tsx
+++ b/ui/src/components/ui/commit-subject.tsx
@@ -1,0 +1,46 @@
+import { Fragment } from 'react'
+
+import { repoWebUrl, splitPullRequestRefs } from '@/lib/commit-refs'
+
+interface CommitSubjectProps {
+  className?: string
+  /**
+   * The commit's web URL. The repository behind it anchors the ``#N``
+   * links; without it the subject renders as plain text.
+   */
+  commitUrl?: null | string
+  /** Full commit message — only the subject line renders. */
+  message: string
+}
+
+/**
+ * A commit's subject line with its ``#N`` pull-request references linked,
+ * matching how the same references render in the release notes below.
+ */
+export function CommitSubject({
+  className,
+  commitUrl,
+  message,
+}: CommitSubjectProps) {
+  const subject = message.split('\n')[0] ?? ''
+  const segments = splitPullRequestRefs(subject, repoWebUrl(commitUrl))
+  return (
+    <span className={className}>
+      {segments.map((segment, idx) =>
+        segment.href ? (
+          <a
+            className="text-warning hover:underline"
+            href={segment.href}
+            key={idx}
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            {segment.text}
+          </a>
+        ) : (
+          <Fragment key={idx}>{segment.text}</Fragment>
+        ),
+      )}
+    </span>
+  )
+}

--- a/ui/src/lib/__tests__/commit-refs.test.ts
+++ b/ui/src/lib/__tests__/commit-refs.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  pullRequestRefs,
+  repoWebUrl,
+  splitPullRequestRefs,
+} from '../commit-refs'
+
+const GH = 'https://github.com/aweber-imbi/imbi'
+const GHE = 'https://aweber.ghe.com/apis/address-verification'
+
+describe('repoWebUrl', () => {
+  it('derives the repo root from a commit URL', () => {
+    expect(repoWebUrl(`${GH}/commit/c5c7e0af`)).toBe(GH)
+    expect(repoWebUrl(`${GHE}/commit/deadbeef`)).toBe(GHE)
+  })
+
+  it('rejects URLs that are not commit URLs', () => {
+    expect(repoWebUrl(GH)).toBeNull()
+    expect(repoWebUrl(`${GH}/pull/173`)).toBeNull()
+    expect(repoWebUrl('https://github.com/commit/abc')).toBeNull()
+  })
+
+  it('rejects missing and unsafe URLs', () => {
+    expect(repoWebUrl(null)).toBeNull()
+    expect(repoWebUrl(undefined)).toBeNull()
+    expect(repoWebUrl('')).toBeNull()
+    expect(repoWebUrl('javascript:alert(1)')).toBeNull()
+  })
+})
+
+describe('splitPullRequestRefs', () => {
+  it('links a trailing squash-merge reference', () => {
+    expect(
+      splitPullRequestRefs('Show only tagged releases (#173)', GH),
+    ).toStrictEqual([
+      { href: null, text: 'Show only tagged releases (' },
+      { href: `${GH}/pull/173`, text: '#173' },
+      { href: null, text: ')' },
+    ])
+  })
+
+  it('links a merge-commit reference', () => {
+    expect(
+      splitPullRequestRefs('Merge pull request #82 from feature/x', GH),
+    ).toStrictEqual([
+      { href: null, text: 'Merge pull request ' },
+      { href: `${GH}/pull/82`, text: '#82' },
+      { href: null, text: ' from feature/x' },
+    ])
+  })
+
+  it('links every reference in the subject', () => {
+    const segments = splitPullRequestRefs('Revert #10, reland #11', GH)
+    expect(segments.filter((s) => s.href)).toStrictEqual([
+      { href: `${GH}/pull/10`, text: '#10' },
+      { href: `${GH}/pull/11`, text: '#11' },
+    ])
+  })
+
+  it('leaves the subject plain when there is no repo', () => {
+    expect(splitPullRequestRefs('Bump version (#173)', null)).toStrictEqual([
+      { href: null, text: 'Bump version (#173)' },
+    ])
+  })
+
+  it('leaves subjects without references alone', () => {
+    expect(splitPullRequestRefs('Bump version to 2.20.0', GH)).toStrictEqual([
+      { href: null, text: 'Bump version to 2.20.0' },
+    ])
+  })
+
+  it('ignores mid-word and non-numeric hashes', () => {
+    expect(splitPullRequestRefs('fix sha#12 and #abc', GH)).toStrictEqual([
+      { href: null, text: 'fix sha#12 and #abc' },
+    ])
+  })
+})
+
+describe('pullRequestRefs', () => {
+  it('collects deduplicated references in message order', () => {
+    expect(
+      pullRequestRefs('Revert #10 (#10) then #11', `${GH}/commit/a`),
+    ).toStrictEqual([
+      { href: `${GH}/pull/10`, label: '#10' },
+      { href: `${GH}/pull/11`, label: '#11' },
+    ])
+  })
+
+  it('returns nothing without a commit URL to anchor on', () => {
+    expect(pullRequestRefs('Add a thing (#5)', null)).toStrictEqual([])
+  })
+})

--- a/ui/src/lib/commit-refs.ts
+++ b/ui/src/lib/commit-refs.ts
@@ -1,0 +1,83 @@
+import { sanitizeHttpUrl } from './utils'
+
+/**
+ * A run of commit-subject text, optionally carrying the pull-request URL
+ * a ``#N`` reference resolves to.
+ */
+export interface CommitSubjectSegment {
+  /** Pull-request URL for a ``#N`` segment; null for plain text. */
+  href: null | string
+  text: string
+}
+
+// ``#123`` references, as the source host itself linkifies them. The
+// lookbehind keeps mid-word noise (``sha#12``, ``##12``) from matching.
+const PR_REF_RE = /(?<![\w#])#(\d+)\b/g
+
+/**
+ * The pull requests a commit subject references, deduplicated and in
+ * message order. Used where the subject can't host inline links (e.g.
+ * inside a clickable row) and the references need their own affordance.
+ */
+export function pullRequestRefs(
+  subject: string,
+  commitUrl: null | string | undefined,
+): { href: string; label: string }[] {
+  const repoUrl = repoWebUrl(commitUrl)
+  if (!repoUrl) return []
+  const seen = new Set<string>()
+  const refs: { href: string; label: string }[] = []
+  for (const match of subject.matchAll(PR_REF_RE)) {
+    if (seen.has(match[1])) continue
+    seen.add(match[1])
+    refs.push({ href: `${repoUrl}/pull/${match[1]}`, label: match[0] })
+  }
+  return refs
+}
+
+/**
+ * Repository web root behind a commit's ``html_url``
+ * (``https://host/owner/repo/commit/<sha>`` → ``https://host/owner/repo``),
+ * or null when the URL isn't a commit URL we recognize.
+ *
+ * The synced ClickHouse ``commits`` table carries no PR number, so the
+ * commit URL is the only per-row handle on the repository the ``#N``
+ * references in its message belong to.
+ */
+export function repoWebUrl(
+  commitUrl: null | string | undefined,
+): null | string {
+  const sanitized = sanitizeHttpUrl(commitUrl)
+  if (!sanitized) return null
+  const { origin, pathname } = new URL(sanitized)
+  const parts = pathname.split('/').filter(Boolean)
+  // …/{owner}/{repo}/commit/{sha}
+  if (parts.length < 4 || parts[parts.length - 2] !== 'commit') return null
+  return `${origin}/${parts.slice(0, -2).join('/')}`
+}
+
+/**
+ * Split a commit subject into plain-text and pull-request-reference
+ * segments. Returns the subject as a single plain segment when there is
+ * no repository to resolve references against.
+ */
+export function splitPullRequestRefs(
+  subject: string,
+  repoUrl: null | string,
+): CommitSubjectSegment[] {
+  if (!repoUrl) return [{ href: null, text: subject }]
+  const segments: CommitSubjectSegment[] = []
+  let cursor = 0
+  for (const match of subject.matchAll(PR_REF_RE)) {
+    const at = match.index
+    if (at > cursor) {
+      segments.push({ href: null, text: subject.slice(cursor, at) })
+    }
+    segments.push({ href: `${repoUrl}/pull/${match[1]}`, text: match[0] })
+    cursor = at + match[0].length
+  }
+  if (cursor < subject.length) {
+    segments.push({ href: null, text: subject.slice(cursor) })
+  }
+  return segments
+}


### PR DESCRIPTION
## Summary
Link the `#N` pull-request references in the Deployments tab's commit lists, so they behave like the same references in the release notes rendered right below them.

## Problem
Reported as a PR-linking inconsistency: on a project's Deployments tab the PR numbers in the commit rows were plain text, while the ones lower down on the same card were clickable.

The two are rendered from different sources. The release notes are host-authored markdown containing full PR URLs, which `react-markdown` linkifies for free. The commit rows render the raw commit subject as text, so the `(#82)` in a squash-merge subject was inert — and the synced `commits` table carries no PR number to link against, as `RecentCommit`'s docstring notes.

## Solution
Resolve `#N` against the repository derived from the commit's own web URL — `https://host/owner/repo/commit/<sha>` → `https://host/owner/repo/pull/N`. That's the only per-row handle on the repository available in the synced data, so no API or schema change is needed, and subjects fall back to plain text when a commit carries no URL.

- `lib/commit-refs` derives the repo root and tokenizes a subject into text and reference segments. The URL goes through the existing `sanitizeHttpUrl`, so an unsafe scheme can't reach an `href`.
- A `CommitSubject` component renders those segments, styled `text-warning` to match how the release-notes links already render.
- Used for the "Recent commits" rows (`CommitDeployCard`) and the "Changes in `<tag>`" list (`PendingReleasesCard`).
- In `ReleaseCommitPicker` the row itself is the select control, so anchors can't be nested inline; the references get their own affordance in the selected row's footer, beside the existing "View commit" link.

## Impact
UI only — no API, schema, or sync changes. Works for both github.com and GitHub Enterprise commit URLs, and matches how the source host renders the same message, including linking a bare `#2` in prose (GitHub does this too, resolving issues and PRs through the same path).

Commits pushed directly rather than squash-merged still show no reference, because their messages genuinely contain none. Tying those to their PRs needs a commit→PR join against the pull-requests data and is deliberately out of scope here.

## Testing
- 11 unit tests for the new helper, plus component tests asserting the rendered `href` and the no-URL fallback.
- Full UI suite green: 83 files / 646 tests. `npm run lint` at 0 errors, `format:check` clean.
- Spot-checked the helper against a real GitHub Enterprise commit URL and a subject carrying two references, to confirm both the repo-root derivation and multi-reference tokenizing.
