### PR TITLE
Resolve MCP policy paths against the API's mount prefix

### DIFF
--- a/apps/assistant/src/imbi/assistant/mcp.py
+++ b/apps/assistant/src/imbi/assistant/mcp.py
@@ -16,7 +16,7 @@ import fastmcp
 import httpx
 
 from imbi.assistant import settings
-from imbi.common.mcp import EXCLUDED_ROUTE_MAPS, exclude_non_ai_tools
+from imbi.common.mcp import exclude_non_ai_tools, excluded_route_maps
 
 LOGGER = logging.getLogger(__name__)
 
@@ -100,7 +100,7 @@ class MCPManager:
             openapi_spec=spec,
             client=self._http_client,
             name='Imbi',
-            route_maps=list(EXCLUDED_ROUTE_MAPS),
+            route_maps=excluded_route_maps(spec),
             route_map_fn=exclude_non_ai_tools,
         )
 

--- a/apps/assistant/tests/test_mcp.py
+++ b/apps/assistant/tests/test_mcp.py
@@ -100,7 +100,14 @@ class MCPManagerTestCase(unittest.IsolatedAsyncioTestCase):
             mock_response = mock.MagicMock()
             mock_response.json.return_value = {
                 'openapi': '3.1.0',
-                'paths': {},
+                'paths': {
+                    '/users/me': {
+                        'get': {
+                            'operationId': 'profile',
+                            'responses': {'200': {'description': 'OK'}},
+                        }
+                    }
+                },
             }
             mock_tmp.get.return_value = mock_response
             mock_tmp.__aenter__ = mock.AsyncMock(
@@ -163,7 +170,14 @@ class MCPManagerTestCase(unittest.IsolatedAsyncioTestCase):
             mock_response = mock.MagicMock()
             mock_response.json.return_value = {
                 'openapi': '3.1.0',
-                'paths': {},
+                'paths': {
+                    '/users/me': {
+                        'get': {
+                            'operationId': 'profile',
+                            'responses': {'200': {'description': 'OK'}},
+                        }
+                    }
+                },
             }
             mock_tmp.get.return_value = mock_response
             mock_tmp.__aenter__ = mock.AsyncMock(return_value=mock_tmp)
@@ -208,7 +222,14 @@ class MCPManagerTestCase(unittest.IsolatedAsyncioTestCase):
             mock_response = mock.MagicMock()
             mock_response.json.return_value = {
                 'openapi': '3.1.0',
-                'paths': {},
+                'paths': {
+                    '/users/me': {
+                        'get': {
+                            'operationId': 'profile',
+                            'responses': {'200': {'description': 'OK'}},
+                        }
+                    }
+                },
             }
             mock_tmp.get.return_value = mock_response
             mock_tmp.__aenter__ = mock.AsyncMock(
@@ -275,7 +296,14 @@ class MCPManagerTestCase(unittest.IsolatedAsyncioTestCase):
             mock_response = mock.MagicMock()
             mock_response.json.return_value = {
                 'openapi': '3.1.0',
-                'paths': {},
+                'paths': {
+                    '/users/me': {
+                        'get': {
+                            'operationId': 'profile',
+                            'responses': {'200': {'description': 'OK'}},
+                        }
+                    }
+                },
             }
             mock_tmp.get.return_value = mock_response
             mock_tmp.__aenter__ = mock.AsyncMock(
@@ -339,7 +367,14 @@ class MCPManagerTestCase(unittest.IsolatedAsyncioTestCase):
             mock_response = mock.MagicMock()
             mock_response.json.return_value = {
                 'openapi': '3.1.0',
-                'paths': {},
+                'paths': {
+                    '/users/me': {
+                        'get': {
+                            'operationId': 'profile',
+                            'responses': {'200': {'description': 'OK'}},
+                        }
+                    }
+                },
             }
             mock_tmp.get.return_value = mock_response
             mock_tmp.__aenter__ = mock.AsyncMock(return_value=mock_tmp)

--- a/apps/mcp/src/imbi/mcp/server.py
+++ b/apps/mcp/src/imbi/mcp/server.py
@@ -31,10 +31,10 @@ from starlette.responses import JSONResponse
 import imbi.mcp
 from imbi.common.auth import core
 from imbi.common.mcp import (
-    EXCLUDED_ROUTE_MAPS,
     PermissionFilterMiddleware,
     copy_permissions_to_meta,
     exclude_non_ai_tools,
+    excluded_route_maps,
 )
 
 if typing.TYPE_CHECKING:
@@ -139,15 +139,16 @@ def create_server(
         name='Imbi',
         version=imbi.mcp.version,
         auth=_build_auth(public_url, auth_server_url),
-        route_maps=list(EXCLUDED_ROUTE_MAPS),
+        route_maps=excluded_route_maps(spec),
         route_map_fn=exclude_non_ai_tools,
         mcp_component_fn=copy_permissions_to_meta,
     )
 
     # ``client`` forwards the caller's Authorization header via
     # ``_inject_auth``, so the middleware resolves permissions for the
-    # principal making the request rather than a fixed identity.
-    mcp.add_middleware(PermissionFilterMiddleware(client))
+    # principal making the request rather than a fixed identity. The
+    # spec supplies the API's mount prefix, which ``base_url`` lacks.
+    mcp.add_middleware(PermissionFilterMiddleware(client, spec))
 
     @mcp.custom_route('/status', methods=['GET'])
     async def status(_request: Request) -> JSONResponse:

--- a/apps/mcp/tests/test_server.py
+++ b/apps/mcp/tests/test_server.py
@@ -46,6 +46,15 @@ def _minimal_openapi_spec() -> dict[str, object]:
                     },
                 },
             },
