### PR TITLE
Record the peeled commit SHA for annotated tags

### DIFF
--- a/libraries/common/src/imbi/common/models.py
+++ b/libraries/common/src/imbi/common/models.py
@@ -1132,7 +1132,9 @@ class TagRecord(pydantic.BaseModel):
     expose annotated tags as their own objects (git, hence GitHub) must
     peel the tag before recording it: consumers join this column against
     ``commits.sha`` and match it against deployment committishes, so a tag
-    object hash silently matches nothing.
+    object hash silently matches nothing. A tag that cannot be peeled to a
+    commit must be skipped rather than recorded against the unresolved
+    hash -- no row is better than one nothing can join to.
     """
 
     project_id: str

--- a/libraries/common/src/imbi/common/models.py
+++ b/libraries/common/src/imbi/common/models.py
@@ -1127,6 +1127,12 @@ class TagRecord(pydantic.BaseModel):
     ``ReplacingMergeTree`` keyed by ``(project_id, name)``; annotated-tag
     metadata (``message``, ``tagger_*``, ``tagged_at``) is populated when
     the provider exposes it and left at its default otherwise.
+
+    ``sha`` is always the **commit** the tag resolves to. Providers that
+    expose annotated tags as their own objects (git, hence GitHub) must
+    peel the tag before recording it: consumers join this column against
+    ``commits.sha`` and match it against deployment committishes, so a tag
+    object hash silently matches nothing.
     """
 
     project_id: str

--- a/plugins/github/src/imbi/plugins/github/commits.py
+++ b/plugins/github/src/imbi/plugins/github/commits.py
@@ -998,6 +998,14 @@ def _tag_record(
 ) -> TagRecord:
     """Build the ClickHouse row for one tag.
 
+    ``sha`` records the *commit* the tag resolves to, never the hash of an
+    annotated tag object. Callers pass whatever the ref points at, which
+    for an annotated tag is the tag object; the peeled commit is read back
+    off *annotated* (``object.sha``). Storing the tag object hash instead
+    breaks every downstream consumer, all of which key on commit SHAs --
+    the ``commits`` join that supplies a release's CI status and
+    authorship, and the Deployments tab's release-to-commit matching.
+
     ``tagged_at`` preference: the GitHub release's published date
     (*published_at*), then the annotated tag's tagger date, then the
     target commit's committer date (*fallback_tagged_at*, lightweight
@@ -1012,10 +1020,11 @@ def _tag_record(
             tagged_at=published_at or fallback_tagged_at,
         )
     tagger: dict[str, typing.Any] = annotated.get('tagger') or {}
+    target: dict[str, typing.Any] = annotated.get('object') or {}
     return TagRecord(
         project_id=project_id,
         name=name,
-        sha=sha,
+        sha=str(target.get('sha') or sha),
         url=url,
         message=str(annotated.get('message') or ''),
         tagger_name=str(tagger.get('name') or ''),
@@ -1032,6 +1041,8 @@ async def _reconcile_tags(
     ``/git/matching-refs/tags`` yields each tag's object sha + type;
     annotated tags (``type == 'tag'``) are enriched with tagger/message/
     date from the tag object, lightweight tags carry name/sha/url only.
+    An annotated tag's ref points at the tag object rather than a commit,
+    so ``_tag_record`` peels it back to the commit before recording it.
     ``ReplacingMergeTree`` dedupes against rows recorded from pushes.
     """
     out: list[TagRecord] = []

--- a/plugins/github/src/imbi/plugins/github/commits.py
+++ b/plugins/github/src/imbi/plugins/github/commits.py
@@ -995,8 +995,8 @@ def _tag_record(
     url: str = '',
     published_at: datetime.datetime | None = None,
     fallback_tagged_at: datetime.datetime | None = None,
-) -> TagRecord:
-    """Build the ClickHouse row for one tag.
+) -> TagRecord | None:
+    """Build the ClickHouse row for one tag, ``None`` to skip it.
 
     ``sha`` records the *commit* the tag resolves to, never the hash of an
     annotated tag object. Callers pass whatever the ref points at, which
