### PR TITLE
Index nodes into vector search on write, not just on backfill

### DIFF
--- a/apps/api/src/imbi/api/backfill_embeddings.py
+++ b/apps/api/src/imbi/api/backfill_embeddings.py
@@ -4,8 +4,12 @@ Run with::
 
     uv run python -m imbi.api.backfill_embeddings
 
-Iterates every embeddable node type and calls ``_auto_embed`` for each
-instance.  By default skips any node that already has an embedding row
+Iterates every embeddable node type and re-embeds each instance.  The
+Maintenance admin page offers the same job as the ``search-reindex``
+operation, which is the better route for a running deployment; this
+script stays for offline/CLI runs against a database with no API up.
+
+By default it skips any node that already has an embedding row
 in ``public.embeddings`` so the script is safely resumable -- pass
 ``--force`` to re-embed everything.  Per-type batches fan out
 concurrently up to ``--concurrency`` so a backfill against a remote
@@ -21,39 +25,12 @@ import typing
 import psycopg
 
 from imbi.common import graph, models
-from imbi.common.graph.client import (
-    _embeddable_fields,  # type: ignore[attr-defined]
-)
 
 logging.basicConfig(
     level=logging.INFO,
     format='%(asctime)s %(levelname)-8s %(name)s: %(message)s',
 )
 LOGGER = logging.getLogger('backfill_embeddings')
-
-# Node subclasses — _auto_embed is called normally.
-_NODE_TYPES: list[type[models.Node]] = [
-    models.Organization,
-    models.Blueprint,
-    models.Team,
-    models.Environment,
-    models.ProjectType,
-    models.Integration,
-    models.Tag,
-    models.LinkDefinition,
-    models.DocumentTemplate,
-    models.Project,
-]
-
-# GraphModel types that have Embeddable fields but are not Node subclasses.
-# match() still works via model_construct fallback; _auto_embed embeds any
-# GraphModel that declares Embeddable fields.
-_GRAPH_MODEL_TYPES: list[type[models.GraphModel]] = [
-    models.Document,
-    models.Release,
-    models.Comment,
-    models.Component,
-]
 
 _DEFAULT_CONCURRENCY = 4
 
@@ -91,13 +68,11 @@ async def _embed_type(
     )
 
     async def _embed_one(node: models.GraphModel) -> int:
-        if not _embeddable_fields(node):  # type: ignore[arg-type]
-            return 0
         if node.id in skip_ids:
             return 0
         async with semaphore:
             try:
-                await db._auto_embed(node)  # type: ignore[arg-type]
+                await db.embed_node(node, raise_on_error=True)
             except psycopg.Error:
                 LOGGER.exception('Failed to embed %s id=%s', label, node.id)
                 return 0
@@ -113,7 +88,7 @@ async def run(*, concurrency: int, force: bool) -> None:
     semaphore = asyncio.Semaphore(concurrency)
     try:
         total = 0
-        for node_type in [*_NODE_TYPES, *_GRAPH_MODEL_TYPES]:
+        for node_type in graph.embeddable_node_types():
             label = node_type.__name__
             LOGGER.info(
                 'Embedding %s nodes (concurrency=%d, force=%s)...',

--- a/apps/api/src/imbi/api/endpoints/_search_index.py
+++ b/apps/api/src/imbi/api/endpoints/_search_index.py
@@ -12,11 +12,11 @@ until the next reindex.
 
 Embedding chunks and runs a local model, so callers on a request path
 should schedule :func:`index` as a background task rather than paying
-for it before the response.
+for it before the response.  It re-reads the node when it runs, so the
+caller only has to name the node, not hand over the values it wrote.
 """
 
 import logging
-import typing
 
 from imbi.common import graph, models
 
@@ -29,22 +29,35 @@ async def index(
     node_id: str,
     *,
     raise_on_error: bool = False,
-    **fields: typing.Any,
-) -> None:
-    """(Re)build the embeddings for one node from *fields*.
+) -> bool:
+    """(Re)build the embeddings for one node from its persisted state.
 
-    Pass the node's embeddable fields by name (``title=``/``content=``
-    for a document, ``body=`` for a comment, ...).  ``model_construct``
-    skips validation because only those fields are read.
+    The node is re-read here rather than embedded from the values the
+    caller wrote, because nothing orders the background tasks two
+    concurrent edits schedule.  Embedding the queued payload lets the
+    older task run last and leave the vector index holding stale text;
+    re-reading means whichever task runs last embeds the row as it
+    actually stands, which is correct either way round.
+
+    A node that was deleted between the write and this task is skipped
+    -- ``drop`` has already cleared its rows.  Returns whether the node
+    was found and embedded, which the reindex operation reports as
+    ``succeeded`` vs ``skipped``.
 
     Failures are logged and swallowed, which suits a best-effort call
     alongside a graph write; pass ``raise_on_error`` when indexing *is*
     the job (a reindex) and silent failure would look like success.
     """
-    await db.embed_node(
-        node_type.model_construct(id=node_id, **fields),
-        raise_on_error=raise_on_error,
-    )
+    nodes = await db.match(node_type, {'id': node_id})
+    if not nodes:
+        LOGGER.debug(
+            'Skipping index of %s id=%s; the node is gone',
+            node_type.__name__,
+            node_id,
+        )
+        return False
+    await db.embed_node(nodes[0], raise_on_error=raise_on_error)
+    return True
 
 
 async def drop(

--- a/apps/api/src/imbi/api/endpoints/_search_index.py
+++ b/apps/api/src/imbi/api/endpoints/_search_index.py
@@ -15,9 +15,12 @@ should schedule :func:`index` as a background task rather than paying
 for it before the response.
 """
 
+import logging
 import typing
 
 from imbi.common import graph, models
+
+LOGGER = logging.getLogger(__name__)
 
 
 async def index(
@@ -49,5 +52,20 @@ async def drop(
     node_type: type[models.GraphModel],
     node_id: str,
 ) -> None:
-    """Delete every embedding row for a node that was just deleted."""
-    await db.delete_node_embeddings(node_type.__name__, node_id)
+    """Delete every embedding row for a node that was just deleted.
+
+    Best-effort like :func:`index`: the node itself is already gone by
+    the time this runs, so a failure here must not turn a successful
+    delete into a 500.  The orphaned rows are cleaned up by the next
+    ``search-reindex``.
+    """
+    try:
+        await db.delete_node_embeddings(node_type.__name__, node_id)
+    except Exception:  # noqa: BLE001
+        LOGGER.warning(
+            'Failed to drop embeddings for %s id=%s; a search-reindex '
+            'will clean this up',
+            node_type.__name__,
+            node_id,
+            exc_info=True,
+        )

--- a/apps/api/src/imbi/api/endpoints/_search_index.py
+++ b/apps/api/src/imbi/api/endpoints/_search_index.py
@@ -1,0 +1,53 @@
+"""Keep vector-search embeddings in step with raw-Cypher writes.
+
+The graph client embeds a node's ``Embeddable`` fields automatically
+when it is written through ``db.create``/``db.merge`` and clears them on
+``db.delete``.  Endpoints in this package write their nodes as raw
+Cypher through ``db.execute`` instead -- there is no model for the
+client to inspect, so nothing is embedded.  Any such write of a node
+type with ``Embeddable`` fields (``Document``, ``Comment``, ``Release``,
+``Project``) must call :func:`index` after a create/update and
+:func:`drop` after a delete, or the node silently falls out of search
+until the next reindex.
+
+Embedding chunks and runs a local model, so callers on a request path
+should schedule :func:`index` as a background task rather than paying
+for it before the response.
+"""
+
+import typing
+
+from imbi.common import graph, models
+
+
+async def index(
+    db: graph.Graph,
+    node_type: type[models.GraphModel],
+    node_id: str,
+    *,
+    raise_on_error: bool = False,
+    **fields: typing.Any,
+) -> None:
+    """(Re)build the embeddings for one node from *fields*.
+
+    Pass the node's embeddable fields by name (``title=``/``content=``
+    for a document, ``body=`` for a comment, ...).  ``model_construct``
+    skips validation because only those fields are read.
+
+    Failures are logged and swallowed, which suits a best-effort call
+    alongside a graph write; pass ``raise_on_error`` when indexing *is*
+    the job (a reindex) and silent failure would look like success.
+    """
+    await db.embed_node(
+        node_type.model_construct(id=node_id, **fields),
+        raise_on_error=raise_on_error,
+    )
+
+
+async def drop(
+    db: graph.Graph,
+    node_type: type[models.GraphModel],
+    node_id: str,
+) -> None:
+    """Delete every embedding row for a node that was just deleted."""
+    await db.delete_node_embeddings(node_type.__name__, node_id)

--- a/apps/api/src/imbi/api/endpoints/_search_index.py
+++ b/apps/api/src/imbi/api/endpoints/_search_index.py
@@ -47,8 +47,23 @@ async def index(
     Failures are logged and swallowed, which suits a best-effort call
     alongside a graph write; pass ``raise_on_error`` when indexing *is*
     the job (a reindex) and silent failure would look like success.
+    That covers the re-read as well as the embedding: a lookup that
+    raises out of a background task would abort the tasks queued behind
+    it, which is too much collateral for an index refresh.
     """