+            '/users/me': {
+                'get': {
+                    'operationId': 'profile',
+                    'summary': 'Current user profile',
+                    'responses': {
+                        '200': {'description': 'OK'},
+                    },
+                },
+            },
             '/organizations/{org_slug}/projects/{id}/configuration/{key}': {
                 'put': {
                     'operationId': 'set_configuration_value',

--- a/apps/slackbot/src/imbi/slackbot/mcp.py
+++ b/apps/slackbot/src/imbi/slackbot/mcp.py
@@ -17,7 +17,7 @@ import typing
 import fastmcp
 import httpx
 
-from imbi.common.mcp import EXCLUDED_ROUTE_MAPS, exclude_non_ai_tools
+from imbi.common.mcp import exclude_non_ai_tools, excluded_route_maps
 from imbi.slackbot import settings
 
 LOGGER = logging.getLogger(__name__)
@@ -89,7 +89,7 @@ class MCPManager:
             openapi_spec=spec,
             client=self._http_client,
             name='Imbi',
-            route_maps=list(EXCLUDED_ROUTE_MAPS),
+            route_maps=excluded_route_maps(spec),
             route_map_fn=exclude_non_ai_tools,
         )
 

--- a/apps/slackbot/tests/test_mcp.py
+++ b/apps/slackbot/tests/test_mcp.py
@@ -15,7 +15,13 @@ _SPEC = {
                 'operationId': 'list_projects',
                 'responses': {'200': {'description': 'ok'}},
             }
-        }
+        },
+        '/users/me': {
+            'get': {
+                'operationId': 'profile',
+                'responses': {'200': {'description': 'ok'}},
+            }
+        },
     },
 }
 

--- a/docs/common/api/mcp.md
+++ b/docs/common/api/mcp.md
@@ -25,7 +25,9 @@ place instead of being copied into each consumer:
 - **`mount_prefix`** — the path prefix imbi-api mounts its routers under
   (the path of `IMBI_API_URL`, e.g. `/api`), read back off the spec.
   Spec paths carry it but a client's `base_url` does not, so anything
-  naming a path by hand has to add it back.
+  naming a path by hand has to add it back. Raises `ValueError` when the
+  prefix cannot be resolved unambiguously, so a spec glitch fails closed
+  rather than silently unanchoring the exclusions above.
 
 Keeping the *which* in imbi-api (it stamps the extension on tagged
 operations) and the *how to honour it* here means hiding a future endpoint

--- a/docs/common/api/mcp.md
+++ b/docs/common/api/mcp.md
@@ -10,8 +10,9 @@ the Imbi API's `/openapi.json` into a toolset via
 operations are kept out of those toolsets so the decision lives in one
 place instead of being copied into each consumer:
 
-- **`EXCLUDED_ROUTE_MAPS`** — a static path/method denylist (auth, MFA,
-  status, thumbnails) passed as `route_maps`.
+- **`excluded_route_maps`** — a path/method denylist (auth, MFA,
+  status, thumbnails) passed as `route_maps`, anchored at the spec's
+  mount prefix.
 - **`exclude_non_ai_tools`** — a `route_map_fn` that honours the
   `x-imbi-ai-tool: false` extension imbi-api stamps on sensitive
   operations (e.g. project Configuration / SSM Parameter Store).
@@ -21,6 +22,10 @@ place instead of being copied into each consumer:
 - **`PermissionFilterMiddleware`** — narrows `tools/list` per caller to
   the operations that caller has permission for. Requires
   `copy_permissions_to_meta`; advisory only, and fails open.