@@ -1005,6 +1005,16 @@ def _tag_record(
     breaks every downstream consumer, all of which key on commit SHAs --
     the ``commits`` join that supplies a release's CI status and
     authorship, and the Deployments tab's release-to-commit matching.
+
+    An annotated tag that cannot be peeled to a commit is *skipped*
+    rather than recorded against the tag object: a row whose sha matches
+    no commit renders a release with unknown CI, no author, and an empty
+    commit list, which is the failure this peeling exists to prevent.
+    Skipping keeps the bad value out of ClickHouse and leaves a warning
+    to diagnose from. GitHub always returns ``object`` on a tag object, so
+    this is defensive -- a tag pointing at a tree/blob, or a nested
+    annotated tag (which is legal git but never a release, and is not
+    peeled recursively), takes the same path.
 
     ``tagged_at`` preference: the GitHub release's published date
     (*published_at*), then the annotated tag's tagger date, then the
@@ -1021,10 +1031,25 @@ def _tag_record(
         )
     tagger: dict[str, typing.Any] = annotated.get('tagger') or {}
     target: dict[str, typing.Any] = annotated.get('object') or {}
+    commit_sha = str(target.get('sha') or '')
+    # A payload carrying a sha but no type is trusted: GitHub sends both,
+    # and defaulting to 'commit' keeps a well-formed row from being
+    # dropped over a missing field.
+    target_type = str(target.get('type') or 'commit')
+    if not commit_sha or target_type != 'commit':
+        LOGGER.warning(
+            'github-commit-sync: skipping tag %s for project %s; its tag '
+            'object %s resolves to %s, not a commit',
+            name,
+            project_id,
+            sha,
+            f'{target_type} {commit_sha}' if commit_sha else 'nothing',
+        )
+        return None
     return TagRecord(
         project_id=project_id,
         name=name,
-        sha=str(target.get('sha') or sha),
+        sha=commit_sha,
         url=url,
         message=str(annotated.get('message') or ''),
         tagger_name=str(tagger.get('name') or ''),
@@ -1077,21 +1102,21 @@ async def _reconcile_tags(
                 if obj.get('type') == 'tag'
                 else None
             )
-            out.append(
-                _tag_record(
-                    project_id=project_id,
-                    name=name,
-                    sha=sha,
-                    annotated=annotated,
-                    url=_tag_web_url(client, name),
-                    published_at=published,
-                    fallback_tagged_at=(
-                        await _commit_date(client, sha, max_wait=max_wait)
-                        if annotated is None and published is None
-                        else None
-                    ),
-                )
+            record = _tag_record(
+                project_id=project_id,
+                name=name,
+                sha=sha,
+                annotated=annotated,
+                url=_tag_web_url(client, name),
+                published_at=published,
+                fallback_tagged_at=(
+                    await _commit_date(client, sha, max_wait=max_wait)
+                    if annotated is None and published is None
+                    else None
+                ),
             )
+            if record is not None:
+                out.append(record)
         next_url = _next_page_url(resp.headers.get('link'))
         if next_url is None:
             return out
@@ -1137,23 +1162,24 @@ async def sync_tags(
             published = await _release_published_for_tag(
                 client, name, max_wait=_WEBHOOK_MAX_WAIT_SECONDS
             )
-            records: list[pydantic.BaseModel] = [
-                _tag_record(
-                    project_id=ctx.project_id,
-                    name=name,
-                    sha=after,
-                    annotated=annotated,
-                    url=_tag_web_url(client, name),
-                    published_at=published,
-                    fallback_tagged_at=(
-                        await _commit_date(
-                            client, after, max_wait=_WEBHOOK_MAX_WAIT_SECONDS
-                        )
-                        if annotated is None and published is None
-                        else None
-                    ),
-                )
-            ]
+            pushed = _tag_record(
+                project_id=ctx.project_id,
+                name=name,
+                sha=after,
+                annotated=annotated,
+                url=_tag_web_url(client, name),
+                published_at=published,
+                fallback_tagged_at=(
+                    await _commit_date(
+                        client, after, max_wait=_WEBHOOK_MAX_WAIT_SECONDS
+                    )
+                    if annotated is None and published is None
+                    else None
+                ),
+            )
+            records: list[pydantic.BaseModel] = (
+                [] if pushed is None else [pushed]
+            )
             if action_config.reconcile_all:
                 extra = await _reconcile_tags(
                     client, ctx.project_id, max_wait=_WEBHOOK_MAX_WAIT_SECONDS
@@ -1168,6 +1194,8 @@ async def sync_tags(
             exc,
         )
         return
+    if not records:
+        return  # every tag in this delivery was unpeelable (warned above)
     try:
         await clickhouse.insert('tags', records)
     except Exception:

--- a/plugins/github/src/imbi/plugins/github/commits.py
+++ b/plugins/github/src/imbi/plugins/github/commits.py
@@ -887,12 +887,30 @@ async def sync_commits(
 
 async def _annotated_tag(
     client: httpx.AsyncClient, sha: str, *, max_wait: float
-) -> dict[str, typing.Any] | None:
-    """Fetch annotated-tag metadata, ``None`` for a lightweight tag."""
+) -> tuple[dict[str, typing.Any] | None, bool]:
+    """Fetch annotated-tag metadata as ``(payload, conclusive)``.
+
+    Three outcomes, which callers must keep apart:
+
+    * ``(payload, True)``  -- an annotated tag; *payload* carries the
+      tagger/message and the ``object`` to peel.
+    * ``(None, True)``     -- a 404: *sha* is not a tag object, so the ref
+      points straight at a commit (a lightweight tag).
+    * ``(None, False)``    -- any other failure (5xx, permissions). We
+      cannot tell which of the two it was.
+
+    Collapsing the last case into the lightweight one would record the
+    ref target as if it were a commit, which for an annotated tag is the
+    tag object hash -- the unjoinable value :func:`_tag_record` exists to
+    keep out. Callers skip the tag instead; a later push or backfill
+    re-syncs it (``ReplacingMergeTree`` dedupes).
+    """
     resp = await _request(client, 'GET', f'/git/tags/{sha}', max_wait=max_wait)
+    if resp.status_code == 404:
+        return None, True
     if resp.status_code != 200:
-        return None
-    return typing.cast('dict[str, typing.Any]', resp.json())
+        return None, False
+    return typing.cast('dict[str, typing.Any]', resp.json()), True
 
 
 async def _commit_date(
@@ -1097,11 +1115,25 @@ async def _reconcile_tags(
                     client, max_wait=max_wait
                 )
             published = released.get(name)
-            annotated = (
-                await _annotated_tag(client, sha, max_wait=max_wait)
-                if obj.get('type') == 'tag'
-                else None
-            )
+            # The ref tells us whether this is an annotated tag, so an
+            # inconclusive lookup is not a lightweight tag -- it is a tag
+            # we cannot peel. Skip it rather than recording the ref target
+            # (the tag object) as if it were the commit.
+            annotated: dict[str, typing.Any] | None = None
+            if obj.get('type') == 'tag':
+                annotated, conclusive = await _annotated_tag(
+                    client, sha, max_wait=max_wait
+                )
+                if annotated is None:
+                    LOGGER.warning(
+                        'github-commit-sync: skipping tag %s for project '
+                        '%s; its tag object %s could not be %s',
+                        name,
+                        project_id,
+                        sha,
+                        'read' if conclusive else 'fetched',
+                    )
+                    continue
             record = _tag_record(
                 project_id=project_id,
                 name=name,
@@ -1156,27 +1188,41 @@ async def sync_tags(
     token = await _resolve_bearer(credentials, base, owner, repo)
     try:
         async with _client(base, owner, repo, token) as client:
-            annotated = await _annotated_tag(
+            annotated, conclusive = await _annotated_tag(
                 client, after, max_wait=_WEBHOOK_MAX_WAIT_SECONDS
             )
             published = await _release_published_for_tag(
                 client, name, max_wait=_WEBHOOK_MAX_WAIT_SECONDS
             )
-            pushed = _tag_record(
-                project_id=ctx.project_id,
-                name=name,
-                sha=after,
-                annotated=annotated,
-                url=_tag_web_url(client, name),
-                published_at=published,
-                fallback_tagged_at=(
-                    await _commit_date(
-                        client, after, max_wait=_WEBHOOK_MAX_WAIT_SECONDS
-                    )
-                    if annotated is None and published is None
-                    else None
-                ),
-            )
+            # A push payload carries no object type, so only a conclusive
+            # 404 proves ``after`` is a commit. An inconclusive lookup may
+            # be an annotated tag, whose ref target is the tag object --
+            # skip rather than record it as the commit.
+            pushed: TagRecord | None = None
+            if conclusive:
+                pushed = _tag_record(
+                    project_id=ctx.project_id,
+                    name=name,
+                    sha=after,
+                    annotated=annotated,
+                    url=_tag_web_url(client, name),
+                    published_at=published,
+                    fallback_tagged_at=(
+                        await _commit_date(
+                            client, after, max_wait=_WEBHOOK_MAX_WAIT_SECONDS
+                        )
+                        if annotated is None and published is None
+                        else None
+                    ),
+                )
+            else:
+                LOGGER.warning(
+                    'github-commit-sync: skipping tag %s for project %s; '
+                    'could not determine whether %s is a tag object',
+                    name,
+                    ctx.project_id,
+                    after,
+                )
             records: list[pydantic.BaseModel] = (
                 [] if pushed is None else [pushed]
             )
@@ -1184,7 +1230,10 @@ async def sync_tags(
                 extra = await _reconcile_tags(
                     client, ctx.project_id, max_wait=_WEBHOOK_MAX_WAIT_SECONDS
                 )
-                seen = {name}
+                # Only reserve the pushed name when it actually produced a
+                # row: when it was skipped, the reconcile pass may have
+                # resolved the same tag and that result should stand.
+                seen = {name} if pushed is not None else set[str]()
                 records.extend(r for r in extra if r.name not in seen)
     except PluginRateLimited as exc:
         LOGGER.warning(

--- a/plugins/github/tests/test_commits.py
+++ b/plugins/github/tests/test_commits.py
@@ -673,6 +673,81 @@ class SyncTagsTestCase(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(commit_sha, records[0].sha)
 
     @respx.mock
+    async def test_inconclusive_tag_lookup_skips_push(self) -> None:
+        # A push payload carries no object type, so only a 404 proves
+        # ``after`` is a commit. On a 5xx it may be an annotated tag, whose
+        # ``after`` is the tag object -- record nothing rather than risk
+        # storing a sha that joins to no commit.
+        sha = 't' * 40
+        respx.get(
+            f'https://api.github.com/repos/octo/demo/git/tags/{sha}'
+        ).mock(return_value=httpx.Response(500))
+        respx.get(
+            'https://api.github.com/repos/octo/demo/releases/tags/v1.2.3'
+        ).mock(return_value=httpx.Response(404))
+        with mock.patch(_INSERT, new=mock.AsyncMock()) as insert:
+            await commits.sync_tags(
+                ctx=_ctx(),
+                credentials=_CREDS,
+                external_identifier='',
+                action_config=commits.SyncTagsConfig(),
+                event=_event(self._tag_push(after=sha)),
+            )
+        insert.assert_not_awaited()
+
+    @respx.mock
+    async def test_reconcile_recovers_a_skipped_push(self) -> None:
+        # The pushed tag is skipped (its tag-object lookup fails), then the
+        # reconcile pass resolves the same tag on a retry. Its name must not
+        # be reserved by the skipped push, or the good row is dropped too.
+        tag_sha = 't' * 40
+        commit_sha = 'c' * 40
+        respx.get(
+            f'https://api.github.com/repos/octo/demo/git/tags/{tag_sha}'
+        ).mock(
+            side_effect=[
+                httpx.Response(500),
+                httpx.Response(
+                    200,
+                    json={
+                        'message': 'Release 1.2.3',
+                        'object': {'sha': commit_sha, 'type': 'commit'},
+                    },
+                ),
+            ]
+        )
+        respx.get(
+            'https://api.github.com/repos/octo/demo/releases/tags/v1.2.3'
+        ).mock(return_value=httpx.Response(404))
+        respx.get('https://api.github.com/repos/octo/demo/releases').mock(
+            return_value=httpx.Response(200, json=[])
+        )
+        respx.get(
+            'https://api.github.com/repos/octo/demo/git/matching-refs/tags'
+        ).mock(
+            return_value=httpx.Response(
+                200,
+                json=[
+                    {
+                        'ref': 'refs/tags/v1.2.3',
+                        'object': {'sha': tag_sha, 'type': 'tag'},
+                    }
+                ],
+            )
+        )
+        with mock.patch(_INSERT, new=mock.AsyncMock()) as insert:
+            await commits.sync_tags(
+                ctx=_ctx(),
+                credentials=_CREDS,
+                external_identifier='',
+                action_config=commits.SyncTagsConfig(reconcile_all=True),
+                event=_event(self._tag_push(after=tag_sha)),
+            )
+        _, records = _await_args(insert)
+        self.assertEqual(['v1.2.3'], [r.name for r in records])
+        self.assertEqual(commit_sha, records[0].sha)
+
+    @respx.mock
     async def test_reconcile_all_adds_full_list(self) -> None:
         sha = 't' * 40
         respx.get(
@@ -1435,9 +1510,13 @@ class SyncAllHistoryTestCase(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(commit_sha, record.sha)
 
     async def _tags_recorded_for_target(
-        self, target: dict[str, str] | None
+        self, target: dict[str, str] | None, status: int = 200
     ) -> list[TagRecord]:
-        """Run a backfill whose one annotated tag points at *target*."""
+        """Run a backfill whose one annotated tag points at *target*.
+
+        *status* overrides the ``/git/tags`` response code so a failed
+        tag-object lookup can be exercised.
+        """
         self._mock_default_branch()
         respx.get(f'{self._REPO}/commits').mock(
             return_value=httpx.Response(200, json=[_commit('c' * 40)])
@@ -1461,7 +1540,11 @@ class SyncAllHistoryTestCase(unittest.IsolatedAsyncioTestCase):
         if target is not None:
             body['object'] = target
         respx.get(f'{self._REPO}/git/tags/{tag_sha}').mock(
-            return_value=httpx.Response(200, json=body)
+            return_value=(
+                httpx.Response(status)
+                if status != 200
+                else httpx.Response(200, json=body)
+            )
         )
         with mock.patch(_INSERT, new=mock.AsyncMock()) as insert:
             await commits.GitHubCommitSync().sync_all_history(
@@ -1506,12 +1589,32 @@ class SyncAllHistoryTestCase(unittest.IsolatedAsyncioTestCase):
         )
 
     @respx.mock
+    async def test_annotated_tag_lookup_failure_is_skipped(self) -> None:
+        # The ref said ``type: tag``, so a 5xx on the tag object is not a
+        # lightweight tag -- it is a tag we cannot peel. Recording it would
+        # store the ref target (the tag object) as if it were the commit.
+        self.assertEqual(
+            [],
+            await self._tags_recorded_for_target(
+                {'sha': 'd' * 40, 'type': 'commit'}, status=500
+            ),
+        )
+
+    @respx.mock
     async def test_annotated_tag_on_commit_is_recorded(self) -> None:
-        # The positive control for the three skip cases above: an ordinary
+        # The positive control for the skip cases above: an ordinary
         # annotated release tag still lands, carrying the peeled commit.
         recorded = await self._tags_recorded_for_target(
             {'sha': 'd' * 40, 'type': 'commit'}
         )
+        self.assertEqual(1, len(recorded))
+        self.assertEqual('d' * 40, recorded[0].sha)
+
+    @respx.mock
+    async def test_annotated_tag_without_target_type_is_recorded(self) -> None:
+        # GitHub always sends ``type``, so a payload carrying only a sha is
+        # trusted as a commit rather than dropped over a missing field.
+        recorded = await self._tags_recorded_for_target({'sha': 'd' * 40})
         self.assertEqual(1, len(recorded))
         self.assertEqual('d' * 40, recorded[0].sha)
 

--- a/plugins/github/tests/test_commits.py
+++ b/plugins/github/tests/test_commits.py
@@ -634,7 +634,11 @@ class SyncTagsTestCase(unittest.IsolatedAsyncioTestCase):
 
     @respx.mock
     async def test_annotated_tag_metadata(self) -> None:
+        # A tag-push delivery's ``after`` is the tag object for an
+        # annotated tag, so the recorded sha must be the commit it peels
+        # to -- not ``after``.
         sha = 't' * 40
+        commit_sha = 'c' * 40
         respx.get(
             'https://api.github.com/repos/octo/demo/releases/tags/v1.2.3'
         ).mock(return_value=httpx.Response(404))
@@ -645,6 +649,7 @@ class SyncTagsTestCase(unittest.IsolatedAsyncioTestCase):
                 200,
                 json={
                     'message': 'Release 1.2.3',
+                    'object': {'sha': commit_sha, 'type': 'commit'},
                     'tagger': {
                         'name': 'Rel Bot',
                         'email': 'rel@example.com',
@@ -665,6 +670,7 @@ class SyncTagsTestCase(unittest.IsolatedAsyncioTestCase):
         self.assertEqual('Release 1.2.3', records[0].message)
         self.assertEqual('Rel Bot', records[0].tagger_name)
         self.assertIsNotNone(records[0].tagged_at)
+        self.assertEqual(commit_sha, records[0].sha)
 
     @respx.mock
     async def test_reconcile_all_adds_full_list(self) -> None:
@@ -1383,6 +1389,7 @@ class SyncAllHistoryTestCase(unittest.IsolatedAsyncioTestCase):
             return_value=httpx.Response(200, json=[])
         )
         tag_sha = 'a' * 40
+        commit_sha = 'c' * 40
         respx.get(f'{self._REPO}/git/matching-refs/tags').mock(
             return_value=httpx.Response(
                 200,
@@ -1399,6 +1406,7 @@ class SyncAllHistoryTestCase(unittest.IsolatedAsyncioTestCase):
                 200,
                 json={
                     'message': 'Release 2.0.0',
+                    'object': {'sha': commit_sha, 'type': 'commit'},
                     'tagger': {
                         'name': 'Rel Bot',
                         'email': 'rel@example.com',
@@ -1421,6 +1429,46 @@ class SyncAllHistoryTestCase(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(
             'https://github.com/octo/demo/releases/tag/v2.0.0', record.url
         )
+        # The ref points at the tag object; the row must carry the commit
+        # it peels to, which is what ``commits`` and the deployment
+        # committishes are keyed by.
+        self.assertEqual(commit_sha, record.sha)
+
+    @respx.mock
+    async def test_annotated_tag_falls_back_when_unpeelable(self) -> None:
+        # A tag object payload without ``object`` (a provider quirk, or a
+        # 200 with an unexpected shape) must still produce a usable row
+        # rather than an empty sha.
+        self._mock_default_branch()
+        respx.get(f'{self._REPO}/commits').mock(
+            return_value=httpx.Response(200, json=[_commit('c' * 40)])
+        )
+        respx.get(f'{self._REPO}/releases').mock(
+            return_value=httpx.Response(200, json=[])
+        )
+        tag_sha = 'a' * 40
+        respx.get(f'{self._REPO}/git/matching-refs/tags').mock(
+            return_value=httpx.Response(
+                200,
+                json=[
+                    {
+                        'ref': 'refs/tags/v2.0.0',
+                        'object': {'sha': tag_sha, 'type': 'tag'},
+                    }
+                ],
+            )
+        )
+        respx.get(f'{self._REPO}/git/tags/{tag_sha}').mock(
+            return_value=httpx.Response(200, json={'message': 'no object'})
+        )
+        with mock.patch(_INSERT, new=mock.AsyncMock()) as insert:
+            await commits.GitHubCommitSync().sync_all_history(
+                ctx=self._ctx(), credentials=_CREDS
+            )
+        tag_call = next(
+            c for c in insert.await_args_list if c.args[0] == 'tags'
+        )
+        self.assertEqual(tag_sha, tag_call.args[1][0].sha)
 
 
 class WebBaseTestCase(unittest.TestCase):

--- a/plugins/github/tests/test_commits.py
+++ b/plugins/github/tests/test_commits.py
@@ -1434,11 +1434,10 @@ class SyncAllHistoryTestCase(unittest.IsolatedAsyncioTestCase):
         # committishes are keyed by.
         self.assertEqual(commit_sha, record.sha)
 
-    @respx.mock
-    async def test_annotated_tag_falls_back_when_unpeelable(self) -> None:
-        # A tag object payload without ``object`` (a provider quirk, or a
-        # 200 with an unexpected shape) must still produce a usable row
-        # rather than an empty sha.
+    async def _tags_recorded_for_target(
+        self, target: dict[str, str] | None
+    ) -> list[TagRecord]:
+        """Run a backfill whose one annotated tag points at *target*."""
         self._mock_default_branch()
         respx.get(f'{self._REPO}/commits').mock(
             return_value=httpx.Response(200, json=[_commit('c' * 40)])
@@ -1458,17 +1457,63 @@ class SyncAllHistoryTestCase(unittest.IsolatedAsyncioTestCase):
                 ],
             )
         )
+        body: dict[str, typing.Any] = {'message': 'Release 2.0.0'}
+        if target is not None:
+            body['object'] = target
         respx.get(f'{self._REPO}/git/tags/{tag_sha}').mock(
-            return_value=httpx.Response(200, json={'message': 'no object'})
+            return_value=httpx.Response(200, json=body)
         )
         with mock.patch(_INSERT, new=mock.AsyncMock()) as insert:
             await commits.GitHubCommitSync().sync_all_history(
                 ctx=self._ctx(), credentials=_CREDS
             )
-        tag_call = next(
-            c for c in insert.await_args_list if c.args[0] == 'tags'
+        return [
+            r
+            for c in insert.await_args_list
+            if c.args[0] == 'tags'
+            for r in c.args[1]
+        ]
+
+    @respx.mock
+    async def test_unpeelable_annotated_tag_is_skipped(self) -> None:
+        # A 200 tag object with no ``object`` leaves no way to resolve the
+        # commit. Recording it against the tag object hash would put back
+        # exactly the unjoinable sha this peeling removes, so the tag is
+        # dropped instead.
+        self.assertEqual([], await self._tags_recorded_for_target(None))
+
+    @respx.mock
+    async def test_annotated_tag_on_tree_is_skipped(self) -> None:
+        # A tag may legally point at a tree or blob. Neither is a release
+        # and neither hash joins to ``commits``, so it is skipped.
+        self.assertEqual(
+            [],
+            await self._tags_recorded_for_target(
+                {'sha': 'd' * 40, 'type': 'tree'}
+            ),
         )
-        self.assertEqual(tag_sha, tag_call.args[1][0].sha)
+
+    @respx.mock
+    async def test_nested_annotated_tag_is_skipped(self) -> None:
+        # A tag object pointing at another tag object is legal git but
+        # never a release; peeling is deliberately not recursive, so the
+        # tag is skipped rather than recorded against the inner tag hash.
+        self.assertEqual(
+            [],
+            await self._tags_recorded_for_target(
+                {'sha': 'd' * 40, 'type': 'tag'}
+            ),
+        )
+
+    @respx.mock
+    async def test_annotated_tag_on_commit_is_recorded(self) -> None:
+        # The positive control for the three skip cases above: an ordinary
+        # annotated release tag still lands, carrying the peeled commit.
+        recorded = await self._tags_recorded_for_target(
+            {'sha': 'd' * 40, 'type': 'commit'}
+        )
+        self.assertEqual(1, len(recorded))
+        self.assertEqual('d' * 40, recorded[0].sha)
 
 
 class WebBaseTestCase(unittest.TestCase):


### PR DESCRIPTION
## Summary

Record the commit an annotated tag resolves to in `tags.sha`, instead of the
hash of the tag object itself. Restores the commit lists and release identity
on the Deployments tab for every repository that uses annotated tags.

Closes #180

## Problem

An annotated tag's ref points at a tag object, not a commit, and the two have
different hashes. The GitHub commit-sync plugin recorded whatever the ref
pointed at, so `tags.sha` held the tag object hash for every annotated tag.
Every consumer keys on commit SHAs, so nothing matched.

Both hashes were visible side by side in one pane for
`frontend-applications/user-management-client` release `2.9.1`: the
"Currently running" card showed the commit `41afbee`, while "Recent releases"
showed the tag object `71d8352`. `71d8352` exists nowhere in the `commits`
table.

What users reported was the commit list disappearing. In
`PendingReleasesCard`, `SingleReleaseChanges` slices the range with
`commitRange(recentCommits, entry.sha, baseSha)`; an unmatched head SHA
produces an empty range, and the component returns `null` — dropping the
"Changes in `<tag>`" section entirely, with no empty state to hint that
anything went wrong.

Three further consequences of the same mismatch:

- `currentReleaseEntry` in `pipeline.ts` falls back to
  `shaMatch(entry.sha, release.committish)` when the running release carries
  no tag. It never matched, so an environment running a released commit
  rendered as a bare SHA — Testing shows `41afbee` rather than `2.9.1`, even
  though that commit *is* `2.9.1`.
- `_commit_facts_by_sha` looked the tag object up in `commits` and missed, so
  every release reported `ci_status: "unknown"` and lost commit-derived
  authorship.
- `releasesInRange` / `promotableCommits` (added in #178) compare history
  SHAs to commit SHAs, making the promote-card gating in
  `EnvironmentDetail.tsx` inert on these repos.

Lightweight tags were unaffected, which is why this presented as
project-specific.

## Solution

Peel `annotated.object.sha` inside `_tag_record` — the single choke point
shared by both writers, `_reconcile_tags` (backfill) and `sync_tags` (push
deliveries), so one change fixes both. Falls back to the ref target when a
tag payload carries no `object`.

The commit-SHA contract is now documented on `TagRecord` itself so another
provider does not reintroduce it.

Also fixes the test fixtures that hid this: both annotated-tag tests mocked
`/git/tags/{sha}` with a payload that had **no `object` key at all**, and
asserted on `message`/`tagger_name`/`url` but never on `record.sha`.

## Impact

Existing rows need no migration. `imbi.tags` is
`ReplacingMergeTree(recorded_at)` ordered by `(project_id, name)` and `sha`
is not in the sort key, so re-syncing replaces the bad row rather than
duplicating it. **After deploying, run the Sync Commits & Tags
(`commit-sync`) maintenance operation** to repair affected projects; the
Deployments tab corrects itself once the rows are rewritten.

Minor caveat: the table is `PARTITION BY toYear(recorded_at)`, so a re-sync
landing in a later year than the original row is worth spot-checking.

No API or UI changes — the data flowing into the existing contract is simply
correct now.

## Testing

- `uv run --frozen pytest plugins/github/tests/ libraries/common/tests/test_models.py` — 532 passed
- Both new assertions were verified to fail against the unfixed source, then
  pass with the fix, so they are genuine regression tests
- Added a fallback case for an unpeelable tag payload (200 with no `object`)
- `moon run github:typecheck` — 0 errors; `pre-commit` (ruff + mypy) clean on
  the changed files

## Not addressed here

`GitHubDeployment.create_tag` returns `RefInfo(sha=<tag object sha>)` for the
annotated tag it creates. The caller discards the return value (the Release
node's committish comes from `from_committish`), so it is latent rather than
live — but it is the same defect and worth cleaning up before anyone starts
using that value.

Separately, the silent `return null` in `SingleReleaseChanges` turned a data
mismatch into an invisible section. An explicit empty state would have
surfaced this far sooner.
