### PR TITLE
Let the document reader use the full page width

### DIFF
--- a/ui/src/components/documents/DocumentsPinboardReader.tsx
+++ b/ui/src/components/documents/DocumentsPinboardReader.tsx
@@ -246,7 +246,10 @@ export function DocumentsPinboardReader({
 
   // Reader is navigable from the same tab; filter rail keeps rail semantics.
   return (
-    <div className="grid grid-cols-1 gap-5 lg:grid-cols-[220px_1fr]">
+    <div
+      className="grid grid-cols-1 gap-5 lg:grid-cols-[220px_1fr]"
+      data-documents-reader
+    >
       <DocumentsFilterRail
         active={EMPTY_ACTIVE}
         counts={counts}

--- a/ui/src/pages/DocumentsIndexPage.tsx
+++ b/ui/src/pages/DocumentsIndexPage.tsx
@@ -69,7 +69,10 @@ export function DocumentsIndexPage() {
         className="px-6 pt-20 pb-12"
         style={{ paddingBottom: 'var(--assistant-height, 64px)' }}
       >
-        <div className="mx-auto max-w-7xl">
+        {/* The reader lays out its own rail / content / margin columns and
+            wants the whole viewport for them, so the content column can grow;
+            every other view stays measured. */}
+        <div className="mx-auto max-w-7xl has-[[data-documents-reader]]:max-w-none">
           {!orgSlug && <DocumentsIndexSkeleton />}
           {orgSlug && (
             <DocumentsIndexBody


### PR DESCRIPTION
## Summary

The document reader on the org Documents page now spans the full page width: the filter rail sits on the left margin, the "On this page" / related-documents column on the right margin, and the article content column takes everything in between.

## Problem

`DocumentsIndexPage` wraps every view in a `mx-auto max-w-7xl` container. That is right for the feed, index, and editor, but in the reader it inset both side columns from the viewport edges and squeezed the article into whatever 1280px minus 220px rail minus 260px margin minus gaps left over — leaving unused space on both sides on any wide display.

## Solution

- Tag the reader's root grid with `data-documents-reader`.
- On the page container, drop the max width when that element is present, using Tailwind's `has-*` variant: `has-[[data-documents-reader]]:max-w-none`.

No prop plumbing through `DocumentsTab`, and every other view on the page keeps its measured width. Verified in the running dev environment with inline comments both hidden (rail / content / margin) and shown (rail / content / margin / comment bar).