+- **`mount_prefix`** — the path prefix imbi-api mounts its routers under
+  (the path of `IMBI_API_URL`, e.g. `/api`), read back off the spec.
+  Spec paths carry it but a client's `base_url` does not, so anything
+  naming a path by hand has to add it back.
 
 Keeping the *which* in imbi-api (it stamps the extension on tagged
 operations) and the *how to honour it* here means hiding a future endpoint
@@ -34,8 +39,8 @@ imbi-common[mcp]
 
 ## Usage
 
-The two pieces compose — pass the static maps as `route_maps` (alongside
-any consumer-specific maps) and the hook as `route_map_fn`:
+The two pieces compose — pass the maps as `route_maps` (alongside any
+consumer-specific maps) and the hook as `route_map_fn`:
 
 ```python
 import fastmcp
@@ -48,7 +53,7 @@ server = fastmcp.FastMCP.from_openapi(
     openapi_spec=spec,
     client=client,
     name="Imbi",
-    route_maps=list(mcp.EXCLUDED_ROUTE_MAPS),
+    route_maps=mcp.excluded_route_maps(spec),
     route_map_fn=mcp.exclude_non_ai_tools,
 )
 ```
@@ -60,7 +65,7 @@ its own:
 server = fastmcp.FastMCP.from_openapi(
     openapi_spec=spec,
     client=client,
-    route_maps=[*mcp.EXCLUDED_ROUTE_MAPS, *MY_ROUTE_MAPS],
+    route_maps=[*mcp.excluded_route_maps(spec), *MY_ROUTE_MAPS],
     route_map_fn=mcp.exclude_non_ai_tools,
 )
 ```
@@ -76,18 +81,20 @@ add the `mcp_component_fn` and the middleware:
 server = fastmcp.FastMCP.from_openapi(
     openapi_spec=spec,
     client=client,
-    route_maps=list(mcp.EXCLUDED_ROUTE_MAPS),
+    route_maps=mcp.excluded_route_maps(spec),
     route_map_fn=mcp.exclude_non_ai_tools,
     mcp_component_fn=mcp.copy_permissions_to_meta,
 )
-server.add_middleware(mcp.PermissionFilterMiddleware(client))
+server.add_middleware(mcp.PermissionFilterMiddleware(client, spec))
 ```
 
 Both parts are required: without `copy_permissions_to_meta` no tool
 carries permission metadata, so the middleware has nothing to filter on
 and returns every tool. The `client` must forward the calling
 principal's credentials, or every caller is filtered against one
-identity.
+identity. Both take the spec so they can resolve the API's mount
+prefix — the profile lookup and the denylist patterns are absolute
+paths, and a deployment served under `/api` needs them prefixed.
 
 `exclude_non_ai_tools` is backward compatible: when the extension is
 absent it returns `None` and changes nothing, so a consumer can adopt it
@@ -98,7 +105,11 @@ likewise a no-op on operations with no `x-imbi-permission`.
 
 ::: imbi.common.mcp.AI_TOOL_EXTENSION
 
-::: imbi.common.mcp.EXCLUDED_ROUTE_MAPS
+::: imbi.common.mcp.PROFILE_PATH
+
+::: imbi.common.mcp.mount_prefix
+
+::: imbi.common.mcp.excluded_route_maps
 
 ::: imbi.common.mcp.exclude_non_ai_tools
 

--- a/libraries/common/src/imbi/common/mcp.py
+++ b/libraries/common/src/imbi/common/mcp.py
@@ -6,7 +6,7 @@ their toolsets by turning the Imbi API's ``/openapi.json`` into tools via
 operations are kept out of those toolsets so the policy lives in one place
 rather than being copied into each consumer:
 