-    nodes = await db.match(node_type, {'id': node_id})
+    try:
+        nodes = await db.match(node_type, {'id': node_id})
+    except Exception:
+        if raise_on_error:
+            raise
+        LOGGER.warning(
+            'Failed to look up %s id=%s to index; a search-reindex '
+            'will pick it up',
+            node_type.__name__,
+            node_id,
+            exc_info=True,
+        )
+        return False
     if not nodes:
         LOGGER.debug(
             'Skipping index of %s id=%s; the node is gone',

--- a/apps/api/src/imbi/api/endpoints/comments.py
+++ b/apps/api/src/imbi/api/endpoints/comments.py
@@ -24,7 +24,8 @@ import nanoid
 import pydantic
 
 from imbi.api.auth import permissions
-from imbi.common import graph
+from imbi.api.endpoints import _search_index
+from imbi.common import graph, models
 from imbi.common import patch as json_patch
 from imbi.common.clickhouse import client as ch_client
 
@@ -423,6 +424,7 @@ async def create_comment_thread(
     document_id: str,
     data: CommentThreadCreate,
     db: graph.Pool,
+    background_tasks: fastapi.BackgroundTasks,
     auth: typing.Annotated[
         permissions.AuthContext,
         fastapi.Depends(permissions.require_permission('comment:create')),
@@ -519,6 +521,13 @@ async def create_comment_thread(
         principal=auth.principal_name,
         body=data.body,
     )
+    background_tasks.add_task(
+        _search_index.index,
+        db,
+        models.Comment,
+        comment_id,
+        body=data.body,
+    )
     return thread
 
 
@@ -533,6 +542,7 @@ async def create_reply(
     thread_id: str,
     data: CommentBodyCreate,
     db: graph.Pool,
+    background_tasks: fastapi.BackgroundTasks,
     auth: typing.Annotated[
         permissions.AuthContext,
         fastapi.Depends(permissions.require_permission('comment:create')),
@@ -592,6 +602,13 @@ async def create_reply(
         kind='',
         action='replied',
         principal=auth.principal_name,
+        body=data.body,
+    )
+    background_tasks.add_task(
+        _search_index.index,
+        db,
+        models.Comment,
+        comment_id,
         body=data.body,
     )
     return _parse_comment(records[0]['c'])
@@ -682,6 +699,7 @@ async def patch_comment(
     comment_id: str,
     operations: list[json_patch.PatchOperation],
     db: graph.Pool,
+    background_tasks: fastapi.BackgroundTasks,
     auth: typing.Annotated[
         permissions.AuthContext,
         fastapi.Depends(permissions.require_permission('comment:write')),
@@ -755,6 +773,14 @@ async def patch_comment(
     if not records:
         raise fastapi.HTTPException(
             status_code=404, detail=f'Comment {comment_id!r} not found'
+        )
+    if update.body != existing['body']:
+        background_tasks.add_task(
+            _search_index.index,
+            db,
+            models.Comment,
+            comment_id,
+            body=update.body,
         )
     return _parse_comment(records[0]['c'])
 
@@ -903,3 +929,4 @@ async def delete_comment(
         raise fastapi.HTTPException(
             status_code=404, detail=f'Comment {comment_id!r} not found'
         )
+    await _search_index.drop(db, models.Comment, comment_id)

--- a/apps/api/src/imbi/api/endpoints/comments.py
+++ b/apps/api/src/imbi/api/endpoints/comments.py
@@ -526,7 +526,6 @@ async def create_comment_thread(
         db,
         models.Comment,
         comment_id,
-        body=data.body,
     )
     return thread
 
@@ -609,7 +608,6 @@ async def create_reply(
         db,
         models.Comment,
         comment_id,
-        body=data.body,
     )
     return _parse_comment(records[0]['c'])
 
@@ -780,7 +778,6 @@ async def patch_comment(
             db,
             models.Comment,
             comment_id,
-            body=update.body,
         )
     return _parse_comment(records[0]['c'])
 

--- a/apps/api/src/imbi/api/endpoints/documents.py
+++ b/apps/api/src/imbi/api/endpoints/documents.py
@@ -394,8 +394,6 @@ async def _create_document_impl(
         db,
         models.Document,
         document_id,
-        title=data.title,
-        content=data.content,
     )
 
     document = await fetch_document(db, org_slug, document_id)
@@ -1027,8 +1025,6 @@ async def apply_document_update(
             db,
             models.Document,
             document_id,
-            title=title,
-            content=content,
         )
 
     document = await fetch_document(db, org_slug, document_id, project_id)

--- a/apps/api/src/imbi/api/endpoints/documents.py
+++ b/apps/api/src/imbi/api/endpoints/documents.py
@@ -23,14 +23,14 @@ import nanoid
 import pydantic
 
 from imbi.api.auth import permissions
-from imbi.api.endpoints import _document_history
+from imbi.api.endpoints import _document_history, _search_index
 from imbi.api.endpoints._helpers import fetch_or_404
 from imbi.api.endpoints._pagination import (
     build_link_header,
     decode_cursor,
     encode_cursor,
 )
-from imbi.common import graph
+from imbi.common import graph, models
 from imbi.common import patch as json_patch
 
 LOGGER = logging.getLogger(__name__)
@@ -386,6 +386,16 @@ async def _create_document_impl(
         tags=tag_slugs,
         created_by=auth.principal_name,
         created_at=now,
+    )
+    # Embedding a long markdown document costs a chunked model run,
+    # so it runs after the response for the same reason.
+    background_tasks.add_task(
+        _search_index.index,
+        db,
+        models.Document,
+        document_id,
+        title=data.title,
+        content=data.content,
     )
 
     document = await fetch_document(db, org_slug, document_id)
@@ -944,6 +954,12 @@ async def apply_document_update(
     content_changed = _document_history.has_changed(
         existing, title, content, tags
     )
+    # Tags are not embedded, so a tag-only edit -- which still cuts a new
+    # version -- must not re-chunk and re-embed the whole document.
+    text_changed = (
+        title != str(existing.get('title') or '')
+        or content != existing['content']
+    )
 
     scope, scope_params = _scope_filter(project_id)
     now = datetime.datetime.now(datetime.UTC)
@@ -1003,6 +1019,16 @@ async def apply_document_update(
             change_kind=change_kind,
             updated_by=auth.principal_name,
             updated_at=now,
+        )
+
+    if text_changed:
+        background_tasks.add_task(
+            _search_index.index,
+            db,
+            models.Document,
+            document_id,
+            title=title,
+            content=content,
         )
 
     document = await fetch_document(db, org_slug, document_id, project_id)
@@ -1088,6 +1114,7 @@ async def _delete_document_impl(
         raise fastapi.HTTPException(
             status_code=404, detail=f'Document {document_id!r} not found'
         )
+    await _search_index.drop(db, models.Document, document_id)
 
 
 @documents_router.delete('/{document_id}', status_code=204)

--- a/apps/api/src/imbi/api/endpoints/projects.py
+++ b/apps/api/src/imbi/api/endpoints/projects.py
@@ -1437,8 +1437,6 @@ async def create_project(
         db,
         models.Project,
         project_id,
-        name=props['name'],
-        description=props.get('description'),
     )
     return ProjectMutationResponse(
         **ProjectResponse.model_validate(project_data).model_dump(),
@@ -2913,8 +2911,6 @@ async def patch_project(
             db,
             models.Project,
             project_id,
-            name=response.name,
-            description=response.description,
         )
     await score_queue.enqueue_recompute(
         valkey_client, project_id, 'attribute_change'

--- a/apps/api/src/imbi/api/endpoints/projects.py
+++ b/apps/api/src/imbi/api/endpoints/projects.py
@@ -20,6 +20,7 @@ from imbi.api import blueprint_attributes
 from imbi.api.auth import permissions
 from imbi.api.domain import scoring as scoring_models
 from imbi.api.domain.models import ExistsInResponse
+from imbi.api.endpoints import _search_index
 from imbi.api.endpoints._helpers import conflict_on_unique_violation
 from imbi.api.endpoints._json_fields import (
     JSONFields,
@@ -1237,6 +1238,7 @@ async def create_project(
     org_slug: str,
     data: ProjectCreate,
     request: fastapi.Request,
+    background: fastapi.BackgroundTasks,
     db: graph.Pool,
     valkey_client: OptionalValkeyClient,
     auth: typing.Annotated[
@@ -1430,6 +1432,14 @@ async def create_project(
             'Lifecycle dispatch failed after creating project %s',
             project_id,
         )
+    background.add_task(
+        _search_index.index,
+        db,
+        models.Project,
+        project_id,
+        name=props['name'],
+        description=props.get('description'),
+    )
     return ProjectMutationResponse(
         **ProjectResponse.model_validate(project_data).model_dump(),
         lifecycle_results=lifecycle_results,
@@ -2895,6 +2905,17 @@ async def patch_project(
         request,
         db,
     )
+    if response.name != project_data.get(
+        'name'
+    ) or response.description != project_data.get('description'):
+        background.add_task(
+            _search_index.index,
+            db,
+            models.Project,
+            project_id,
+            name=response.name,
+            description=response.description,
+        )
     await score_queue.enqueue_recompute(
         valkey_client, project_id, 'attribute_change'
     )
@@ -3307,6 +3328,7 @@ async def delete_project(
             status_code=404,
             detail=f'Project {project_id!r} not found',
         )
+    await _search_index.drop(db, models.Project, project_id)
 
     # Project node is gone; never let a dispatch hiccup turn a
     # successful delete into a 500.  ``delete_repository=false`` skips

--- a/apps/api/src/imbi/api/endpoints/releases.py
+++ b/apps/api/src/imbi/api/endpoints/releases.py
@@ -1006,14 +1006,17 @@ async def patch_release(
             ),
         )
     release_data = graph.parse_agtype(rows[0]['release'])
-    background_tasks.add_task(
-        _search_index.index,
-        db,
-        models.Release,
-        release_id,
-        title=merged_title,
-        description=merged_description,
-    )
+    if merged_title != data['title'] or merged_description != data.get(
+        'description'
+    ):
+        background_tasks.add_task(
+            _search_index.index,
+            db,
+            models.Release,
+            release_id,
+            title=merged_title,
+            description=merged_description,
+        )
     return _release_to_response(release_data, project_id)
 
 

--- a/apps/api/src/imbi/api/endpoints/releases.py
+++ b/apps/api/src/imbi/api/endpoints/releases.py
@@ -589,8 +589,6 @@ async def create_release(
         db,
         models.Release,
         props['id'],
-        title=props['title'],
-        description=description,
     )
     return _release_to_response(release_data, project_id)
 
@@ -1014,8 +1012,6 @@ async def patch_release(
             db,
             models.Release,
             release_id,
-            title=merged_title,
-            description=merged_description,
         )
     return _release_to_response(release_data, project_id)
 

--- a/apps/api/src/imbi/api/endpoints/releases.py
+++ b/apps/api/src/imbi/api/endpoints/releases.py
@@ -23,6 +23,7 @@ import pydantic
 from imbi.api import sbom
 from imbi.api.auth import permissions
 from imbi.api.domain.models import User
+from imbi.api.endpoints import _search_index
 from imbi.api.endpoints._helpers import fetch_or_404
 from imbi.api.endpoints.operations_log import complete_opslog_entry
 from imbi.api.endpoints.projects import lookup_ops_log_performed_by
@@ -474,6 +475,7 @@ async def create_release(
     project_id: str,
     data: ReleaseCreate,
     db: graph.Pool,
+    background_tasks: fastapi.BackgroundTasks,
     auth: typing.Annotated[
         permissions.AuthContext,
         fastapi.Depends(
@@ -582,6 +584,14 @@ async def create_release(
             detail=f'Project {project_id!r} not found',
         )
     release_data = graph.parse_agtype(rows[0]['release'])
+    background_tasks.add_task(
+        _search_index.index,
+        db,
+        models.Release,
+        props['id'],
+        title=props['title'],
+        description=description,
+    )
     return _release_to_response(release_data, project_id)
 
 
@@ -879,6 +889,7 @@ async def patch_release(
     release_id: str,
     operations: list[json_patch.PatchOperation],
     db: graph.Pool,
+    background_tasks: fastapi.BackgroundTasks,
     _auth: typing.Annotated[
         permissions.AuthContext,
         fastapi.Depends(
@@ -995,6 +1006,14 @@ async def patch_release(
             ),
         )
     release_data = graph.parse_agtype(rows[0]['release'])
+    background_tasks.add_task(
+        _search_index.index,
+        db,
+        models.Release,
+        release_id,
+        title=merged_title,
+        description=merged_description,
+    )
     return _release_to_response(release_data, project_id)
 
 

--- a/apps/api/src/imbi/api/endpoints/search.py
+++ b/apps/api/src/imbi/api/endpoints/search.py
@@ -37,6 +37,44 @@ class SearchResult(pydantic.BaseModel):
     project_id: str | None = None
 
 
+#: Every membership traversal that puts a node in an org's search scope,
+#: each returning the node id as ``nid`` and taking ``org_slug``.
+_ORG_SCOPE_QUERIES: tuple[str, ...] = (
+    # Direct BELONGS_TO children (Team, Environment, ProjectType, ...).
+    'MATCH (n)-[:BELONGS_TO]->(:Organization {{slug: {org_slug}}})'
+    ' RETURN n.id AS nid',
+    'MATCH (p:Project)-[:OWNED_BY]->(:Team)-[:BELONGS_TO]->'
+    '(:Organization {{slug: {org_slug}}})'
+    ' WHERE coalesce(p.archived, false) = false'
+    ' RETURN p.id AS nid',
+    'MATCH (d:Document)-[:ATTACHED_TO]->(p:Project)-[:OWNED_BY]->'
+    '(:Team)-[:BELONGS_TO]->(:Organization {{slug: {org_slug}}})'
+    ' WHERE coalesce(p.archived, false) = false'
+    ' RETURN d.id AS nid',
+    'MATCH (d:Document)-[:ATTACHED_TO]->(:ProjectType)-[:BELONGS_TO]->'
+    '(:Organization {{slug: {org_slug}}})'
+    ' RETURN d.id AS nid',
+    'MATCH (d:Document)-[:ATTACHED_TO]->(:User)-[:MEMBER_OF]->'
+    '(:Organization {{slug: {org_slug}}})'
+    ' RETURN d.id AS nid',
+    'MATCH (:Organization {{slug: {org_slug}}})<-[:BELONGS_TO]-'
+    '(:Team)<-[:OWNED_BY]-(p:Project)-[:HAS_RELEASE]->(r:Release)'
+    ' WHERE coalesce(p.archived, false) = false'
+    ' RETURN r.id AS nid',
+    'MATCH (c:Comment)-[:IN_THREAD]->(:CommentThread)-[:ON_DOCUMENT]->'
+    '(:Document)-[:ATTACHED_TO]->(p:Project)-[:OWNED_BY]->(:Team)'
+    '-[:BELONGS_TO]->(:Organization {{slug: {org_slug}}})'
+    ' WHERE coalesce(p.archived, false) = false'
+    ' RETURN c.id AS nid',
+    'MATCH (comp:Component)-[:HAS_RELEASE]->(:ComponentRelease)'
+    '<-[:USES_COMPONENT_RELEASE]-(:Release)<-[:HAS_RELEASE]-(p:Project)'
+    '-[:OWNED_BY]->(:Team)-[:BELONGS_TO]->'
+    '(:Organization {{slug: {org_slug}}})'
+    ' WHERE coalesce(p.archived, false) = false'
+    ' RETURN comp.id AS nid',
+)
+
+
 async def _get_org_node_ids(
     db: graph.Graph,
     org_slug: str,
@@ -49,6 +87,10 @@ async def _get_org_node_ids(
     through the org's release dependency graph. Components are shared,
     cross-org identities, so they are scoped to those an org actually
     depends on rather than enumerated globally.
+
+    Documents are reached through all three attachment kinds — Project,
+    ProjectType, and User — so an org-scoped search sees every document
+    the org's document index lists.
 
     Archived projects are excluded, along with the Documents, Releases,
     Comments, and Components reached through them, so search never
@@ -67,78 +109,15 @@ async def _get_org_node_ids(
     if org_id:
         node_ids.add(org_id)
 
-    for row in await db.execute(
-        'MATCH (n)-[:BELONGS_TO]->(:Organization {{slug: {org_slug}}})'
-        ' RETURN n.id AS nid',
-        {'org_slug': org_slug},
-        columns=['nid'],
-    ):
-        nid = graph.parse_agtype(row['nid'])
-        if nid:
-            node_ids.add(nid)
-
-    for row in await db.execute(
-        'MATCH (p:Project)-[:OWNED_BY]->(:Team)-[:BELONGS_TO]->'
-        '(:Organization {{slug: {org_slug}}})'
-        ' WHERE coalesce(p.archived, false) = false'
-        ' RETURN p.id AS nid',
-        {'org_slug': org_slug},
-        columns=['nid'],
-    ):
-        nid = graph.parse_agtype(row['nid'])
-        if nid:
-            node_ids.add(nid)
-
-    for row in await db.execute(
-        'MATCH (d:Document)-[:ATTACHED_TO]->(p:Project)-[:OWNED_BY]->'
-        '(:Team)-[:BELONGS_TO]->(:Organization {{slug: {org_slug}}})'
-        ' WHERE coalesce(p.archived, false) = false'
-        ' RETURN d.id AS nid',
-        {'org_slug': org_slug},
-        columns=['nid'],
-    ):
-        nid = graph.parse_agtype(row['nid'])
-        if nid:
-            node_ids.add(nid)
-
-    for row in await db.execute(
-        'MATCH (:Organization {{slug: {org_slug}}})<-[:BELONGS_TO]-'
-        '(:Team)<-[:OWNED_BY]-(p:Project)-[:HAS_RELEASE]->(r:Release)'
-        ' WHERE coalesce(p.archived, false) = false'
-        ' RETURN r.id AS nid',
-        {'org_slug': org_slug},
-        columns=['nid'],
-    ):
-        nid = graph.parse_agtype(row['nid'])
-        if nid:
-            node_ids.add(nid)
-
-    for row in await db.execute(
-        'MATCH (c:Comment)-[:IN_THREAD]->(:CommentThread)-[:ON_DOCUMENT]->'
-        '(:Document)-[:ATTACHED_TO]->(p:Project)-[:OWNED_BY]->(:Team)'
-        '-[:BELONGS_TO]->(:Organization {{slug: {org_slug}}})'
-        ' WHERE coalesce(p.archived, false) = false'
-        ' RETURN c.id AS nid',
-        {'org_slug': org_slug},
-        columns=['nid'],
-    ):
-        nid = graph.parse_agtype(row['nid'])
-        if nid:
-            node_ids.add(nid)
-
-    for row in await db.execute(
-        'MATCH (comp:Component)-[:HAS_RELEASE]->(:ComponentRelease)'
-        '<-[:USES_COMPONENT_RELEASE]-(:Release)<-[:HAS_RELEASE]-(p:Project)'
-        '-[:OWNED_BY]->(:Team)-[:BELONGS_TO]->'
-        '(:Organization {{slug: {org_slug}}})'
-        ' WHERE coalesce(p.archived, false) = false'
-        ' RETURN comp.id AS nid',
-        {'org_slug': org_slug},
-        columns=['nid'],
-    ):
-        nid = graph.parse_agtype(row['nid'])
-        if nid:
-            node_ids.add(nid)
+    for query in _ORG_SCOPE_QUERIES:
+        for row in await db.execute(
+            query,
+            {'org_slug': org_slug},
+            columns=['nid'],
+        ):
+            nid = graph.parse_agtype(row['nid'])
+            if nid:
+                node_ids.add(nid)
 
     return node_ids
 

--- a/apps/api/src/imbi/api/endpoints/search.py
+++ b/apps/api/src/imbi/api/endpoints/search.py
@@ -66,6 +66,14 @@ _ORG_SCOPE_QUERIES: tuple[str, ...] = (
     '-[:BELONGS_TO]->(:Organization {{slug: {org_slug}}})'
     ' WHERE coalesce(p.archived, false) = false'
     ' RETURN c.id AS nid',
+    'MATCH (c:Comment)-[:IN_THREAD]->(:CommentThread)-[:ON_DOCUMENT]->'
+    '(:Document)-[:ATTACHED_TO]->(:ProjectType)-[:BELONGS_TO]->'
+    '(:Organization {{slug: {org_slug}}})'
+    ' RETURN c.id AS nid',
+    'MATCH (c:Comment)-[:IN_THREAD]->(:CommentThread)-[:ON_DOCUMENT]->'
+    '(:Document)-[:ATTACHED_TO]->(:User)-[:MEMBER_OF]->'
+    '(:Organization {{slug: {org_slug}}})'
+    ' RETURN c.id AS nid',
     'MATCH (comp:Component)-[:HAS_RELEASE]->(:ComponentRelease)'
     '<-[:USES_COMPONENT_RELEASE]-(:Release)<-[:HAS_RELEASE]-(p:Project)'
     '-[:OWNED_BY]->(:Team)-[:BELONGS_TO]->'
@@ -90,7 +98,8 @@ async def _get_org_node_ids(
 
     Documents are reached through all three attachment kinds — Project,
     ProjectType, and User — so an org-scoped search sees every document
-    the org's document index lists.
+    the org's document index lists.  Comments follow the same three
+    kinds, so a document in scope always has its comments in scope too.
 
     Archived projects are excluded, along with the Documents, Releases,
     Comments, and Components reached through them, so search never

--- a/apps/api/src/imbi/api/maintenance/operations.py
+++ b/apps/api/src/imbi/api/maintenance/operations.py
@@ -746,3 +746,55 @@ async def execute_release_repair(
         removed,
     )
     return 'succeeded'
+
+
+#: Reindex work items are ``Label:node_id`` -- the maintenance framework
+#: distributes opaque item id strings, and a reindex spans every model
+#: that declares ``Embeddable`` fields, not one node type.
+_REINDEX_ITEM_SEPARATOR = ':'
+
+
+async def enumerate_embeddable_nodes(db: graph.Graph) -> list[str]:
+    """Every ``Label:node_id`` whose model declares embeddable fields."""
+    items: list[str] = []
+    for node_type in graph.embeddable_node_types():
+        label = node_type.__name__
+        rows = await db.execute(
+            f'MATCH (n:{label}) RETURN n.id AS id', {}, ['id']
+        )
+        items.extend(
+            f'{label}{_REINDEX_ITEM_SEPARATOR}{node_id}'
+            for node_id in (graph.parse_agtype(row.get('id')) for row in rows)
+            if node_id
+        )
+    return items
+
+
+async def execute_search_reindex(
+    db: graph.Graph, client: valkey.Valkey, item_id: str
+) -> ExecuteOutcome:
+    """Rebuild one node's search embeddings from its current properties.
+
+    Skipped when the node went away between enumeration and execution,
+    or when its label is no longer embeddable (a run that outlives a
+    model change).  ``raise_on_error`` is set so an embedding failure
+    is recorded against the node instead of counting as a success --
+    reindexing *is* the operation here.
+    """
+    label, _, node_id = item_id.partition(_REINDEX_ITEM_SEPARATOR)
+    node_type = {t.__name__: t for t in graph.embeddable_node_types()}.get(
+        label
+    )
+    if node_type is None:
+        return 'skipped'
+    nodes = await db.match(node_type, {'id': node_id})
+    if not nodes:
+        return 'skipped'
+    try:
+        await db.embed_node(nodes[0], raise_on_error=True)
+    except Exception as exc:
+        LOGGER.exception('search-reindex failed for %s', item_id)
+        raise MaintenanceItemFailed(
+            'Could not rebuild the search index for this node.'
+        ) from exc
+    return 'succeeded'

--- a/apps/api/src/imbi/api/maintenance/operations.py
+++ b/apps/api/src/imbi/api/maintenance/operations.py
@@ -775,26 +775,31 @@ async def execute_search_reindex(
 ) -> ExecuteOutcome:
     """Rebuild one node's search embeddings from its current properties.
 
-    Skipped when the node went away between enumeration and execution,
-    or when its label is no longer embeddable (a run that outlives a
-    model change).  ``raise_on_error`` is set so an embedding failure
-    is recorded against the node instead of counting as a success --
+    Shares :func:`_search_index.index` with the endpoint write paths so
+    there is one definition of "re-read the node and embed it".  Skipped
+    when the node went away between enumeration and execution, or when
+    its label is no longer embeddable (a run that outlives a model
+    change).  ``raise_on_error`` is set so an embedding failure is
+    recorded against the node instead of counting as a success --
     reindexing *is* the operation here.
     """
+    # Imported here, not at module scope: ``imbi.api.endpoints`` pulls in
+    # the maintenance router, which imports this module back.
+    from imbi.api.endpoints import _search_index
+
     label, _, node_id = item_id.partition(_REINDEX_ITEM_SEPARATOR)
     node_type = {t.__name__: t for t in graph.embeddable_node_types()}.get(
         label
     )
     if node_type is None:
         return 'skipped'
-    nodes = await db.match(node_type, {'id': node_id})
-    if not nodes:
-        return 'skipped'
     try:
-        await db.embed_node(nodes[0], raise_on_error=True)
+        embedded = await _search_index.index(
+            db, node_type, node_id, raise_on_error=True
+        )
     except Exception as exc:
         LOGGER.exception('search-reindex failed for %s', item_id)
         raise MaintenanceItemFailed(
             'Could not rebuild the search index for this node.'
         ) from exc
-    return 'succeeded'
+    return 'succeeded' if embedded else 'skipped'

--- a/apps/api/src/imbi/api/maintenance/registry.py
+++ b/apps/api/src/imbi/api/maintenance/registry.py
@@ -28,6 +28,7 @@ MaintenanceSlug = typing.Literal[
     'release-repair',
     'commit-sync',
     'pr-sync',
+    'search-reindex',
 ]
 
 
@@ -152,6 +153,20 @@ OPERATIONS: dict[MaintenanceSlug, OperationDefinition] = {
             pause_key=pr_sync_queue.PAUSE_KEY,
             enumerate=operations.enumerate_all_projects,
             execute=operations.execute_pr_sync,
+        ),
+        OperationDefinition(
+            slug='search-reindex',
+            label='Reindex Search',
+            description=(
+                'Rebuild the vector search index for every searchable node '
+                '-- documents, comments, releases, projects, and the rest '
+                '-- from its current content. Run this after a bulk import '
+                'or a change to the embedding model; ordinary saves index '
+                'themselves.'
+            ),
+            pause_key=None,
+            enumerate=operations.enumerate_embeddable_nodes,
+            execute=operations.execute_search_reindex,
         ),
     )
 }

--- a/apps/api/tests/endpoints/test_comments.py
+++ b/apps/api/tests/endpoints/test_comments.py
@@ -901,6 +901,54 @@ class CommentEndpointsTestCase(support.SharedAppTestCase):
         response = self.client.delete(f'{_BASE}/thread-1/comments/ghost')
         self.assertEqual(response.status_code, 404)
 
+    # -- Search index --------------------------------------------------
+
+    def test_create_thread_indexes_the_root_comment(self) -> None:
+        """Comment writes are raw Cypher, so they must index themselves."""
+        self.mock_db.execute.side_effect = [
+            [{'id': 'doc-1'}],
+            [{'id': 'thread-1'}],
+            [self._thread_row()],
+        ]
+        with mock.patch(
+            'imbi.common.graph.parse_agtype', side_effect=lambda x: x
+        ):
+            response = self.client.post(_BASE, json={'body': 'First!'})
+        self.assertEqual(response.status_code, 201)
+        node = self.mock_db.embed_node.await_args.args[0]
+        self.assertEqual('First!', node.body)
+
+    def test_create_reply_indexes_the_comment(self) -> None:
+        self.mock_db.execute.return_value = [
+            {'c': self._comment(id='c2', body='reply')}
+        ]
+        with mock.patch(
+            'imbi.common.graph.parse_agtype', side_effect=lambda x: x
+        ):
+            response = self.client.post(
+                f'{_BASE}/thread-1/comments', json={'body': 'reply'}
+            )
+        self.assertEqual(response.status_code, 201)
+        node = self.mock_db.embed_node.await_args.args[0]
+        self.assertEqual('reply', node.body)
+
+    def test_delete_comment_removes_its_embeddings(self) -> None:
+        self.mock_db.execute.side_effect = [
+            [{'c': self._comment(id='comment-1')}],
+            [self._thread_row()],
+            [{'deleted': 1}],
+        ]
+        with mock.patch(
+            'imbi.common.graph.parse_agtype', side_effect=lambda x: x
+        ):
+            response = self.client.delete(
+                f'{_BASE}/thread-1/comments/comment-1'
+            )
+        self.assertEqual(response.status_code, 204)
+        self.mock_db.delete_node_embeddings.assert_awaited_once_with(
+            'Comment', 'comment-1'
+        )
+
     # -- Permission failures -------------------------------------------
 
     def test_create_thread_requires_comment_create(self) -> None:

--- a/apps/api/tests/endpoints/test_comments.py
+++ b/apps/api/tests/endpoints/test_comments.py
@@ -10,6 +10,7 @@ from fastapi.testclient import TestClient
 from apps.api.tests import support
 from imbi.api import models
 from imbi.common import graph
+from imbi.common import models as common_models
 
 _BASE = '/organizations/engineering/projects/proj-abc/documents/doc-1/comments'
 
@@ -910,18 +911,27 @@ class CommentEndpointsTestCase(support.SharedAppTestCase):
             [{'id': 'thread-1'}],
             [self._thread_row()],
         ]
+        # The index task re-reads the comment rather than embedding the
+        # body the request supplied.
+        persisted = common_models.Comment.model_construct(
+            id='c1', body='First!'
+        )
+        self.mock_db.match.return_value = [persisted]
         with mock.patch(
             'imbi.common.graph.parse_agtype', side_effect=lambda x: x
         ):
             response = self.client.post(_BASE, json={'body': 'First!'})
         self.assertEqual(response.status_code, 201)
-        node = self.mock_db.embed_node.await_args.args[0]
-        self.assertEqual('First!', node.body)
+        self.assertIs(persisted, self.mock_db.embed_node.await_args.args[0])
 
     def test_create_reply_indexes_the_comment(self) -> None:
         self.mock_db.execute.return_value = [
             {'c': self._comment(id='c2', body='reply')}
         ]
+        persisted = common_models.Comment.model_construct(
+            id='c2', body='reply'
+        )
+        self.mock_db.match.return_value = [persisted]
         with mock.patch(
             'imbi.common.graph.parse_agtype', side_effect=lambda x: x
         ):
@@ -929,8 +939,7 @@ class CommentEndpointsTestCase(support.SharedAppTestCase):
                 f'{_BASE}/thread-1/comments', json={'body': 'reply'}
             )
         self.assertEqual(response.status_code, 201)
-        node = self.mock_db.embed_node.await_args.args[0]
-        self.assertEqual('reply', node.body)
+        self.assertIs(persisted, self.mock_db.embed_node.await_args.args[0])
 
     def test_delete_comment_removes_its_embeddings(self) -> None:
         self.mock_db.execute.side_effect = [

--- a/apps/api/tests/endpoints/test_documents.py
+++ b/apps/api/tests/endpoints/test_documents.py
@@ -10,6 +10,7 @@ from fastapi.testclient import TestClient
 from apps.api.tests import support
 from imbi.api import models
 from imbi.common import graph
+from imbi.common import models as common_models
 
 
 class DocumentEndpointsTestCase(support.SharedAppTestCase):
@@ -904,12 +905,23 @@ class DocumentEndpointsTestCase(support.SharedAppTestCase):
         self.mock_db.embed_node.assert_awaited_once()
         return self.mock_db.embed_node.await_args.args[0]
 
+    def _persisted_document(self, **fields: typing.Any) -> typing.Any:
+        """Stub the re-read the background index task performs."""
+        node = common_models.Document.model_construct(**fields)
+        self.mock_db.match.return_value = [node]
+        return node
+
     def test_create_embeds_document(self) -> None:
         """Creation is raw Cypher, so it must embed the document itself."""
         self.mock_db.execute.side_effect = [
             [{'id': 'document-1', 'version': 2}],
             [self._project_row()],
         ]
+        persisted = self._persisted_document(
+            id='document-1',
+            title='DB lock runbook',
+            content='Watch out for DB locks',
+        )
         with mock.patch(
             'imbi.common.graph.parse_agtype', side_effect=lambda x: x
         ):
@@ -921,13 +933,13 @@ class DocumentEndpointsTestCase(support.SharedAppTestCase):
                 },
             )
         self.assertEqual(response.status_code, 201)
-        node = self._embedded_document()
-        # The response body is the canned fixture row, so compare against
-        # the id the CREATE actually wrote.
+        # The task re-reads the node instead of embedding the queued
+        # payload, so assert it looked up the id the CREATE wrote.
         create_call = self.mock_db.execute.await_args_list[0]
-        self.assertEqual(node.id, create_call.args[1]['id'])
-        self.assertEqual(node.title, 'DB lock runbook')
-        self.assertEqual(node.content, 'Watch out for DB locks')
+        self.mock_db.match.assert_awaited_once_with(
+            common_models.Document, {'id': create_call.args[1]['id']}
+        )
+        self.assertIs(persisted, self._embedded_document())
 
     def test_patch_content_re_embeds_document(self) -> None:
         self.mock_db.execute.side_effect = [
@@ -935,6 +947,9 @@ class DocumentEndpointsTestCase(support.SharedAppTestCase):
             [{'id': 'document-1', 'version': 2}],
             [self._project_row(n=self._document_data(content='New content'))],
         ]
+        persisted = self._persisted_document(
+            id='document-1', content='New content'
+        )
         with mock.patch(
             'imbi.common.graph.parse_agtype', side_effect=lambda x: x
         ):
@@ -949,9 +964,34 @@ class DocumentEndpointsTestCase(support.SharedAppTestCase):
                 ],
             )
         self.assertEqual(response.status_code, 200)
-        node = self._embedded_document()
-        self.assertEqual(node.id, 'document-1')
-        self.assertEqual(node.content, 'New content')
+        self.mock_db.match.assert_awaited_once_with(
+            common_models.Document, {'id': 'document-1'}
+        )
+        self.assertIs(persisted, self._embedded_document())
+
+    def test_patch_skips_embedding_when_the_document_is_gone(self) -> None:
+        """A document deleted before the task runs is skipped quietly."""
+        self.mock_db.execute.side_effect = [
+            [self._project_row()],
+            [{'id': 'document-1', 'version': 2}],
+            [self._project_row(n=self._document_data(content='New content'))],
+        ]
+        self.mock_db.match.return_value = []
+        with mock.patch(
+            'imbi.common.graph.parse_agtype', side_effect=lambda x: x
+        ):
+            response = self.client.patch(
+                '/organizations/engineering/projects/proj-abc/documents/document-1',
+                json=[
+                    {
+                        'op': 'replace',
+                        'path': '/content',
+                        'value': 'New content',
+                    }
+                ],
+            )
+        self.assertEqual(response.status_code, 200)
+        self.mock_db.embed_node.assert_not_awaited()
 
     def test_patch_is_pinned_does_not_re_embed(self) -> None:
         """A pin toggle leaves title/content alone, so nothing to re-embed."""

--- a/apps/api/tests/endpoints/test_documents.py
+++ b/apps/api/tests/endpoints/test_documents.py
@@ -877,6 +877,10 @@ class DocumentEndpointsTestCase(support.SharedAppTestCase):
             '/organizations/engineering/projects/proj-abc/documents/document-1'
         )
         self.assertEqual(response.status_code, 204)
+        # A deleted document must not linger in search results.
+        self.mock_db.delete_node_embeddings.assert_awaited_once_with(
+            'Document', 'document-1'
+        )
 
     def test_delete_not_found(self) -> None:
         self.mock_db.execute.return_value = []
@@ -884,6 +888,7 @@ class DocumentEndpointsTestCase(support.SharedAppTestCase):
             '/organizations/engineering/projects/proj-abc/documents/ghost'
         )
         self.assertEqual(response.status_code, 404)
+        self.mock_db.delete_node_embeddings.assert_not_awaited()
 
     def test_delete_org_document(self) -> None:
         self.mock_db.execute.return_value = [{'deleted': 1}]
@@ -891,6 +896,79 @@ class DocumentEndpointsTestCase(support.SharedAppTestCase):
             '/organizations/engineering/documents/document-1'
         )
         self.assertEqual(response.status_code, 204)
+
+    # -- Search embeddings ---------------------------------------------
+
+    def _embedded_document(self) -> typing.Any:
+        """The node passed to the single expected ``embed_node`` call."""
+        self.mock_db.embed_node.assert_awaited_once()
+        return self.mock_db.embed_node.await_args.args[0]
+
+    def test_create_embeds_document(self) -> None:
+        """Creation is raw Cypher, so it must embed the document itself."""
+        self.mock_db.execute.side_effect = [
+            [{'id': 'document-1', 'version': 2}],
+            [self._project_row()],
+        ]
+        with mock.patch(
+            'imbi.common.graph.parse_agtype', side_effect=lambda x: x
+        ):
+            response = self.client.post(
+                '/organizations/engineering/projects/proj-abc/documents/',
+                json={
+                    'title': 'DB lock runbook',
+                    'content': 'Watch out for DB locks',
+                },
+            )
+        self.assertEqual(response.status_code, 201)
+        node = self._embedded_document()
+        # The response body is the canned fixture row, so compare against
+        # the id the CREATE actually wrote.
+        create_call = self.mock_db.execute.await_args_list[0]
+        self.assertEqual(node.id, create_call.args[1]['id'])
+        self.assertEqual(node.title, 'DB lock runbook')
+        self.assertEqual(node.content, 'Watch out for DB locks')
+
+    def test_patch_content_re_embeds_document(self) -> None:
+        self.mock_db.execute.side_effect = [
+            [self._project_row()],
+            [{'id': 'document-1', 'version': 2}],
+            [self._project_row(n=self._document_data(content='New content'))],
+        ]
+        with mock.patch(
+            'imbi.common.graph.parse_agtype', side_effect=lambda x: x
+        ):
+            response = self.client.patch(
+                '/organizations/engineering/projects/proj-abc/documents/document-1',
+                json=[
+                    {
+                        'op': 'replace',
+                        'path': '/content',
+                        'value': 'New content',
+                    }
+                ],
+            )
+        self.assertEqual(response.status_code, 200)
+        node = self._embedded_document()
+        self.assertEqual(node.id, 'document-1')
+        self.assertEqual(node.content, 'New content')
+
+    def test_patch_is_pinned_does_not_re_embed(self) -> None:
+        """A pin toggle leaves title/content alone, so nothing to re-embed."""
+        self.mock_db.execute.side_effect = [
+            [self._project_row()],
+            [{'id': 'document-1', 'version': 2}],
+            [self._project_row(n=self._document_data(is_pinned=True))],
+        ]
+        with mock.patch(
+            'imbi.common.graph.parse_agtype', side_effect=lambda x: x
+        ):
+            response = self.client.patch(
+                '/organizations/engineering/projects/proj-abc/documents/document-1',
+                json=[{'op': 'replace', 'path': '/is_pinned', 'value': True}],
+            )
+        self.assertEqual(response.status_code, 200)
+        self.mock_db.embed_node.assert_not_awaited()
 
     # -- Pagination + cursor edge cases --------------------------------
 

--- a/apps/api/tests/endpoints/test_projects.py
+++ b/apps/api/tests/endpoints/test_projects.py
@@ -1107,6 +1107,10 @@ class ProjectEndpointsTestCase(support.SharedAppTestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {'lifecycle_results': []})
+        # A deleted project must not linger in search results.
+        self.mock_db.delete_node_embeddings.assert_awaited_once_with(
+            'Project', PROJECT_ID
+        )
 
     def test_delete_not_found(self) -> None:
         """Test deleting nonexistent project."""
@@ -1118,6 +1122,7 @@ class ProjectEndpointsTestCase(support.SharedAppTestCase):
 
         self.assertEqual(response.status_code, 404)
         self.assertIn('not found', response.json()['detail'])
+        self.mock_db.delete_node_embeddings.assert_not_awaited()
 
     def test_delete_succeeds_when_snapshot_raises(self) -> None:
         """A lifecycle snapshot failure must not abort the delete.

--- a/apps/api/tests/endpoints/test_releases.py
+++ b/apps/api/tests/endpoints/test_releases.py
@@ -136,6 +136,12 @@ class CreateReleaseTestCase(_ReleasesTestBase):
         self.assertEqual(body['project_id'], PROJECT_ID)
         self.assertEqual(body['id'], RELEASE_ID)
         self.assertEqual(body['created_by'], 'alice@example.com')
+        # Releases are written as raw Cypher, so the endpoint owns
+        # keeping them searchable.
+        node = self.mock_db.embed_node.await_args.args[0]
+        self.assertEqual(RELEASE_ID, node.id)
+        self.assertEqual('Initial release', node.title)
+        self.assertEqual('First cut', node.description)
 
     def test_create_with_explicit_created_by(self) -> None:
         self.mock_db.execute.side_effect = [

--- a/apps/api/tests/endpoints/test_releases.py
+++ b/apps/api/tests/endpoints/test_releases.py
@@ -552,6 +552,60 @@ class PatchReleaseTestCase(_ReleasesTestBase):
         self.assertEqual(body['description'], 'New desc')
         self.assertEqual(len(body['links']), 1)
 
+    def test_patch_title_reindexes(self) -> None:
+        """A changed embeddable field re-embeds the release."""
+        self.mock_db.execute.side_effect = [
+            [{'release': _release_row()}],
+            [],  # _conflict_query — no collision
+            [{'release': _release_row(title='Updated')}],
+        ]
+        with mock.patch(
+            'imbi.common.graph.parse_agtype',
+            side_effect=lambda x: x,
+        ):
+            response = self.client.patch(
+                self._url(f'/{RELEASE_ID}'),
+                json=[
+                    {'op': 'replace', 'path': '/title', 'value': 'Updated'},
+                ],
+            )
+        self.assertEqual(response.status_code, 200)
+        node = self.mock_db.embed_node.await_args.args[0]
+        self.assertEqual('Updated', node.title)
+
+    def test_patch_links_only_skips_reindex(self) -> None:
+        """Embedding is skipped when no embeddable field changed.
+
+        Chunking and running the embedding model is not free, so a
+        tag- or links-only patch must not pay for it.
+        """
+        self.mock_db.execute.side_effect = [
+            [{'release': _release_row()}],
+            [],  # _conflict_query — no collision
+            [{'release': _release_row()}],
+        ]
+        with mock.patch(
+            'imbi.common.graph.parse_agtype',
+            side_effect=lambda x: x,
+        ):
+            response = self.client.patch(
+                self._url(f'/{RELEASE_ID}'),
+                json=[
+                    {
+                        'op': 'replace',
+                        'path': '/links',
+                        'value': [
+                            {
+                                'type': 'github_release',
+                                'url': 'https://example.com/',
+                            }
+                        ],
+                    },
+                ],
+            )
+        self.assertEqual(response.status_code, 200)
+        self.mock_db.embed_node.assert_not_awaited()
+
     def test_patch_title_to_empty_string(self) -> None:
         """Explicit empty-string patches of ``title`` must persist."""
         self.mock_db.execute.side_effect = [

--- a/apps/api/tests/endpoints/test_releases.py
+++ b/apps/api/tests/endpoints/test_releases.py
@@ -73,6 +73,14 @@ class _ReleasesTestBase(support.SharedAppTestCase):
         self.test_app.dependency_overrides[graph._inject_graph] = lambda: (
             self.mock_db
         )
+        # The background search-index task re-reads the release it just
+        # wrote, so give every test a node for that lookup to return.
+        self.persisted_release = models.Release.model_construct(
+            id=RELEASE_ID,
+            title='Initial release',
+            description='First cut',
+        )
+        self.mock_db.match.return_value = [self.persisted_release]
         # The create path enriches a tagged, note-less release from the
         # remote release body; that resolves the deployment capability and
         # makes its own DB/HTTP calls. Neutralize it here so create-logic
@@ -137,11 +145,13 @@ class CreateReleaseTestCase(_ReleasesTestBase):
         self.assertEqual(body['id'], RELEASE_ID)
         self.assertEqual(body['created_by'], 'alice@example.com')
         # Releases are written as raw Cypher, so the endpoint owns
-        # keeping them searchable.
-        node = self.mock_db.embed_node.await_args.args[0]
-        self.assertEqual(RELEASE_ID, node.id)
-        self.assertEqual('Initial release', node.title)
-        self.assertEqual('First cut', node.description)
+        # keeping them searchable. The task re-reads the release.
+        self.mock_db.match.assert_awaited_once_with(
+            models.Release, {'id': RELEASE_ID}
+        )
+        self.assertIs(
+            self.persisted_release, self.mock_db.embed_node.await_args.args[0]
+        )
 
     def test_create_with_explicit_created_by(self) -> None:
         self.mock_db.execute.side_effect = [
@@ -570,8 +580,12 @@ class PatchReleaseTestCase(_ReleasesTestBase):
                 ],
             )
         self.assertEqual(response.status_code, 200)
-        node = self.mock_db.embed_node.await_args.args[0]
-        self.assertEqual('Updated', node.title)
+        self.mock_db.match.assert_awaited_once_with(
+            models.Release, {'id': RELEASE_ID}
+        )
+        self.assertIs(
+            self.persisted_release, self.mock_db.embed_node.await_args.args[0]
+        )
 
     def test_patch_links_only_skips_reindex(self) -> None:
         """Embedding is skipped when no embeddable field changed.

--- a/apps/api/tests/endpoints/test_search.py
+++ b/apps/api/tests/endpoints/test_search.py
@@ -421,29 +421,44 @@ class SearchEndpointTestCase(support.SharedAppTestCase):
         self.assertEqual(data[0]['node_id'], 'rel-1')
 
     def test_comment_node_ids_included(self) -> None:
-        """Comment IN_THREAD query nodes are included in org scope."""
-        self.mock_db.execute.side_effect = [
-            [{'org_id': '"org-abc"'}],
-            *self._scope_rows(q6=[{'nid': '"comment-1"'}]),  # q6: Comments
-        ]
-        self.mock_db.search.return_value = [
-            self._make_result(
-                node_id='comment-1',
-                node_label='Comment',
-                attribute='body',
-            ),
-        ]
-        response = self.client.get(f'{_BASE_URL}?q=test')
-        self.assertEqual(response.status_code, 200)
-        data = response.json()
-        self.assertEqual(len(data), 1)
-        self.assertEqual(data[0]['node_id'], 'comment-1')
+        """Comments follow the same three attachment kinds as Documents.
+
+        A comment is only reachable through its parent document, so the
+        comment traversals have to cover Project-, ProjectType-, and
+        User-attached documents too — otherwise a document in scope
+        would surface without its comments.
+        """
+        # q6/q7/q8 are the Project-, ProjectType-, and User-attached
+        # comment traversals.
+        for position, comment_id in enumerate(
+            ('project-comment', 'project-type-comment', 'user-comment'),
+            start=6,
+        ):
+            with self.subTest(comment=comment_id):
+                self.mock_db.execute.side_effect = [
+                    [{'org_id': '"org-abc"'}],
+                    *self._scope_rows(
+                        **{f'q{position}': [{'nid': f'"{comment_id}"'}]},
+                    ),
+                ]
+                self.mock_db.search.return_value = [
+                    self._make_result(
+                        node_id=comment_id,
+                        node_label='Comment',
+                        attribute='body',
+                    ),
+                ]
+                response = self.client.get(f'{_BASE_URL}?q=test')
+                self.assertEqual(response.status_code, 200)
+                data = response.json()
+                self.assertEqual(len(data), 1)
+                self.assertEqual(data[0]['node_id'], comment_id)
 
     def test_component_node_ids_included(self) -> None:
         """Component dependency-graph query nodes are in org scope."""
         self.mock_db.execute.side_effect = [
             [{'org_id': '"org-abc"'}],
-            *self._scope_rows(q7=[{'nid': '"comp-1"'}]),  # q7: Components
+            *self._scope_rows(q9=[{'nid': '"comp-1"'}]),  # q9: Components
         ]
         self.mock_db.search.return_value = [
             self._make_result(node_id='comp-1', node_label='Component'),

--- a/apps/api/tests/endpoints/test_search.py
+++ b/apps/api/tests/endpoints/test_search.py
@@ -76,28 +76,37 @@ class SearchEndpointTestCase(support.SharedAppTestCase):
             distance=distance,
         )
 
+    def _scope_rows(
+        self,
+        **rows_by_position: list[dict[str, str]],
+    ) -> list[list[dict[str, str]]]:
+        """One result list per scope query, empty unless named.
+
+        Positions are named ``q0``, ``q1``, ... matching the order of
+        ``search._ORG_SCOPE_QUERIES``, so adding a traversal to the
+        endpoint does not mean renumbering every test.
+        """
+        rows: list[list[dict[str, str]]] = [
+            [] for _ in search_endpoint._ORG_SCOPE_QUERIES
+        ]
+        for name, value in rows_by_position.items():
+            rows[int(name.removeprefix('q'))] = value
+        return rows
+
     def _setup_org(self, node_ids: list[str] | None = None) -> None:
         """Configure mock_db.execute for the org-membership queries.
 
-        The search handler calls db.execute in this order:
-          1. org lookup -> [{org_id: ...}] or []
-          2. direct BELONGS_TO children -> [{nid: ...}, ...]
-          3. Project nodes -> [{nid: ...}, ...]
-          4. Document nodes -> []
-          5. Release nodes -> []
-          6. Comment nodes -> []
-          7. Component nodes -> []
+        The org lookup runs first, then one query per entry in
+        ``search._ORG_SCOPE_QUERIES``. Only the Project query (q1)
+        returns anything here.
         """
         if node_ids is None:
             node_ids = ['proj-1']
         self.mock_db.execute.side_effect = [
             [{'org_id': '"org-abc"'}],
-            [],
-            [{'nid': f'"{nid}"'} for nid in node_ids],
-            [],
-            [],
-            [],
-            [],
+            *self._scope_rows(
+                q1=[{'nid': f'"{nid}"'} for nid in node_ids],
+            ),
         ]
 
     def _setup_org_not_found(self) -> None:
@@ -120,22 +129,20 @@ class SearchEndpointTestCase(support.SharedAppTestCase):
     def test_archived_projects_excluded_from_scope(self) -> None:
         """Each project-traversing scope query filters out archived projects.
 
-        The org lookup and the direct BELONGS_TO query do not traverse a
-        Project, so they must not carry the filter; the Project, Document,
-        Release, Comment, and Component queries must.
+        Queries that never bind a Project (the org lookup, the direct
+        BELONGS_TO children, and the ProjectType/User document queries)
+        must not carry the filter; every query that does bind ``p`` must.
         """
         self._setup_org()
         self.mock_db.search.return_value = []
         self.client.get(f'{_BASE_URL}?q=test')
         queries = [c.args[0] for c in self.mock_db.execute.call_args_list]
         archived_clause = 'coalesce(p.archived, false) = false'
-        # The org lookup and the direct BELONGS_TO query do not traverse a
-        # Project, so they must not carry the filter.
-        self.assertNotIn(archived_clause, queries[0])
-        self.assertNotIn(archived_clause, queries[1])
-        # Every subsequent project-traversing query must carry the filter.
-        for query in queries[2:]:
-            self.assertIn(archived_clause, query)
+        for query in queries:
+            if '(p:Project)' in query:
+                self.assertIn(archived_clause, query)
+            else:
+                self.assertNotIn(archived_clause, query)
 
     def test_org_not_found_returns_404(self) -> None:
         self._setup_org_not_found()
@@ -334,16 +341,15 @@ class SearchEndpointTestCase(support.SharedAppTestCase):
     def test_falsy_org_id_and_nids_skipped(self) -> None:
         """parse_agtype returning falsy for org_id or any nid skips it."""
         # org_id is falsy ('') so org node is not added to the set,
-        # but the org IS found (non-empty list returned).
-        # BELONGS_TO and Document/Release return falsy nids; Projects is valid.
+        # but the org IS found (non-empty list returned). Every scope
+        # query but the Project one yields a falsy nid, which is skipped.
+        scope_rows = [
+            [{'nid': '""'}] for _ in search_endpoint._ORG_SCOPE_QUERIES
+        ]
+        scope_rows[1] = [{'nid': '"proj-1"'}]
         self.mock_db.execute.side_effect = [
             [{'org_id': '""'}],  # org found but parse_agtype -> ''
-            [{'nid': '""'}],  # BELONGS_TO: falsy nid skipped
-            [{'nid': '"proj-1"'}],  # Project: valid nid included
-            [{'nid': '""'}],  # Document: falsy nid skipped
-            [{'nid': '""'}],  # Release: falsy nid skipped
-            [{'nid': '""'}],  # Comment: falsy nid skipped
-            [{'nid': '""'}],  # Component: falsy nid skipped
+            *scope_rows,
         ]
         self.mock_db.search.return_value = [
             self._make_result(node_id='proj-1'),
@@ -358,12 +364,8 @@ class SearchEndpointTestCase(support.SharedAppTestCase):
         """Nodes returned by the BELONGS_TO query are included in org scope."""
         self.mock_db.execute.side_effect = [
             [{'org_id': '"org-abc"'}],
-            [{'nid': '"team-1"'}],  # BELONGS_TO child (e.g. Team)
-            [],  # Projects
-            [],  # Documents
-            [],  # Releases
-            [],  # Comments
-            [],  # Components
+            # q0 is the direct BELONGS_TO child query (e.g. Team).
+            *self._scope_rows(q0=[{'nid': '"team-1"'}]),
         ]
         self.mock_db.search.return_value = [
             self._make_result(node_id='team-1', node_label='Team'),
@@ -375,35 +377,39 @@ class SearchEndpointTestCase(support.SharedAppTestCase):
         self.assertEqual(data[0]['node_id'], 'team-1')
 
     def test_document_node_ids_included(self) -> None:
-        """Document ATTACHED_TO query nodes are included in org scope."""
-        self.mock_db.execute.side_effect = [
-            [{'org_id': '"org-abc"'}],
-            [],  # BELONGS_TO
-            [],  # Projects
-            [{'nid': '"doc-1"'}],  # Documents
-            [],  # Releases
-            [],  # Comments
-            [],  # Components
-        ]
-        self.mock_db.search.return_value = [
-            self._make_result(node_id='doc-1', node_label='Document'),
-        ]
-        response = self.client.get(f'{_BASE_URL}?q=test')
-        self.assertEqual(response.status_code, 200)
-        data = response.json()
-        self.assertEqual(len(data), 1)
-        self.assertEqual(data[0]['node_id'], 'doc-1')
+        """Documents are in scope through all three attachment kinds.
+
+        A document hangs off a Project, a ProjectType, or a User, and
+        the org's document index lists all three, so search scope has
+        to enumerate all three as well.
+        """
+        # q2/q3/q4 are the Project-, ProjectType-, and User-attached
+        # document traversals.
+        for position, doc_id in enumerate(
+            ('project-doc', 'project-type-doc', 'user-doc'),
+            start=2,
+        ):
+            with self.subTest(document=doc_id):
+                self.mock_db.execute.side_effect = [
+                    [{'org_id': '"org-abc"'}],
+                    *self._scope_rows(
+                        **{f'q{position}': [{'nid': f'"{doc_id}"'}]},
+                    ),
+                ]
+                self.mock_db.search.return_value = [
+                    self._make_result(node_id=doc_id, node_label='Document'),
+                ]
+                response = self.client.get(f'{_BASE_URL}?q=test')
+                self.assertEqual(response.status_code, 200)
+                data = response.json()
+                self.assertEqual(len(data), 1)
+                self.assertEqual(data[0]['node_id'], doc_id)
 
     def test_release_node_ids_included(self) -> None:
         """Nodes returned by the Release HAS_RELEASE query are in org scope."""
         self.mock_db.execute.side_effect = [
             [{'org_id': '"org-abc"'}],
-            [],  # BELONGS_TO
-            [],  # Projects
-            [],  # Documents
-            [{'nid': '"rel-1"'}],  # Releases
-            [],  # Comments
-            [],  # Components
+            *self._scope_rows(q5=[{'nid': '"rel-1"'}]),  # q5: Releases
         ]
         self.mock_db.search.return_value = [
             self._make_result(node_id='rel-1', node_label='Release'),
@@ -418,12 +424,7 @@ class SearchEndpointTestCase(support.SharedAppTestCase):
         """Comment IN_THREAD query nodes are included in org scope."""
         self.mock_db.execute.side_effect = [
             [{'org_id': '"org-abc"'}],
-            [],  # BELONGS_TO
-            [],  # Projects
-            [],  # Documents
-            [],  # Releases
-            [{'nid': '"comment-1"'}],  # Comments
-            [],  # Components
+            *self._scope_rows(q6=[{'nid': '"comment-1"'}]),  # q6: Comments
         ]
         self.mock_db.search.return_value = [
             self._make_result(
@@ -442,12 +443,7 @@ class SearchEndpointTestCase(support.SharedAppTestCase):
         """Component dependency-graph query nodes are in org scope."""
         self.mock_db.execute.side_effect = [
             [{'org_id': '"org-abc"'}],
-            [],  # BELONGS_TO
-            [],  # Projects
-            [],  # Documents
-            [],  # Releases
-            [],  # Comments
-            [{'nid': '"comp-1"'}],  # Components
+            *self._scope_rows(q7=[{'nid': '"comp-1"'}]),  # q7: Components
         ]
         self.mock_db.search.return_value = [
             self._make_result(node_id='comp-1', node_label='Component'),
@@ -507,12 +503,7 @@ class SearchEndpointTestCase(support.SharedAppTestCase):
         """A falsy nid from the Project query is skipped."""
         self.mock_db.execute.side_effect = [
             [{'org_id': '"org-abc"'}],
-            [],  # BELONGS_TO
-            [{'nid': '""'}],  # Project: falsy nid skipped
-            [],  # Documents
-            [],  # Releases
-            [],  # Comments
-            [],  # Components
+            *self._scope_rows(q1=[{'nid': '""'}]),  # q1: Projects
         ]
         self.mock_db.search.return_value = []
         response = self.client.get(f'{_BASE_URL}?q=test')

--- a/apps/api/tests/endpoints/test_search_index.py
+++ b/apps/api/tests/endpoints/test_search_index.py
@@ -1,0 +1,59 @@
+"""Tests for the shared search-index hooks used by raw-Cypher writes."""
+
+import unittest
+from unittest import mock
+
+from imbi.api.endpoints import _search_index
+from imbi.common import models
+
+
+class IndexTestCase(unittest.IsolatedAsyncioTestCase):
+    async def test_index_builds_the_node_from_fields(self) -> None:
+        mock_db = mock.AsyncMock()
+        await _search_index.index(
+            mock_db,
+            models.Document,
+            'doc-1',
+            title='Runbook',
+            content='Restart the thing.',
+        )
+        node = mock_db.embed_node.await_args.args[0]
+        self.assertEqual('doc-1', node.id)
+        self.assertEqual('Runbook', node.title)
+        self.assertEqual('Restart the thing.', node.content)
+        self.assertFalse(
+            mock_db.embed_node.await_args.kwargs['raise_on_error']
+        )
+
+    async def test_index_forwards_raise_on_error(self) -> None:
+        mock_db = mock.AsyncMock()
+        await _search_index.index(
+            mock_db,
+            models.Document,
+            'doc-1',
+            raise_on_error=True,
+            title='Runbook',
+        )
+        self.assertTrue(mock_db.embed_node.await_args.kwargs['raise_on_error'])
+
+
+class DropTestCase(unittest.IsolatedAsyncioTestCase):
+    async def test_drop_deletes_by_label_and_id(self) -> None:
+        mock_db = mock.AsyncMock()
+        await _search_index.drop(mock_db, models.Comment, 'comment-1')
+        mock_db.delete_node_embeddings.assert_awaited_once_with(
+            'Comment', 'comment-1'
+        )
+
+    async def test_drop_swallows_failures(self) -> None:
+        """A cleanup failure must not fail an already-committed delete.
+
+        The node is gone by the time ``drop`` runs, so raising here
+        would turn a successful delete into a 500 and make the client's
+        retry 404.
+        """
+        mock_db = mock.AsyncMock()
+        mock_db.delete_node_embeddings.side_effect = RuntimeError('boom')
+        with self.assertLogs(_search_index.LOGGER, level='WARNING') as logs:
+            await _search_index.drop(mock_db, models.Comment, 'comment-1')
+        self.assertIn('search-reindex', logs.output[0])

--- a/apps/api/tests/endpoints/test_search_index.py
+++ b/apps/api/tests/endpoints/test_search_index.py
@@ -62,6 +62,37 @@ class IndexTestCase(unittest.IsolatedAsyncioTestCase):
         )
         self.assertTrue(mock_db.embed_node.await_args.kwargs['raise_on_error'])
 
+    async def test_index_swallows_a_failed_lookup(self) -> None:
+        """A failed re-read is best-effort like a failed embedding.
+
+        Background tasks run in sequence, so raising here would abort
+        whatever is queued behind an index refresh.
+        """
+        mock_db = mock.AsyncMock()
+        mock_db.match.side_effect = RuntimeError('boom')
+
+        with self.assertLogs(_search_index.LOGGER, level='WARNING') as logs:
+            embedded = await _search_index.index(
+                mock_db, models.Document, 'doc-1'
+            )
+
+        self.assertFalse(embedded)
+        mock_db.embed_node.assert_not_awaited()
+        self.assertIn('search-reindex', logs.output[0])
+
+    async def test_index_raises_a_failed_lookup_when_strict(self) -> None:
+        """A reindex must not count an unreadable node as indexed."""
+        mock_db = mock.AsyncMock()
+        mock_db.match.side_effect = RuntimeError('boom')
+
+        with self.assertRaises(RuntimeError):
+            await _search_index.index(
+                mock_db,
+                models.Document,
+                'doc-1',
+                raise_on_error=True,
+            )
+
 
 class DropTestCase(unittest.IsolatedAsyncioTestCase):
     async def test_drop_deletes_by_label_and_id(self) -> None:

--- a/apps/api/tests/endpoints/test_search_index.py
+++ b/apps/api/tests/endpoints/test_search_index.py
@@ -8,31 +8,57 @@ from imbi.common import models
 
 
 class IndexTestCase(unittest.IsolatedAsyncioTestCase):
-    async def test_index_builds_the_node_from_fields(self) -> None:
-        mock_db = mock.AsyncMock()
-        await _search_index.index(
-            mock_db,
-            models.Document,
-            'doc-1',
-            title='Runbook',
-            content='Restart the thing.',
+    async def test_index_embeds_the_re_read_node(self) -> None:
+        """The node is re-read at task time, not taken from the caller.
+
+        Two concurrent edits schedule two background tasks in no
+        particular order, so embedding whatever the caller wrote lets
+        the older task run last and leave the index holding stale text.
+        Re-reading makes last-writer-wins correct either way round.
+        """
+        persisted = models.Document.model_construct(
+            id='doc-1',
+            title='Runbook (v2)',
+            content='The newer content.',
         )
-        node = mock_db.embed_node.await_args.args[0]
-        self.assertEqual('doc-1', node.id)
-        self.assertEqual('Runbook', node.title)
-        self.assertEqual('Restart the thing.', node.content)
+        mock_db = mock.AsyncMock()
+        mock_db.match.return_value = [persisted]
+
+        embedded = await _search_index.index(mock_db, models.Document, 'doc-1')
+
+        self.assertTrue(embedded)
+        mock_db.match.assert_awaited_once_with(
+            models.Document, {'id': 'doc-1'}
+        )
+        self.assertIs(persisted, mock_db.embed_node.await_args.args[0])
         self.assertFalse(
             mock_db.embed_node.await_args.kwargs['raise_on_error']
         )
 
+    async def test_index_skips_a_node_that_is_gone(self) -> None:
+        """A node deleted before the task runs is skipped, not an error.
+
+        ``drop`` has already cleared its embedding rows, so there is
+        nothing to do and nothing to report.
+        """
+        mock_db = mock.AsyncMock()
+        mock_db.match.return_value = []
+
+        embedded = await _search_index.index(mock_db, models.Document, 'doc-1')
+
+        self.assertFalse(embedded)
+        mock_db.embed_node.assert_not_awaited()
+
     async def test_index_forwards_raise_on_error(self) -> None:
         mock_db = mock.AsyncMock()
+        mock_db.match.return_value = [
+            models.Document.model_construct(id='doc-1', title='Runbook')
+        ]
         await _search_index.index(
             mock_db,
             models.Document,
             'doc-1',
             raise_on_error=True,
-            title='Runbook',
         )
         self.assertTrue(mock_db.embed_node.await_args.kwargs['raise_on_error'])
 

--- a/apps/api/tests/test_backfill_embeddings.py
+++ b/apps/api/tests/test_backfill_embeddings.py
@@ -7,13 +7,7 @@ from unittest import mock
 import psycopg
 
 from imbi.api import backfill_embeddings
-
-
-def _patch_embeddable(return_value: list[str]) -> mock._patch:
-    return mock.patch(
-        'imbi.api.backfill_embeddings._embeddable_fields',
-        return_value=return_value,
-    )
+from imbi.common import graph
 
 
 def _patch_already_embedded(return_value: set[str]) -> mock._patch:
@@ -32,31 +26,14 @@ class BackfillEmbeddingsTestCase(unittest.IsolatedAsyncioTestCase):
         with mock.patch.object(
             backfill_embeddings.graph, 'Graph', return_value=mock_db
         ):
-            with _patch_embeddable(['name']):
-                with _patch_already_embedded(set()):
-                    await backfill_embeddings.run(concurrency=2, force=False)
+            with _patch_already_embedded(set()):
+                await backfill_embeddings.run(concurrency=2, force=False)
 
-        expected = len(backfill_embeddings._NODE_TYPES) + len(
-            backfill_embeddings._GRAPH_MODEL_TYPES
-        )
+        expected = len(graph.embeddable_node_types())
         self.assertEqual(mock_db.match.await_count, expected)
-        self.assertEqual(mock_db._auto_embed.await_count, expected)
+        self.assertEqual(mock_db.embed_node.await_count, expected)
         mock_db.open.assert_awaited_once()
         mock_db.close.assert_awaited_once()
-
-    async def test_run_skips_non_embeddable_nodes(self) -> None:
-        mock_node = mock.MagicMock(id='node-1')
-        mock_db = mock.AsyncMock()
-        mock_db.match.return_value = [mock_node]
-
-        with mock.patch.object(
-            backfill_embeddings.graph, 'Graph', return_value=mock_db
-        ):
-            with _patch_embeddable([]):
-                with _patch_already_embedded(set()):
-                    await backfill_embeddings.run(concurrency=2, force=False)
-
-        mock_db._auto_embed.assert_not_awaited()
 
     async def test_run_closes_db_on_exception(self) -> None:
         mock_db = mock.AsyncMock()
@@ -65,12 +42,9 @@ class BackfillEmbeddingsTestCase(unittest.IsolatedAsyncioTestCase):
         with mock.patch.object(
             backfill_embeddings.graph, 'Graph', return_value=mock_db
         ):
-            with _patch_embeddable(['name']):
-                with _patch_already_embedded(set()):
-                    with self.assertRaises(RuntimeError):
-                        await backfill_embeddings.run(
-                            concurrency=2, force=False
-                        )
+            with _patch_already_embedded(set()):
+                with self.assertRaises(RuntimeError):
+                    await backfill_embeddings.run(concurrency=2, force=False)
 
         mock_db.close.assert_awaited_once()
 
@@ -78,55 +52,53 @@ class BackfillEmbeddingsTestCase(unittest.IsolatedAsyncioTestCase):
         mock_db = mock.AsyncMock()
         mock_db.match.return_value = []
 
-        with _patch_embeddable(['name']):
-            with _patch_already_embedded(set()):
-                semaphore = asyncio.Semaphore(2)
-                count = await backfill_embeddings._embed_type(
-                    mock_db,
-                    backfill_embeddings._NODE_TYPES[0],
-                    semaphore=semaphore,
-                    force=False,
-                )
+        with _patch_already_embedded(set()):
+            semaphore = asyncio.Semaphore(2)
+            count = await backfill_embeddings._embed_type(
+                mock_db,
+                graph.embeddable_node_types()[0],
+                semaphore=semaphore,
+                force=False,
+            )
 
         self.assertEqual(count, 0)
-        mock_db._auto_embed.assert_not_awaited()
+        mock_db.embed_node.assert_not_awaited()
 
     async def test_embed_type_skips_already_embedded(self) -> None:
         mock_node = mock.MagicMock(id='node-already')
         mock_db = mock.AsyncMock()
         mock_db.match.return_value = [mock_node]
 
-        with _patch_embeddable(['name']):
-            with _patch_already_embedded({'node-already'}):
-                semaphore = asyncio.Semaphore(2)
-                count = await backfill_embeddings._embed_type(
-                    mock_db,
-                    backfill_embeddings._NODE_TYPES[0],
-                    semaphore=semaphore,
-                    force=False,
-                )
+        with _patch_already_embedded({'node-already'}):
+            semaphore = asyncio.Semaphore(2)
+            count = await backfill_embeddings._embed_type(
+                mock_db,
+                graph.embeddable_node_types()[0],
+                semaphore=semaphore,
+                force=False,
+            )
 
         self.assertEqual(count, 0)
-        mock_db._auto_embed.assert_not_awaited()
+        mock_db.embed_node.assert_not_awaited()
 
     async def test_embed_type_force_re_embeds(self) -> None:
         mock_node = mock.MagicMock(id='node-already')
         mock_db = mock.AsyncMock()
         mock_db.match.return_value = [mock_node]
 
-        already_patch = _patch_already_embedded({'node-already'})
-        with _patch_embeddable(['name']):
-            with already_patch as already_mock:
-                semaphore = asyncio.Semaphore(2)
-                count = await backfill_embeddings._embed_type(
-                    mock_db,
-                    backfill_embeddings._NODE_TYPES[0],
-                    semaphore=semaphore,
-                    force=True,
-                )
+        with _patch_already_embedded({'node-already'}) as already_mock:
+            semaphore = asyncio.Semaphore(2)
+            count = await backfill_embeddings._embed_type(
+                mock_db,
+                graph.embeddable_node_types()[0],
+                semaphore=semaphore,
+                force=True,
+            )
 
         self.assertEqual(count, 1)
-        mock_db._auto_embed.assert_awaited_once_with(mock_node)
+        mock_db.embed_node.assert_awaited_once_with(
+            mock_node, raise_on_error=True
+        )
         already_mock.assert_not_called()
 
     async def test_embed_type_swallows_psycopg_error(self) -> None:
@@ -135,25 +107,24 @@ class BackfillEmbeddingsTestCase(unittest.IsolatedAsyncioTestCase):
         mock_db = mock.AsyncMock()
         mock_db.match.return_value = [mock_node_ok, mock_node_bad]
 
-        async def _auto_embed(node: object) -> None:
+        async def _embed(node: object, **_kwargs: object) -> None:
             if getattr(node, 'id', None) == 'bad':
                 raise psycopg.OperationalError('boom')
 
-        mock_db._auto_embed.side_effect = _auto_embed
+        mock_db.embed_node.side_effect = _embed
 
-        with _patch_embeddable(['name']):
-            with _patch_already_embedded(set()):
-                semaphore = asyncio.Semaphore(2)
-                count = await backfill_embeddings._embed_type(
-                    mock_db,
-                    backfill_embeddings._NODE_TYPES[0],
-                    semaphore=semaphore,
-                    force=False,
-                )
+        with _patch_already_embedded(set()):
+            semaphore = asyncio.Semaphore(2)
+            count = await backfill_embeddings._embed_type(
+                mock_db,
+                graph.embeddable_node_types()[0],
+                semaphore=semaphore,
+                force=False,
+            )
 
         # One success, one swallowed psycopg failure.
         self.assertEqual(count, 1)
-        self.assertEqual(mock_db._auto_embed.await_count, 2)
+        self.assertEqual(mock_db.embed_node.await_count, 2)
 
     async def test_already_embedded_ids_queries_label(self) -> None:
         cursor = mock.AsyncMock()

--- a/apps/api/tests/test_maintenance_operations.py
+++ b/apps/api/tests/test_maintenance_operations.py
@@ -6,6 +6,7 @@ import contextlib
 import datetime
 import json
 import time
+import typing
 import unittest
 from unittest import mock
 
@@ -14,6 +15,8 @@ import fastapi
 from imbi.api.commit_sync.service import CommitSyncUnavailable
 from imbi.api.maintenance import operations
 from imbi.api.pr_sync.service import PRSyncUnavailable
+from imbi.common import graph
+from imbi.common import models as common_models
 from imbi.common.plugins.errors import PluginRateLimited
 
 
@@ -778,3 +781,67 @@ class ExecuteReleaseRepairTests(unittest.IsolatedAsyncioTestCase):
         )
         self.assertEqual('skipped', outcome)
         self.assertEqual([], self._queries(db))
+
+
+class SearchReindexTests(unittest.IsolatedAsyncioTestCase):
+    def _db(
+        self,
+        rows: list[dict[str, str]] | None = None,
+        nodes: list[typing.Any] | None = None,
+    ) -> mock.AsyncMock:
+        db = mock.AsyncMock()
+        db.execute.return_value = rows or []
+        db.match.return_value = nodes or []
+        return db
+
+    async def test_enumerates_every_embeddable_label(self) -> None:
+        db = self._db([{'id': '"n-1"'}, {'id': '""'}])
+        items = await operations.enumerate_embeddable_nodes(db)
+        labels = [t.__name__ for t in graph.embeddable_node_types()]
+        # One item per label, falsy ids dropped.
+        self.assertEqual([f'{label}:n-1' for label in labels], items)
+        self.assertIn('Document', labels)
+        self.assertIn('Comment', labels)
+
+    async def test_reindexes_the_matched_node(self) -> None:
+        node = common_models.Document.model_construct(
+            id='doc-1', title='Runbook', content='body'
+        )
+        db = self._db(nodes=[node])
+        outcome = await operations.execute_search_reindex(
+            db, mock.AsyncMock(), 'Document:doc-1'
+        )
+        self.assertEqual('succeeded', outcome)
+        self.assertEqual(common_models.Document, db.match.await_args.args[0])
+        self.assertEqual({'id': 'doc-1'}, db.match.await_args.args[1])
+        self.assertIs(node, db.embed_node.await_args.args[0])
+        # A silent embedding failure must not be reported as success.
+        self.assertTrue(db.embed_node.await_args.kwargs['raise_on_error'])
+
+    async def test_skips_a_node_deleted_mid_run(self) -> None:
+        db = self._db()
+        outcome = await operations.execute_search_reindex(
+            db, mock.AsyncMock(), 'Document:ghost'
+        )
+        self.assertEqual('skipped', outcome)
+        db.embed_node.assert_not_awaited()
+
+    async def test_skips_a_label_that_is_no_longer_embeddable(self) -> None:
+        db = self._db()
+        outcome = await operations.execute_search_reindex(
+            db, mock.AsyncMock(), 'Retired:n-1'
+        )
+        self.assertEqual('skipped', outcome)
+        db.match.assert_not_awaited()
+
+    async def test_embedding_failure_is_recorded_against_the_node(
+        self,
+    ) -> None:
+        db = self._db(
+            nodes=[common_models.Document.model_construct(id='doc-1')]
+        )
+        db.embed_node.side_effect = RuntimeError('model unavailable')
+        with self.assertRaises(operations.MaintenanceItemFailed):
+            await operations.execute_search_reindex(
+                db, mock.AsyncMock(), 'Document:doc-1'
+            )

--- a/libraries/common/src/imbi/common/graph/__init__.py
+++ b/libraries/common/src/imbi/common/graph/__init__.py
@@ -10,6 +10,7 @@ from imbi.common import lifespan
 from imbi.common.graph.client import (
     Graph,
     SearchResult,
+    embeddable_node_types,
     parse_agtype,
 )
 from imbi.common.graph.initializer import initialize
@@ -55,6 +56,7 @@ __all__ = [
     'OnStartup',
     'Pool',
     'SearchResult',
+    'embeddable_node_types',
     'graph_lifespan',
     'parse_agtype',
     'set_on_startup',

--- a/libraries/common/src/imbi/common/graph/client.py
+++ b/libraries/common/src/imbi/common/graph/client.py
@@ -255,6 +255,18 @@ class Graph:
         embeddings.close()
         self.opened = False
 
+    def _require_open(self) -> None:
+        """Raise unless the pool has been opened.
+
+        The pool is built with ``open=False``, so acquiring a
+        connection from an unopened one blocks until ``PoolTimeout``
+        rather than failing.  Every entry point that reaches the pool
+        checks this first so the misuse surfaces immediately.
+
+        """
+        if not self.opened:
+            raise RuntimeError('Graph pool is not open')
+
     # ----------------------------------------------------------
     # Graph CRUD
     # ----------------------------------------------------------
@@ -276,8 +288,7 @@ class Graph:
         then embeddings are cleaned up on the same connection.
 
         """
-        if not self.opened:
-            raise RuntimeError('Graph pool is not open')
+        self._require_open()
         stmt = cypher.delete(node)
         async with self.pool.connection() as conn:
             await self._execute_on(
@@ -395,8 +406,7 @@ class Graph:
         nothing.
 
         """
-        if not self.opened:
-            raise RuntimeError('Graph pool is not open')
+        self._require_open()
         vector = await embeddings.aembed_one(
             query,
             model_name,
@@ -557,8 +567,7 @@ class Graph:
         nodes with raw Cypher instead of ``delete``.
 
         """
-        if not self.opened:
-            raise RuntimeError('Graph pool is not open')
+        self._require_open()
         async with self.pool.connection() as conn:
             await self._delete_embeddings_where(
                 conn,
@@ -596,8 +605,7 @@ class Graph:
         rather than failing.
 
         """
-        if not self.opened:
-            raise RuntimeError('Graph pool is not open')
+        self._require_open()
         embed_settings = settings.Embeddings()
         if not embed_settings.enabled:
             return
@@ -770,8 +778,7 @@ class Graph:
         a manual ``try/except`` calling ``rollback()`` would.
 
         """
-        if not self.opened:
-            raise RuntimeError('Graph pool is not open')
+        self._require_open()
         async with self.pool.connection() as conn:
             async with conn.transaction():
                 for stmt in statements:
@@ -921,8 +928,7 @@ class Graph:
         returns.
 
         """
-        if not self.opened:
-            raise RuntimeError('Graph pool is not open')
+        self._require_open()
 
         async with self.pool.connection() as conn:
             return await self._execute_on(

--- a/libraries/common/src/imbi/common/graph/client.py
+++ b/libraries/common/src/imbi/common/graph/client.py
@@ -590,7 +590,14 @@ class Graph:
         embeddable fields.  Errors propagate; ``_auto_embed`` is the
         swallowing wrapper.
 
+        Checks the pool the way ``search`` and ``delete_node_embeddings``
+        do: the pool is built with ``open=False``, so acquiring a
+        connection from an unopened one blocks until ``PoolTimeout``
+        rather than failing.
+
         """
+        if not self.opened:
+            raise RuntimeError('Graph pool is not open')
         embed_settings = settings.Embeddings()
         if not embed_settings.enabled:
             return

--- a/libraries/common/src/imbi/common/graph/client.py
+++ b/libraries/common/src/imbi/common/graph/client.py
@@ -18,7 +18,7 @@ from pgvector.psycopg import register_vector_async
 from psycopg import rows, sql
 
 from imbi.common import models, settings
-from imbi.common.graph import cypher
+from imbi.common.graph import chunk, cypher, embeddings
 
 LOGGER = logging.getLogger(__name__)
 
@@ -70,6 +70,32 @@ def _embeddable_descriptors(
                 result.append((name, md))
                 break
     return tuple(result)
+
+
+@functools.cache
+def embeddable_node_types() -> tuple[type[models.GraphModel], ...]:
+    """Every graph model that declares at least one ``Embeddable`` field.
+
+    Derived from the model definitions rather than hand-listed, so a
+    model that gains an ``Embeddable`` field is picked up by the
+    reindex paths without a second place to update.  ``Node`` is
+    excluded: it declares the shared ``name``/``description`` fields
+    its subclasses inherit but is never itself a vertex label.
+    Ordered by label for stable enumeration.
+
+    """
+    seen: dict[str, type[models.GraphModel]] = {}
+    queue: list[type[models.GraphModel]] = [models.GraphModel]
+    while queue:
+        for subclass in queue.pop().__subclasses__():
+            if subclass.__name__ in seen:
+                continue
+            queue.append(subclass)
+            if subclass is models.Node:
+                continue
+            if _embeddable_descriptors(subclass):
+                seen[subclass.__name__] = subclass
+    return tuple(seen[label] for label in sorted(seen))
 
 
 def _embeddable_fields(
@@ -225,8 +251,6 @@ class Graph:
 
     async def close(self) -> None:
         """Close the connection pool and release models."""
-        from imbi.common.graph import embeddings
-
         await self.pool.close()
         embeddings.close()
         self.opened = False
@@ -373,8 +397,6 @@ class Graph:
         """
         if not self.opened:
             raise RuntimeError('Graph pool is not open')
-        from imbi.common.graph import embeddings
-
         vector = await embeddings.aembed_one(
             query,
             model_name,
@@ -500,11 +522,73 @@ class Graph:
     # Auto-embedding
     # ----------------------------------------------------------
 
+    async def embed_node(
+        self,
+        node: models.GraphModel,
+        *,
+        raise_on_error: bool = False,
+    ) -> None:
+        """(Re)generate the embeddings for *node*.
+
+        ``create``/``merge``/``delete`` keep embeddings in sync on
+        their own, but ``execute`` takes raw Cypher and has no model
+        to inspect, so callers that write nodes that way must call
+        this after the write.
+
+        Failures are logged and swallowed like the automatic path,
+        which suits a best-effort call alongside a graph write. Pass
+        ``raise_on_error`` when the embedding *is* the job (a reindex)
+        and a silent failure would be reported as success.
+
+        """
+        if raise_on_error:
+            await self._embed_fields(node)
+        else:
+            await self._auto_embed(node)
+
+    async def delete_node_embeddings(
+        self,
+        node_label: str,
+        node_id: str,
+    ) -> None:
+        """Delete every embedding row for a node.
+
+        The counterpart to ``embed_node`` for callers that delete
+        nodes with raw Cypher instead of ``delete``.
+
+        """
+        if not self.opened:
+            raise RuntimeError('Graph pool is not open')
+        async with self.pool.connection() as conn:
+            await self._delete_embeddings_where(
+                conn,
+                node_label=node_label,
+                node_id=node_id,
+            )
+
     async def _auto_embed(self, node: models.GraphModel) -> None:
         """Generate and store embeddings for embeddable fields.
 
         Failures are logged but do not propagate — the graph
         write is the critical path.
+
+        """
+        try:
+            await self._embed_fields(node)
+        except Exception:  # noqa: BLE001
+            LOGGER.warning(
+                'Failed to auto-embed node %s (id=%s)',
+                type(node).__name__,
+                node.id,
+                exc_info=True,
+            )
+
+    async def _embed_fields(self, node: models.GraphModel) -> None:
+        """Write the embedding rows for a node's embeddable fields.
+
+        A no-op when embedding is disabled or the model declares no
+        embeddable fields.  Errors propagate; ``_auto_embed`` is the
+        swallowing wrapper.
 
         """
         embed_settings = settings.Embeddings()
@@ -513,57 +597,47 @@ class Graph:
         fields = _embeddable_fields(node)
         if not fields:
             return
-        try:
-            from imbi.common.graph import chunk, embeddings
-
-            node_label = type(node).__name__
-            async with self.pool.connection() as conn:
-                for attr, text, spec in fields:
-                    if text is None:
-                        await self._delete_embeddings_where(
-                            conn,
-                            node_label=node_label,
-                            node_id=node.id,
-                            attribute=attr,
-                        )
-                        continue
-                    if spec.chunk:
-                        chunks = list(
-                            chunk.content(
-                                spec.mimetype,
-                                text,
-                            ),
-                        )
-                    else:
-                        chunks = [text]
-                    vectors = await embeddings.aembed(
-                        chunks,
-                        spec.model_name,
-                    )
-                    await self._upsert_embeddings(
-                        conn,
-                        node_label,
-                        node.id,
-                        attr,
-                        spec.model_name,
-                        chunks,
-                        vectors,
-                    )
+        node_label = type(node).__name__
+        async with self.pool.connection() as conn:
+            for attr, text, spec in fields:
+                if text is None:
                     await self._delete_embeddings_where(
                         conn,
                         node_label=node_label,
                         node_id=node.id,
                         attribute=attr,
-                        model_name=spec.model_name,
-                        min_chunk_index=len(chunks),
                     )
-        except Exception:  # noqa: BLE001
-            LOGGER.warning(
-                'Failed to auto-embed node %s (id=%s)',
-                type(node).__name__,
-                node.id,
-                exc_info=True,
-            )
+                    continue
+                if spec.chunk:
+                    chunks = list(
+                        chunk.content(
+                            spec.mimetype,
+                            text,
+                        ),
+                    )
+                else:
+                    chunks = [text]
+                vectors = await embeddings.aembed(
+                    chunks,
+                    spec.model_name,
+                )
+                await self._upsert_embeddings(
+                    conn,
+                    node_label,
+                    node.id,
+                    attr,
+                    spec.model_name,
+                    chunks,
+                    vectors,
+                )
+                await self._delete_embeddings_where(
+                    conn,
+                    node_label=node_label,
+                    node_id=node.id,
+                    attribute=attr,
+                    model_name=spec.model_name,
+                    min_chunk_index=len(chunks),
+                )
 
     @staticmethod
     async def _upsert_embeddings(

--- a/libraries/common/tests/test_graph.py
+++ b/libraries/common/tests/test_graph.py
@@ -610,6 +610,25 @@ class EmbedNodeTests(unittest.IsolatedAsyncioTestCase):
         with self.assertRaises(RuntimeError):
             await graph.Graph().delete_node_embeddings('Document', 'doc-1')
 
+    async def test_embed_node_requires_open_pool(self) -> None:
+        """An unopened pool fails fast instead of blocking on checkout.
+
+        ``Graph`` builds its pool with ``open=False``, so acquiring a
+        connection from one waits out ``PoolTimeout`` rather than
+        raising -- the same guard ``search`` and
+        ``delete_node_embeddings`` already carry.
+        """
+        with self.assertRaises(RuntimeError):
+            await graph.Graph().embed_node(
+                self._node(),
+                raise_on_error=True,
+            )
+
+    async def test_embed_node_unopened_pool_is_swallowed(self) -> None:
+        """The best-effort path degrades to a log line, and still no hang."""
+        with self.assertLogs('imbi.common.graph', level='WARNING'):
+            await graph.Graph().embed_node(self._node())
+
     async def test_delete_node_embeddings_deletes_every_row(self) -> None:
         g = graph.Graph()
         g.opened = True

--- a/libraries/common/tests/test_graph.py
+++ b/libraries/common/tests/test_graph.py
@@ -576,6 +576,59 @@ class AutoEmbedTests(unittest.IsolatedAsyncioTestCase):
             await g._auto_embed(org)
 
 
+class EmbedNodeTests(unittest.IsolatedAsyncioTestCase):
+    """The public hook raw-Cypher writers use to stay searchable."""
+
+    def _failing_graph(self) -> graph.Graph:
+        g = graph.Graph()
+        g.opened = True
+        pool = mock.MagicMock()
+        pool.connection.side_effect = RuntimeError('pool fail')
+        g.pool = pool
+        return g
+
+    def _node(self) -> models.Organization:
+        return models.Organization(
+            name='Org',
+            slug='org',
+            description='A description',
+        )
+
+    async def test_failure_is_swallowed_by_default(self) -> None:
+        with self.assertLogs('imbi.common.graph', level='WARNING'):
+            await self._failing_graph().embed_node(self._node())
+
+    async def test_raise_on_error_propagates(self) -> None:
+        """A reindex must not report a failed embedding as success."""
+        with self.assertRaises(RuntimeError):
+            await self._failing_graph().embed_node(
+                self._node(),
+                raise_on_error=True,
+            )
+
+    async def test_delete_node_embeddings_requires_open_pool(self) -> None:
+        with self.assertRaises(RuntimeError):
+            await graph.Graph().delete_node_embeddings('Document', 'doc-1')
+
+    async def test_delete_node_embeddings_deletes_every_row(self) -> None:
+        g = graph.Graph()
+        g.opened = True
+        conn = mock.AsyncMock()
+        pool = mock.MagicMock()
+        pool.connection.return_value.__aenter__.return_value = conn
+        g.pool = pool
+        with mock.patch.object(
+            graph.Graph,
+            '_delete_embeddings_where',
+        ) as deleter:
+            await g.delete_node_embeddings('Document', 'doc-1')
+        deleter.assert_awaited_once_with(
+            conn,
+            node_label='Document',
+            node_id='doc-1',
+        )
+
+
 class SearchResultTests(unittest.TestCase):
     def test_search_result_creation(self) -> None:
         r = graph.SearchResult(

--- a/ui/src/components/admin/MaintenanceManagement.tsx
+++ b/ui/src/components/admin/MaintenanceManagement.tsx
@@ -36,8 +36,8 @@ export function MaintenanceManagement() {
           Maintenance
         </h1>
         <p className="text-secondary mt-1 text-sm">
-          Global background operations — each run applies to every project
-          across all organizations.
+          Global background operations — each run applies to every project or
+          document it covers, across all organizations.
         </p>
       </div>
 
@@ -88,7 +88,7 @@ export function MaintenanceManagement() {
         confirmLabel="Run"
         description={
           confirming
-            ? `"${confirming.label}" runs across every project in all organizations. This may take a while and generate significant load.`
+            ? `"${confirming.label}" runs across everything it covers in all organizations. This may take a while and generate significant load.`
             : ''
         }
         onCancel={() => setConfirming(null)}


### PR DESCRIPTION
## Summary
Nodes with `Embeddable` fields now index themselves into the pgvector search index when they are written, instead of only when the one-shot backfill script is run. Adds a `search-reindex` maintenance operation for bulk rebuilds.

## Problem
Vector search silently missed most content. The graph client embeds a node's `Embeddable` fields automatically when it is written through `db.create`/`db.merge` and clears them on `db.delete` — but the endpoints that write documents, comments, releases, and projects all write raw Cypher through `db.execute`, which has no model for the client to inspect and so embedded nothing.

The result: a node was only searchable if `imbi.api.backfill_embeddings` happened to have run after it was created, and any later edit left a stale vector behind. Verified against a live API — a document titled "Brand Kit as a first-class Lists API resource, stored in a Postgres JSONB column" did not appear in results even when searching its exact title, while unrelated ADRs from the last backfill ranked at distance 0.44.

Two smaller gaps found alongside it:

- Org search scope only reached documents attached to a `Project`. ProjectType- and User-attached documents (both listed in the org document index) could never appear in results even once indexed.
- The backfill script's two hand-maintained lists of embeddable model types had drifted — `MCPServer` was missing.

## Solution
`db.execute` takes arbitrary Cypher, so it cannot know what was written; making it embed would mean parsing Cypher to guess. Instead the write paths call an explicit hook:

- `Graph.embed_node()` / `Graph.delete_node_embeddings()` are the public hooks for raw-Cypher writers. `_auto_embed` splits into a swallowing wrapper over `_embed_fields` so `raise_on_error` can distinguish best-effort indexing alongside a write (failures logged) from indexing as the job itself (failures reported).
- `endpoints/_search_index.py` (`index()` / `drop()`) is called from every write path in `documents.py`, `comments.py`, `releases.py`, and `projects.py` — one shared helper rather than four copies of the same `model_construct`. Indexing runs as a background task, and is skipped when no embeddable field actually changed, so a tag toggle or pin no longer re-chunks a whole document body.
- `graph.embeddable_node_types()` derives the embeddable-model list from the annotations instead of hand-listing it, so a model that gains an `Embeddable` field is covered automatically. `backfill_embeddings` now uses it and the public embed hook, dropping its use of private client internals.
- A registry-driven `search-reindex` maintenance operation ("Reindex Search" on the Admin → Maintenance page) rebuilds the index for every embeddable label, keyed on `Label:node_id` work items. Intended for after a bulk import or an embedding-model change.
- Org search scope now reaches documents through all three attachment kinds, and its eight traversals collapse into one query tuple.

Routing document writes through the ORM's `merge()` was considered and rejected: `Document`'s polymorphic `ATTACHED_TO` anchor includes `User`, which is not modeled, the anchor `MATCH` doubles as the 404/authz check, and `merge()` cannot express the conditional atomic `version` bump.

## Impact
- Existing rows stay stale until a reindex — **run "Reindex Search" once from Admin → Maintenance after deploy** to clear the accumulated drift.
- Each create/edit of a document, comment, release, or project now costs one embedding run, off the response path in a background task. Deletes clear their rows inline (a single SQL `DELETE`).
- Org-scoped search issues two additional Cypher traversals per request (9 total, up from 7). Collapsing or parallelizing these is a follow-up; they were already sequential.
- `search-reindex` walks every embeddable node one at a time per API instance, so a full rebuild on a large database is slow but resumable and rate-limit friendly.
- Three comment endpoints, two release endpoints, and `create_project` gained a `BackgroundTasks` parameter; no route signature or response schema changed.

## Testing
- Full API + common suite: 3679 passed (`apps/api/tests`, `libraries/common/tests`).
- New coverage: embed-on-create and re-embed-on-edit for documents/comments/releases, no-embed when only tags or pin state change, embeddings dropped on document/comment/project delete, all three document attachment kinds in org scope, the derived type list, and the reindex operation including its skip and failure paths.
- `ruff check`, `ruff format --check`, and `basedpyright` clean; UI `MaintenanceManagement` tests pass.
- Not exercised against a running deployment — the dev environment was not up. The diagnosis was confirmed against a live API; the fix is covered by tests only.