-* :data:`EXCLUDED_ROUTE_MAPS` -- a static path/method denylist (auth, MFA,
+* :func:`excluded_route_maps` -- a path/method denylist (auth, MFA,
   status, thumbnails) passed as ``route_maps``.
 * :func:`exclude_non_ai_tools` -- a ``route_map_fn`` that honours the
   ``x-imbi-ai-tool: false`` extension imbi-api stamps on sensitive
@@ -15,8 +15,14 @@ rather than being copied into each consumer:
   ``tools/list`` per caller, dropping operations whose required
   permissions (``x-imbi-permission``) the caller does not hold.
 
-These compose. Pass ``EXCLUDED_ROUTE_MAPS`` (optionally alongside a
-consumer's own maps) as ``route_maps`` and :func:`exclude_non_ai_tools`
+The API mounts its routers under a deployment-specific path prefix (the
+path component of ``IMBI_API_URL``, e.g. ``/api``), which the spec's
+paths carry but a client's ``base_url`` does not. Everything here that
+names a path therefore derives that prefix from the spec via
+:func:`mount_prefix`.
+
+These compose. Pass ``excluded_route_maps(spec)`` (optionally alongside
+a consumer's own maps) as ``route_maps`` and :func:`exclude_non_ai_tools`
 as ``route_map_fn``. :class:`PermissionFilterMiddleware` additionally
 requires :func:`copy_permissions_to_meta` as ``mcp_component_fn`` --
 that is what records each operation's permissions on the tool, so
@@ -29,11 +35,11 @@ returned::
     server = fastmcp.FastMCP.from_openapi(
         openapi_spec=spec,
         client=client,
-        route_maps=list(mcp.EXCLUDED_ROUTE_MAPS),
+        route_maps=mcp.excluded_route_maps(spec),
         route_map_fn=mcp.exclude_non_ai_tools,
         mcp_component_fn=mcp.copy_permissions_to_meta,
     )
-    server.add_middleware(mcp.PermissionFilterMiddleware(client))
+    server.add_middleware(mcp.PermissionFilterMiddleware(client, spec))
 
 Requires the ``mcp`` extra (``imbi-common[mcp]``).
 
@@ -44,6 +50,7 @@ from __future__ import annotations
 import collections
 import hashlib
 import logging
+import re
 import time
 import typing
 
@@ -75,14 +82,62 @@ AI_TOOL_EXTENSION = 'x-imbi-ai-tool'
 #: toolset down to what that caller can actually invoke.
 PERMISSION_EXTENSION = 'x-imbi-permission'
 
-#: Endpoints that should never become AI tools regardless of tagging --
-#: authentication, MFA, the status probe, and image thumbnails.
-EXCLUDED_ROUTE_MAPS: list[RouteMap] = [
-    RouteMap(pattern=r'^/auth/', mcp_type=MCPType.EXCLUDE),
-    RouteMap(pattern=r'^/mfa/', mcp_type=MCPType.EXCLUDE),
-    RouteMap(pattern=r'^/status/?$', mcp_type=MCPType.EXCLUDE),
-    RouteMap(pattern=r'.*/thumbnail/?$', mcp_type=MCPType.EXCLUDE),
-]
+#: Spec path whose presence reveals the API's mount prefix. Every
+#: domain router is mounted under the prefix, so any known-prefixed
+#: operation works; this one is used because
+#: :class:`PermissionFilterMiddleware` has to call it anyway.
+PROFILE_PATH = '/users/me'
+
+
+def mount_prefix(spec: collections.abc.Mapping[str, typing.Any]) -> str:
+    """Return the path prefix the API's routers are mounted under.
+
+    imbi-api mounts every domain router under the path component of
+    ``IMBI_API_URL`` (e.g. ``/api``), so the spec describes
+    ``/api/users/me`` while an internal client's ``base_url`` is just
+    ``http://imbi-api:8000``. Anything that names a path by hand has to
+    add the prefix back, and the spec is the only place it appears.
+
+    Returns:
+        The prefix (``''`` when the API is mounted at the root),
+        derived from the spec path ending in :data:`PROFILE_PATH`.
+        Falls back to ``''`` when that path is absent, which leaves
+        behaviour as it was before the prefix was taken into account.
+
+    """
+    paths: collections.abc.Iterable[str] = spec.get('paths') or {}
+    matches = [path for path in paths if path.endswith(PROFILE_PATH)]
+    if len(matches) != 1:
+        LOGGER.warning(
+            'Expected exactly one spec path ending in %s, found %d; '
+            'assuming the API is mounted at the root',
+            PROFILE_PATH,
+            len(matches),
+        )
+        return ''
+    return matches[0].removesuffix(PROFILE_PATH)
+
+
+def excluded_route_maps(
+    spec: collections.abc.Mapping[str, typing.Any],
+) -> list[RouteMap]:
+    """Endpoints that must never become AI tools regardless of tagging.
+
+    Covers authentication, MFA, the status probe, and image thumbnails.
+    The patterns are anchored at the spec's mount prefix so they still
+    match on a deployment served under one (e.g. ``/api/auth/login``).
+
+    Args:
+        spec: The OpenAPI spec the toolset is built from.
+
+    """
+    prefix = re.escape(mount_prefix(spec))
+    return [
+        RouteMap(pattern=rf'^{prefix}/auth/', mcp_type=MCPType.EXCLUDE),
+        RouteMap(pattern=rf'^{prefix}/mfa/', mcp_type=MCPType.EXCLUDE),
+        RouteMap(pattern=rf'^{prefix}/status/?$', mcp_type=MCPType.EXCLUDE),
+        RouteMap(pattern=r'.*/thumbnail/?$', mcp_type=MCPType.EXCLUDE),
+    ]
 
 
 def exclude_non_ai_tools(
@@ -157,9 +212,11 @@ class PermissionFilterMiddleware(fastmcp.server.middleware.Middleware):
     permissions (see :data:`PERMISSION_EXTENSION`) the caller actually
     holds, so an agent is not offered hundreds of tools that can only
     ever return ``403``. The caller's effective permissions come from
-    the API's ``/users/me``, which reports ``is_admin`` and the
+    the API's :data:`PROFILE_PATH`, which reports ``is_admin`` and the
     ``permissions`` list; admins are never filtered, matching the
-    API's own admin bypass.
+    API's own admin bypass. That path is resolved against the spec's
+    :func:`mount_prefix`, since the client's ``base_url`` does not
+    carry the prefix the API is mounted under.
 
     Requires the server to have been built with
     :func:`copy_permissions_to_meta` as its ``mcp_component_fn``.
@@ -192,7 +249,11 @@ class PermissionFilterMiddleware(fastmcp.server.middleware.Middleware):
     #: Upper bound on cached profiles, evicted least-recently-used.
     CACHE_MAX_ENTRIES = 1024
 
-    def __init__(self, client: httpx.AsyncClient) -> None:
+    def __init__(
+        self,
+        client: httpx.AsyncClient,
+        spec: collections.abc.Mapping[str, typing.Any],
+    ) -> None:
         """Store the API client used to resolve the caller's profile.
 
         Args:
@@ -200,8 +261,11 @@ class PermissionFilterMiddleware(fastmcp.server.middleware.Middleware):
                 calling principal's credentials -- the same client used
                 to build the toolset. Its auth must be per-caller, or
                 every caller would be filtered against one identity.
+            spec: The OpenAPI spec the toolset was built from, used to
+                resolve the profile path against the API's mount prefix.
         """
         self._client = client
+        self._profile_path = f'{mount_prefix(spec)}{PROFILE_PATH}'
         self._cache: collections.OrderedDict[
             str, tuple[float, tuple[bool, set[str]]]
         ] = collections.OrderedDict()
@@ -247,7 +311,7 @@ class PermissionFilterMiddleware(fastmcp.server.middleware.Middleware):
             if cached is not None:
                 return cached
         try:
-            response = await self._client.get('/users/me')
+            response = await self._client.get(self._profile_path)
             response.raise_for_status()
             profile = response.json()
         except (httpx.HTTPError, ValueError):

--- a/libraries/common/src/imbi/common/mcp.py
+++ b/libraries/common/src/imbi/common/mcp.py
@@ -101,20 +101,25 @@ def mount_prefix(spec: collections.abc.Mapping[str, typing.Any]) -> str:
     Returns:
         The prefix (``''`` when the API is mounted at the root),
         derived from the spec path ending in :data:`PROFILE_PATH`.
-        Falls back to ``''`` when that path is absent, which leaves
-        behaviour as it was before the prefix was taken into account.
+
+    Raises:
+        ValueError: When the spec does not contain exactly one path
+            ending in :data:`PROFILE_PATH`. This fails *closed*:
+            assuming the root would unanchor
+            :func:`excluded_route_maps`, re-exposing auth and MFA
+            operations as tools, and would point
+            :class:`PermissionFilterMiddleware` at a profile URL that
+            does not exist.
 
     """
     paths: collections.abc.Iterable[str] = spec.get('paths') or {}
     matches = [path for path in paths if path.endswith(PROFILE_PATH)]
     if len(matches) != 1:
-        LOGGER.warning(
-            'Expected exactly one spec path ending in %s, found %d; '
-            'assuming the API is mounted at the root',
-            PROFILE_PATH,
-            len(matches),
+        raise ValueError(
+            f'Cannot determine the API mount prefix: expected exactly '
+            f'one spec path ending in {PROFILE_PATH}, found '
+            f'{len(matches)}'
         )
-        return ''
     return matches[0].removesuffix(PROFILE_PATH)
 
 

--- a/libraries/common/tests/test_mcp.py
+++ b/libraries/common/tests/test_mcp.py
@@ -47,16 +47,18 @@ class ExcludeNonAiToolsTestCase(unittest.TestCase):
 
 
 class ExcludedRouteMapsTestCase(unittest.TestCase):
-    """Unit tests for :data:`imbi.common.mcp.EXCLUDED_ROUTE_MAPS`."""
+    """Unit tests for :func:`imbi.common.mcp.excluded_route_maps`."""
 
     def test_all_maps_exclude(self) -> None:
-        """Every static map removes the matched route."""
-        for route_map in mcp.EXCLUDED_ROUTE_MAPS:
+        """Every map removes the matched route."""
+        for route_map in mcp.excluded_route_maps(_spec()):
             self.assertEqual(MCPType.EXCLUDE, route_map.mcp_type)
 
     def test_covers_sensitive_prefixes(self) -> None:
         """Auth, MFA, status, and thumbnail paths are all covered."""
-        patterns = {route_map.pattern for route_map in mcp.EXCLUDED_ROUTE_MAPS}
+        patterns = {
+            route_map.pattern for route_map in mcp.excluded_route_maps(_spec())
+        }
         self.assertEqual(
             {
                 r'^/auth/',
@@ -66,6 +68,45 @@ class ExcludedRouteMapsTestCase(unittest.TestCase):
             },
             patterns,
         )
+
+    def test_patterns_anchor_at_the_mount_prefix(self) -> None:
+        """A prefixed deployment gets prefixed patterns."""
+        patterns = {
+            route_map.pattern
+            for route_map in mcp.excluded_route_maps(_spec(prefix='/api'))
+        }
+        self.assertEqual(
+            {
+                r'^/api/auth/',
+                r'^/api/mfa/',
+                r'^/api/status/?$',
+                r'.*/thumbnail/?$',
+            },
+            patterns,
+        )
+
+
+class MountPrefixTestCase(unittest.TestCase):
+    """Unit tests for :func:`imbi.common.mcp.mount_prefix`."""
+
+    def test_root_mounted_spec(self) -> None:
+        """An unprefixed spec yields an empty prefix."""
+        self.assertEqual('', mcp.mount_prefix(_spec()))
+
+    def test_prefixed_spec(self) -> None:
+        """The prefix comes from the profile path's spec entry."""
+        self.assertEqual('/api', mcp.mount_prefix(_spec(prefix='/api')))
+
+    def test_multi_segment_prefix(self) -> None:
+        """Multi-segment prefixes are returned whole."""
+        self.assertEqual(
+            '/imbi/api', mcp.mount_prefix(_spec(prefix='/imbi/api'))
+        )
+
+    def test_missing_profile_path_falls_back_to_root(self) -> None:
+        """Without the anchor path the API is assumed root-mounted."""
+        with self.assertLogs('imbi.common.mcp', level='WARNING'):
+            self.assertEqual('', mcp.mount_prefix(_openapi_spec({})))
 
 
 #: Boilerplate ``responses`` block every test operation needs.
@@ -81,13 +122,23 @@ def _openapi_spec(paths: dict[str, object]) -> dict[str, object]:
     }
 
 
-def _spec() -> dict[str, object]:
-    """Minimal OpenAPI spec exercising each exclusion path."""
+def _spec(prefix: str = '') -> dict[str, object]:
+    """Minimal OpenAPI spec exercising each exclusion path.
+
+    ``prefix`` mimics the path the API is mounted under (the path
+    component of ``IMBI_API_URL``), which every generated spec path
+    carries.
+    """
     return _openapi_spec(
         {
-            '/projects/': {'get': {'operationId': 'list_projects', **OK}},
-            '/auth/login': {'post': {'operationId': 'login', **OK}},
-            '/configuration/{key}': {
+            f'{prefix}/projects/': {
+                'get': {'operationId': 'list_projects', **OK}
+            },
+            f'{prefix}/users/me': {
+                'get': {'operationId': 'get_current_user_profile', **OK}
+            },
+            f'{prefix}/auth/login': {'post': {'operationId': 'login', **OK}},
+            f'{prefix}/configuration/{{key}}': {
                 'put': {
                     'operationId': 'set_configuration_value',
                     'x-imbi-ai-tool': False,
@@ -101,21 +152,34 @@ def _spec() -> dict[str, object]:
 class FromOpenapiExclusionTests(unittest.IsolatedAsyncioTestCase):
     """End-to-end: the policy excludes the right tools via fastmcp."""
 
-    async def test_policy_excludes_expected_tools(self) -> None:
-        """A real server build drops auth and AI-flagged operations."""
+    async def _tool_names(self, prefix: str = '') -> set[str]:
+        """Build a server from the policy and list its tools."""
+        spec = _spec(prefix)
         client = httpx.AsyncClient(base_url='http://localhost:8000')
         try:
             server = fastmcp.FastMCP.from_openapi(
-                openapi_spec=_spec(),
+                openapi_spec=spec,
                 client=client,
                 name='Imbi',
-                route_maps=list(mcp.EXCLUDED_ROUTE_MAPS),
+                route_maps=mcp.excluded_route_maps(spec),
                 route_map_fn=mcp.exclude_non_ai_tools,
             )
             async with fastmcp.Client(server) as connected:
-                names = {tool.name for tool in await connected.list_tools()}
+                return {tool.name for tool in await connected.list_tools()}
         finally:
             await client.aclose()
+
+    async def test_policy_excludes_expected_tools(self) -> None:
+        """A real server build drops auth and AI-flagged operations."""
+        names = await self._tool_names()
+
+        self.assertIn('list_projects', names)
+        self.assertNotIn('login', names)
+        self.assertNotIn('set_configuration_value', names)
+
+    async def test_policy_excludes_expected_tools_when_prefixed(self) -> None:
+        """The same holds when the API is mounted under a prefix."""
+        names = await self._tool_names('/api')
 
         self.assertIn('list_projects', names)
         self.assertNotIn('login', names)
@@ -126,11 +190,25 @@ class FromOpenapiExclusionTests(unittest.IsolatedAsyncioTestCase):
         self.assertIn('x-imbi-ai-tool', json.dumps(_spec()))
 
 
-def _permission_spec() -> dict[str, object]:
-    """Spec whose operations carry ``x-imbi-permission``."""
+def _permission_spec(prefix: str = '') -> dict[str, object]:
+    """Spec whose operations carry ``x-imbi-permission``.
+
+    ``prefix`` mounts every path under a deployment prefix, as imbi-api
+    does when ``IMBI_API_URL`` carries a path. The profile operation is
+    flagged off-limits for AI so it never joins the toolset -- it is
+    here only because it is what :func:`imbi.common.mcp.mount_prefix`
+    reads the prefix from.
+    """
     return _openapi_spec(
         {
-            '/projects/': {
+            f'{prefix}/users/me': {
+                'get': {
+                    'operationId': 'get_current_user_profile',
+                    'x-imbi-ai-tool': False,
+                    **OK,
+                }
+            },
+            f'{prefix}/projects/': {
                 'get': {
                     'operationId': 'list_projects',
                     'x-imbi-permission': ['project:read'],
@@ -142,14 +220,14 @@ def _permission_spec() -> dict[str, object]:
                     **OK,
                 },
             },
-            '/graph/query': {
+            f'{prefix}/graph/query': {
                 'post': {
                     'operationId': 'graph_query',
                     'x-imbi-permission': ['admin'],
                     **OK,
                 }
             },
-            '/ungated': {'get': {'operationId': 'ungated_op', **OK}},
+            f'{prefix}/ungated': {'get': {'operationId': 'ungated_op', **OK}},
         }
     )
 
@@ -158,27 +236,31 @@ class PermissionFilterMiddlewareTests(unittest.IsolatedAsyncioTestCase):
     """Per-caller filtering of ``tools/list``."""
 
     async def _tool_names(
-        self, handler: typing.Callable[[httpx.Request], httpx.Response]
+        self,
+        handler: typing.Callable[[httpx.Request], httpx.Response],
+        prefix: str = '',
     ) -> set[str]:
         """Build a filtered server and list its tools.
 
         ``handler`` stands in for the API, answering the middleware's
-        ``/users/me`` lookup.
+        profile lookup. ``prefix`` mounts the spec under a deployment
+        path prefix.
         """
+        spec = _permission_spec(prefix)
         client = httpx.AsyncClient(
             base_url='http://localhost:8000',
             transport=httpx.MockTransport(handler),
         )
         try:
             server = fastmcp.FastMCP.from_openapi(
-                openapi_spec=_permission_spec(),
+                openapi_spec=spec,
                 client=client,
                 name='Imbi',
-                route_maps=list(mcp.EXCLUDED_ROUTE_MAPS),
+                route_maps=mcp.excluded_route_maps(spec),
                 route_map_fn=mcp.exclude_non_ai_tools,
                 mcp_component_fn=mcp.copy_permissions_to_meta,
             )
-            server.add_middleware(mcp.PermissionFilterMiddleware(client))
+            server.add_middleware(mcp.PermissionFilterMiddleware(client, spec))
             async with fastmcp.Client(server) as connected:
                 return {tool.name for tool in await connected.list_tools()}
         finally:
@@ -201,6 +283,26 @@ class PermissionFilterMiddlewareTests(unittest.IsolatedAsyncioTestCase):
         names = await self._tool_names(
             self._profile(is_admin=False, permissions=['project:read'])
         )
+        self.assertEqual({'list_projects', 'ungated_op'}, names)
+
+    async def test_profile_lookup_uses_the_mount_prefix(self) -> None:
+        """The lookup targets the spec's path, not a bare ``/users/me``.
+
+        imbi-api mounts its routers under the path of ``IMBI_API_URL``
+        while the client's ``base_url`` has no path, so a hard-coded
+        ``/users/me`` 404s and filtering silently fails open.
+        """
+        requested: list[str] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            requested.append(request.url.path)
+            return httpx.Response(
+                200, json={'is_admin': False, 'permissions': ['project:read']}
+            )
+
+        names = await self._tool_names(handler, prefix='/api')
+
+        self.assertEqual(['/api/users/me'], requested)
         self.assertEqual({'list_projects', 'ungated_op'}, names)
 
     async def test_admin_sees_every_tool(self) -> None:
@@ -270,7 +372,9 @@ class PermissionCacheTests(unittest.IsolatedAsyncioTestCase):
             base_url='http://localhost:8000',
             transport=httpx.MockTransport(handler),
         )
-        self.middleware = mcp.PermissionFilterMiddleware(self.client)
+        self.middleware = mcp.PermissionFilterMiddleware(
+            self.client, _permission_spec()
+        )
 
     async def asyncTearDown(self) -> None:
         await self.client.aclose()

--- a/libraries/common/tests/test_mcp.py
+++ b/libraries/common/tests/test_mcp.py
@@ -103,10 +103,21 @@ class MountPrefixTestCase(unittest.TestCase):
             '/imbi/api', mcp.mount_prefix(_spec(prefix='/imbi/api'))
         )
 
-    def test_missing_profile_path_falls_back_to_root(self) -> None:
-        """Without the anchor path the API is assumed root-mounted."""
-        with self.assertLogs('imbi.common.mcp', level='WARNING'):
-            self.assertEqual('', mcp.mount_prefix(_openapi_spec({})))
+    def test_missing_profile_path_raises(self) -> None:
+        """Without the anchor path the prefix cannot be resolved."""
+        with self.assertRaises(ValueError):
+            mcp.mount_prefix(_openapi_spec({}))
+
+    def test_ambiguous_profile_path_raises(self) -> None:
+        """Two candidate anchors are ambiguous, so resolution fails."""
+        spec = _openapi_spec(
+            {
+                f'/api{mcp.PROFILE_PATH}': {'get': OK},
+                f'/v2{mcp.PROFILE_PATH}': {'get': OK},
+            }
+        )
+        with self.assertRaises(ValueError):
+            mcp.mount_prefix(spec)
 
 
 #: Boilerplate ``responses`` block every test operation needs.


### PR DESCRIPTION
## Summary

The shared AI-toolset policy in `imbi-common` named API paths by hand and assumed the API was mounted at the root. It is not: imbi-api mounts every domain router under the path component of `IMBI_API_URL` (`https://imbi.aweber.io/api` → `/api`), and the generated OpenAPI paths carry that prefix while an internal client's `base_url` (`http://imbi-api:8000`) does not.

## Problem

Two distinct failures on any prefixed deployment — which is every real one:

1. **Permission filtering never worked.** `PermissionFilterMiddleware` requested a bare `/users/me`, which Starlette 404s before auth runs. Filtering is advisory and fails open, so every caller got the *unfiltered* tool list. In the logs:

   ```
   imbi.common.access: 127.0.0.1 - davejs "GET /users/me HTTP/1.1" 404
   Could not resolve caller permissions; returning the unfiltered tool list
   httpx.HTTPStatusError: Client error '404 Not Found' for url 'http://localhost:8000/users/me'
   ```

2. **Auth and MFA endpoints became AI tools.** `EXCLUDED_ROUTE_MAPS` anchored its patterns at `^/auth/`, `^/mfa/`, `^/status/?$`; fastmcp `re.search`es those against the spec path, so none match `/api/auth/login`. Those endpoints are excluded by pattern alone — imbi-api only stamps `x-imbi-ai-tool: false` on the `Project: Configuration` tag — so they were exposed as callable tools. (Found while fixing #1; same root cause, so it is fixed here.)

## Solution

- Add `mount_prefix(spec)`, reading the prefix back off the one place it appears: the spec path ending in `/users/me`. Falls back to `''` with a warning if that path is absent.
- `PermissionFilterMiddleware(client, spec)` now resolves its profile lookup against that prefix.
- `EXCLUDED_ROUTE_MAPS` becomes `excluded_route_maps(spec)`, anchoring the auth/MFA/status patterns at the prefix. The thumbnail pattern was already prefix-agnostic.
- Update the three consumers (`imbi-mcp`, `imbi-assistant`, `imbi-slackbot`) and `docs/common/api/mcp.md`.

## Testing

`libraries/common/tests/test_mcp.py` now parameterises its specs by mount prefix and adds coverage for the regressions:

- the profile lookup targets `/api/users/me` (asserted on the recorded request path) and filtering actually filters
- prefixed exclusion patterns still drop auth and AI-flagged operations
- `mount_prefix` for root, single-, and multi-segment prefixes, plus the missing-anchor fallback

`pytest libraries/common/tests/test_mcp.py apps/mcp/tests apps/slackbot/tests apps/assistant/tests` → 374 passed. `ruff check`/`format`, `basedpyright`, and `mypy` clean on the changed files.