### PR TITLE
Add document read analytics and likes

### DIFF
--- a/apps/api/src/imbi/api/app.py
+++ b/apps/api/src/imbi/api/app.py
@@ -30,6 +30,7 @@ def create_app() -> fastapi.FastAPI:
             lifespans.deployment_sync_worker_hook,
             lifespans.maintenance_worker_hook,
             lifespans.identity_refresh_hook,
+            lifespans.document_read_sweeper_hook,
         ),
         version=version,
         redoc_url=None,

--- a/apps/api/src/imbi/api/auth/seed.py
+++ b/apps/api/src/imbi/api/auth/seed.py
@@ -277,6 +277,22 @@ STANDARD_PERMISSIONS: list[tuple[str, str, str, str]] = [
         'delete',
         'Delete project documents',
     ),
+    (
+        'document:analytics:read',
+        'document',
+        'analytics:read',
+        'View aggregate document read analytics',
+    ),
+    # Deliberately separate from the aggregate above: a named list of who
+    # read what and for how long is a different kind of data from a count,
+    # and is additionally gated by the organization's
+    # ``document_analytics_identities`` setting.
+    (
+        'document:analytics:read_identities',
+        'document',
+        'analytics:read_identities',
+        'View which people read a document',
+    ),
     # Comment management
     (
         'comment:create',
@@ -607,6 +623,7 @@ DEFAULT_ROLES: list[tuple[str, str, str, int, list[str], bool]] = [
             'tag:write',
             'document:create',
             'document:read',
+            'document:analytics:read',
             'document:write',
             'document:delete',
             'comment:create',
@@ -626,6 +643,7 @@ DEFAULT_ROLES: list[tuple[str, str, str, int, list[str], bool]] = [
         [
             'blueprint:read',
             'document:read',
+            'document:analytics:read',
             'document_template:read',
             'environment:read',
             'link_definition:read',
@@ -670,6 +688,7 @@ DEFAULT_ROLES: list[tuple[str, str, str, int, list[str], bool]] = [
             'webhook:read',
             'tag:read',
             'document:read',
+            'document:analytics:read',
             'document_template:read',
             'me:identities:manage',
         ],

--- a/apps/api/src/imbi/api/documents/read_sweeper.py
+++ b/apps/api/src/imbi/api/documents/read_sweeper.py
@@ -1,0 +1,94 @@
+"""Background reaper for abandoned document read sessions.
+
+A reading session normally closes itself with a final ``sendBeacon``
+flush, but that is best-effort -- a killed tab, a dropped network, a
+crashed browser. Anything still open past the idle timeout is finalized
+here instead; without it, an abandoned session never contributes to a
+document's numbers.
+
+Lives beside the other background workers rather than in ``endpoints``:
+the lifespan module should not have to import the router package (and
+with it every endpoint) to start a worker.
+"""
+
+import asyncio
+import logging
+
+from valkey import asyncio as valkey_asyncio
+
+from imbi.api.endpoints import _document_reads
+
+LOGGER = logging.getLogger(__name__)
+
+#: How often the reaper looks for abandoned sessions.
+SWEEP_INTERVAL_SECONDS = 60
+_SWEEP_LOCK_KEY = 'imbi:document:read-sweeper'
+
+
+async def _try_sweep_lock(client: valkey_asyncio.Valkey) -> bool:
+    """Claim this sweep round for one instance.
+
+    Every API instance runs a sweeper; without a lock they would all
+    aggregate and re-insert the same sessions each round. Duplicate
+    finalization is *harmless* -- the sessions table dedups on
+    ``session_id`` -- so this is purely to avoid N-way wasted work, and
+    a Valkey outage degrades to every instance sweeping rather than to
+    sessions never being finalized.
+    """
+    try:
+        return bool(
+            await client.set(
+                _SWEEP_LOCK_KEY, '1', nx=True, ex=SWEEP_INTERVAL_SECONDS
+            )
+        )
+    except Exception:  # noqa: BLE001
+        LOGGER.debug('read-session sweep lock acquire failed', exc_info=True)
+        return True
+
+
+async def sweep_once(client: valkey_asyncio.Valkey) -> int:
+    """Finalize every abandoned session found this round.
+
+    Returns how many sessions were finalized.
+    """
+    if not await _try_sweep_lock(client):
+        return 0
+    session_ids = await _document_reads.stale_session_ids()
+    if not session_ids:
+        return 0
+    finalized = await _document_reads.finalize_sessions(session_ids)
+    if finalized:
+        LOGGER.info('Finalized %d abandoned read session(s)', finalized)
+    return finalized
+
+
+async def run_sweeper(
+    client: valkey_asyncio.Valkey,
+    *,
+    stop: asyncio.Event,
+) -> None:
+    """Poll for abandoned read sessions until ``stop`` is set.
+
+    A session ends when the reader closes the tab, which normally
+    arrives as a ``sendBeacon`` flush marked final. That beacon is
+    best-effort -- a killed tab, a lost network, a crashed browser --
+    so anything still open past the idle timeout is finalized here
+    instead. Without this, an abandoned session would never contribute
+    to a document's numbers.
+
+    The loop waits before its first sweep rather than after: nothing can
+    have gone stale in the instant the process booted, and starting with
+    I/O would put a ClickHouse round-trip -- and any ClickHouse outage --
+    directly in the startup path.
+    """
+    while not stop.is_set():
+        try:
+            await asyncio.wait_for(stop.wait(), timeout=SWEEP_INTERVAL_SECONDS)
+        except TimeoutError:
+            pass
+        else:
+            return
+        try:
+            await sweep_once(client)
+        except Exception:  # noqa: BLE001
+            LOGGER.warning('Read-session sweep failed', exc_info=True)

--- a/apps/api/src/imbi/api/endpoints/_document_events.py
+++ b/apps/api/src/imbi/api/endpoints/_document_events.py
@@ -1,0 +1,57 @@
+"""Activity-feed events for document engagement (ClickHouse write side).
+
+Writes ``imbi.events`` rows so document engagement surfaces in the
+project and user activity feeds alongside comments. Best-effort in the
+same sense as the version-history recorder: the request it belongs to
+has already succeeded, so a failed analytics write is logged rather
+than surfaced.
+"""
+
+import datetime
+import logging
+
+from imbi.common import clickhouse, models
+
+LOGGER = logging.getLogger(__name__)
+
+#: Event type for a like or unlike on a document.
+LIKE_EVENT_TYPE = 'document-like'
+
+
+async def emit_like_event(
+    *,
+    org_slug: str,
+    project_id: str,
+    document_id: str,
+    principal: str,
+    action: str,
+    occurred_at: datetime.datetime,
+) -> None:
+    """Record a like/unlike as an ``events`` row. Best-effort.
+
+    ``project_id`` is empty for documents attached to a project type or
+    a user; those events still land and are readable from the user
+    activity feed, which keys on ``attributed_to`` rather than project.
+    """
+    try:
+        await clickhouse.insert(
+            'events',
+            [
+                models.Event(
+                    project_id=project_id,
+                    recorded_at=occurred_at,
+                    type=LIKE_EVENT_TYPE,
+                    integration='internal',
+                    attributed_to=principal,
+                    payload={
+                        'org_slug': org_slug,
+                        'document_id': document_id,
+                        'action': action,
+                    },
+                )
+            ],
+        )
+    except Exception:
+        LOGGER.exception(
+            'Failed to emit %s event for document %s', action, document_id
+        )

--- a/apps/api/src/imbi/api/endpoints/_document_reads.py
+++ b/apps/api/src/imbi/api/endpoints/_document_reads.py
@@ -1,0 +1,407 @@
+"""Read-tracking ingest and session finalization (ClickHouse write side).
+
+Owns the engagement policy: what a heartbeat is allowed to claim
+(:func:`clamp_engaged_ms`), what counts as a view versus a read
+(:func:`classify`), and how an open session becomes a finalized one
+(:func:`finalize_sessions`). The read-side endpoints live in
+``document_analytics.py``.
+
+Engaged time is measured entirely on the client -- only it can know
+whether the tab was visible, focused, and being interacted with. The
+server's job is to bound what a client can claim: every heartbeat
+delta is clamped to slightly more than one heartbeat interval, so a
+clock jump, a suspended debugger, or a hand-rolled client cannot
+inflate a document's numbers. A clamped delta is stored clamped *and*
+flagged, so the distortion is visible rather than silent.
+
+Ingest is best-effort in the same sense as the version-history
+recorder: the reader already got their document, so a failed
+ClickHouse write is logged rather than surfaced.
+"""
+
+import datetime
+import logging
+import typing
+
+import pydantic
+from valkey import asyncio as valkey_asyncio
+
+from imbi.api.endpoints import _document_scope
+from imbi.common import clickhouse, graph
+
+LOGGER = logging.getLogger(__name__)
+
+Surface = typing.Literal['web', 'mcp', 'assistant', 'slackbot', 'api']
+
+#: How often the client sends a heartbeat while a reader is engaged.
+HEARTBEAT_INTERVAL_SECONDS = 15
+#: Ceiling on a single heartbeat's claimed engaged time. The 1.5x cushion
+#: absorbs a late beat (a busy main thread, a slow network) without
+#: letting a beat claim time it could not have accumulated.
+MAX_ENGAGED_DELTA_MS = int(HEARTBEAT_INTERVAL_SECONDS * 1500)
+#: Engaged time below which a session is not a view at all. Filters
+#: index-page prefetches, mis-clicks, and immediate back-navigations.
+VIEW_FLOOR_MS = 5_000
+#: Scroll depth at which a long document counts as read.
+READ_SCROLL_PCT = 80
+#: Reading speed used to derive a document's estimated read time.
+WORDS_PER_MINUTE = 220
+#: A session with no heartbeat for this long is finalized by the reaper.
+SESSION_IDLE_TIMEOUT_SECONDS = 300
+#: Lifetime of a cached document read-meta entry.
+META_CACHE_TTL_SECONDS = 300
+
+_META_KEY_PREFIX = 'imbi:document:readmeta'
+
+
+class DocumentReadMeta(pydantic.BaseModel):
+    """Facts about a document needed to record and classify a read.
+
+    Also carries ``created_by`` so the analytics endpoints can exclude
+    the author's own views without a second traversal of the same
+    org-scoping join -- resolving the document already answers it.
+    """
+
+    project_id: str = ''
+    document_version: int = 0
+    estimated_read_ms: int = 0
+    created_by: str = ''
+
+
+class DocumentReadEventRow(pydantic.BaseModel):
+    """One row in the ``document_read_events`` ClickHouse table."""
+
+    org_slug: str
+    document_id: str
+    session_id: str
+    seq: int
+    principal: str
+    surface: str
+    project_id: str
+    document_version: int
+    estimated_read_ms: int
+    session_started_at: datetime.datetime
+    recorded_at: datetime.datetime
+    engaged_ms: int
+    max_scroll_pct: int
+    clamped: int
+    is_final: int
+
+
+class DocumentReadSessionRow(pydantic.BaseModel):
+    """One row in the ``document_read_sessions`` ClickHouse table."""
+
+    org_slug: str
+    document_id: str
+    session_id: str
+    principal: str
+    surface: str
+    project_id: str
+    document_version: int
+    started_at: datetime.datetime
+    ended_at: datetime.datetime
+    engaged_ms: int
+    max_scroll_pct: int
+    is_view: int
+    is_read: int
+    finalized_at: datetime.datetime
+
+
+def estimated_read_ms(content: str) -> int:
+    """Milliseconds an average reader needs for ``content``.
+
+    Whitespace-delimited word count over :data:`WORDS_PER_MINUTE`. Used
+    as the dwell threshold that marks a *short* document as read -- long
+    documents reach the read threshold by scroll depth first.
+    """
+    words = len(content.split())
+    if not words:
+        return 0
+    return int(words / WORDS_PER_MINUTE * 60_000)
+
+
+def clamp_engaged_ms(value: int) -> tuple[int, bool]:
+    """Bound a heartbeat's claimed engaged time.
+
+    Returns the value to store and whether it was clamped. Negative
+    values clamp to zero: a client that reports one has a broken clock,
+    and subtracting time is never a legitimate correction.
+    """
+    if value < 0:
+        return 0, True
+    if value > MAX_ENGAGED_DELTA_MS:
+        return MAX_ENGAGED_DELTA_MS, True
+    return value, False
+
+
+def classify(
+    *, surface: str, engaged_ms: int, max_scroll_pct: int, read_ms: int
+) -> tuple[bool, bool]:
+    """Decide whether a finalized session is a view and/or a read.
+
+    A view needs :data:`VIEW_FLOOR_MS` of engaged time. A read needs a
+    view that also reached :data:`READ_SCROLL_PCT` scroll depth *or*
+    dwelled for the document's estimated read time -- long documents
+    qualify by scrolling, short ones by dwelling.
+
+    Non-web surfaces (MCP, Assistant, Slackbot, API) have no attention
+    to measure, so they record as a view -- the document was fetched --
+    and never as a read. Reporting filters to ``web`` by default, so
+    these never mix into human numbers.
+    """
+    if surface != 'web':
+        return True, False
+    if engaged_ms < VIEW_FLOOR_MS:
+        return False, False
+    is_read = max_scroll_pct >= READ_SCROLL_PCT or (
+        read_ms > 0 and engaged_ms >= read_ms
+    )
+    return True, is_read
+
+
+def _meta_key(org_slug: str, document_id: str) -> str:
+    return f'{_META_KEY_PREFIX}:{org_slug}:{document_id}'
+
+
+# Resolves the document within the org through whichever vertex it is
+# attached to, and returns everything needed to stamp and classify a
+# read. ``content`` is only used to derive the estimated read time; it is
+# never stored on a read event.
+_META_QUERY: typing.LiteralString = (
+    _document_scope.BY_ID
+    + '    RETURN p.id AS project_id, d.version AS version,'
+    + ' d.content AS content, d.created_by AS created_by'
+)
+
+
+async def load_document_meta(
+    db: graph.Pool,
+    client: valkey_asyncio.Valkey | None,
+    org_slug: str,
+    document_id: str,
+) -> DocumentReadMeta | None:
+    """Read-meta for a document, cached in Valkey.
+
+    Returns ``None`` when the document does not resolve within the org,
+    which is how the ingest endpoint rejects a read event for a document
+    the caller cannot see.
+
+    The cache exists because heartbeats arrive every few seconds per
+    open reader; a graph round-trip per beat would be wasted load for
+    facts that change only when the document is edited. A stale entry
+    costs at most :data:`META_CACHE_TTL_SECONDS` of reads classified
+    against the previous revision's length.
+    """
+    key = _meta_key(org_slug, document_id)
+    if client is not None:
+        try:
+            cached = await client.get(key)
+        except Exception:  # noqa: BLE001
+            LOGGER.debug('read-meta cache read failed', exc_info=True)
+            cached = None
+        if cached is not None:
+            try:
+                raw = cached.decode() if isinstance(cached, bytes) else cached
+                return DocumentReadMeta.model_validate_json(raw)
+            except (ValueError, pydantic.ValidationError):
+                LOGGER.debug('discarding malformed read-meta cache entry')
+
+    records = await db.execute(
+        _META_QUERY,
+        {'document_id': document_id, 'org_slug': org_slug},
+        columns=['project_id', 'version', 'content', 'created_by'],
+    )
+    if not records:
+        return None
+    project_id = graph.parse_agtype(records[0]['project_id'])
+    version = graph.parse_agtype(records[0]['version'])
+    content = graph.parse_agtype(records[0]['content'])
+    created_by = graph.parse_agtype(records[0]['created_by'])
+    meta = DocumentReadMeta(
+        project_id=str(project_id) if project_id else '',
+        document_version=int(version or 1),
+        estimated_read_ms=estimated_read_ms(str(content or '')),
+        created_by=str(created_by) if created_by else '',
+    )
+    if client is not None:
+        try:
+            await client.set(
+                key, meta.model_dump_json(), ex=META_CACHE_TTL_SECONDS
+            )
+        except Exception:  # noqa: BLE001
+            LOGGER.debug('read-meta cache write failed', exc_info=True)
+    return meta
+
+
+async def record_events(rows: list[DocumentReadEventRow]) -> None:
+    """Insert heartbeat rows. Best-effort; never raises."""
+    if not rows:
+        return
+    try:
+        await clickhouse.insert(
+            'document_read_events',
+            typing.cast('list[pydantic.BaseModel]', rows),
+        )
+    except Exception:
+        LOGGER.exception(
+            'failed to record %d read event(s) for document %s',
+            len(rows),
+            rows[0].document_id,
+        )
+
+
+# Aggregates a session's heartbeats into the facts a finalized row needs.
+#
+# The inner GROUP BY collapses duplicate deliveries of the same
+# ``(session_id, seq)`` before anything is summed. The raw table is a
+# ReplacingMergeTree, so a retried heartbeat and its twin can both be
+# live until a background merge runs -- summing them directly would
+# double-count that beat's engaged time. Deduping explicitly makes the
+# result independent of merge state, which ``FINAL`` would not do
+# cheaply here: ``session_id`` is the third key column, so filtering on
+# it alone cannot use the primary key.
+_SESSION_AGGREGATE_SQL = """
+SELECT org_slug,
+       document_id,
+       session_id,
+       any(principal)          AS principal,
+       any(surface)            AS surface,
+       any(project_id)         AS project_id,
+       max(document_version)   AS document_version,
+       max(estimated_read_ms)  AS estimated_read_ms,
+       min(session_started_at) AS started_at,
+       max(recorded_at)        AS ended_at,
+       sum(engaged_ms)         AS engaged_ms,
+       max(max_scroll_pct)     AS max_scroll_pct
+FROM (
+    SELECT org_slug,
+           document_id,
+           session_id,
+           seq,
+           argMax(principal, recorded_at)          AS principal,
+           argMax(surface, recorded_at)            AS surface,
+           argMax(project_id, recorded_at)         AS project_id,
+           argMax(document_version, recorded_at)   AS document_version,
+           argMax(estimated_read_ms, recorded_at)  AS estimated_read_ms,
+           min(session_started_at)                 AS session_started_at,
+           max(recorded_at)                        AS recorded_at,
+           argMax(engaged_ms, recorded_at)         AS engaged_ms,
+           argMax(max_scroll_pct, recorded_at)     AS max_scroll_pct
+    FROM imbi.document_read_events
+    WHERE session_id IN {session_ids:Array(String)}
+    GROUP BY org_slug, document_id, session_id, seq
+)
+GROUP BY org_slug, document_id, session_id
+"""
+
+
+async def finalize_sessions(session_ids: list[str]) -> int:
+    """Write a finalized row for each of ``session_ids``.
+
+    Returns the number of sessions written. Idempotent: the sessions
+    table dedups on ``session_id``, so the client's own final flush and
+    a reaper sweep racing each other converge on one row rather than
+    double-counting the session. Best-effort; never raises.
+    """
+    if not session_ids:
+        return 0
+    try:
+        aggregates = await clickhouse.query(
+            _SESSION_AGGREGATE_SQL, {'session_ids': session_ids}
+        )
+    except Exception:
+        LOGGER.exception('failed to aggregate %d session(s)', len(session_ids))
+        return 0
+
+    now = datetime.datetime.now(datetime.UTC)
+    rows: list[pydantic.BaseModel] = []
+    for row in aggregates:
+        surface = str(row.get('surface') or 'web')
+        engaged = int(row.get('engaged_ms') or 0)
+        scroll = int(row.get('max_scroll_pct') or 0)
+        read_ms = int(row.get('estimated_read_ms') or 0)
+        is_view, is_read = classify(
+            surface=surface,
+            engaged_ms=engaged,
+            max_scroll_pct=scroll,
+            read_ms=read_ms,
+        )
+        rows.append(
+            DocumentReadSessionRow(
+                org_slug=str(row.get('org_slug') or ''),
+                document_id=str(row.get('document_id') or ''),
+                session_id=str(row.get('session_id') or ''),
+                principal=str(row.get('principal') or ''),
+                surface=surface,
+                project_id=str(row.get('project_id') or ''),
+                document_version=int(row.get('document_version') or 0),
+                started_at=clickhouse.as_utc(row['started_at']),
+                ended_at=clickhouse.as_utc(row['ended_at']),
+                engaged_ms=engaged,
+                max_scroll_pct=scroll,
+                is_view=int(is_view),
+                is_read=int(is_read),
+                finalized_at=now,
+            )
+        )
+    if not rows:
+        return 0
+    try:
+        await clickhouse.insert('document_read_sessions', rows)
+    except Exception:
+        LOGGER.exception('failed to finalize %d session(s)', len(rows))
+        return 0
+    return len(rows)
+
+
+#: How far back the reaper looks for sessions still open. The sweep runs
+#: every minute, so anything unfinalized is normally minutes old; a day
+#: is generous cover for an instance that was down. A session older than
+#: this is left to the raw table's own TTL, which is the same outcome as
+#: never having been finalized.
+SWEEP_LOOKBACK_HOURS = 24
+
+# Sessions whose last heartbeat has aged past the idle timeout and that
+# have no finalized row yet.
+#
+# Both sides are pinned to the same recent window so neither scans more
+# than the other needs: without the `recorded_at` bound the outer scan
+# reads whole partitions, since `session_started_at` is not part of the
+# table's `ORDER BY` and only prunes by partition. The anti-join is a
+# LEFT JOIN rather than `NOT IN` so the right side stays a bounded
+# hash-side rather than a materialized id set.
+_STALE_SESSION_SQL = """
+SELECT e.session_id AS session_id
+FROM (
+    SELECT session_id, max(recorded_at) AS last_beat
+    FROM imbi.document_read_events
+    WHERE session_started_at > now() - INTERVAL {lookback_hours:UInt32} HOUR
+      AND recorded_at > now() - INTERVAL {lookback_hours:UInt32} HOUR
+    GROUP BY session_id
+    HAVING last_beat < now() - INTERVAL {idle_seconds:UInt32} SECOND
+) AS e
+LEFT JOIN (
+    SELECT DISTINCT session_id
+    FROM imbi.document_read_sessions
+    WHERE started_at > now() - INTERVAL {lookback_hours:UInt32} HOUR
+) AS s USING (session_id)
+WHERE s.session_id = ''
+LIMIT {batch:UInt32}
+"""
+
+
+async def stale_session_ids(batch: int = 500) -> list[str]:
+    """Sessions with no heartbeat since the idle timeout and no final row."""
+    try:
+        rows = await clickhouse.query(
+            _STALE_SESSION_SQL,
+            {
+                'idle_seconds': SESSION_IDLE_TIMEOUT_SECONDS,
+                'lookback_hours': SWEEP_LOOKBACK_HOURS,
+                'batch': batch,
+            },
+        )
+    except Exception:
+        LOGGER.exception('failed to list stale read sessions')
+        return []
+    return [str(row['session_id']) for row in rows if row.get('session_id')]

--- a/apps/api/src/imbi/api/endpoints/_document_scope.py
+++ b/apps/api/src/imbi/api/endpoints/_document_scope.py
@@ -1,0 +1,49 @@
+"""The org-scoping join shared by every document query.
+
+A document hangs off exactly one vertex -- a ``Project``, a
+``ProjectType``, or a ``User`` -- and belongs to an organization only
+through that vertex. Resolving it is therefore the authorization
+boundary for documents: a query that scopes the join loosely returns
+another organization's document.
+
+That made it worth having in one place. Callers concatenate a fragment
+with their own ``RETURN``/``WITH`` tail:
+
+    query = _document_scope.BY_ID + 'RETURN d.created_by AS created_by'
+
+Both fragments leave ``d`` (the document) and ``p``/``pt``/``u`` (the
+attachment candidates, at most one non-null) in scope, and require an
+``org_slug`` parameter -- plus ``document_id`` for :data:`BY_ID`.
+"""
+
+import typing
+
+# The three attachment kinds and the guard that at least one resolved
+# within the org. Everything above it differs only in how the document
+# itself is matched.
+_ATTACHMENT_TAIL: typing.LiteralString = """
+    OPTIONAL MATCH (d)-[:ATTACHED_TO]->(p:Project)
+          -[:OWNED_BY]->(:Team)
+          -[:BELONGS_TO]->(:Organization {{slug: {org_slug}}})
+    OPTIONAL MATCH (d)-[:ATTACHED_TO]->(pt:ProjectType)
+          -[:BELONGS_TO]->(:Organization {{slug: {org_slug}}})
+    OPTIONAL MATCH (d)-[:ATTACHED_TO]->(u:User)
+          -[:MEMBER_OF]->(:Organization {{slug: {org_slug}}})
+    WITH d, p, pt, u
+    WHERE (p IS NOT NULL OR pt IS NOT NULL OR u IS NOT NULL)
+"""
+
+#: One document by id, scoped to the org. Needs ``document_id``.
+BY_ID: typing.LiteralString = (
+    '\n    MATCH (d:Document {{id: {document_id}}})' + _ATTACHMENT_TAIL
+)
+
+#: Every document in the org.
+ALL_IN_ORG: typing.LiteralString = (
+    '\n    MATCH (d:Document)' + _ATTACHMENT_TAIL
+)
+
+#: Appended when only the document itself is needed downstream. The
+#: attachment candidates have served their purpose as a guard, and
+#: dropping them collapses the row-per-candidate fan-out.
+DISTINCT_DOCUMENT: typing.LiteralString = '    WITH DISTINCT d\n'

--- a/apps/api/src/imbi/api/endpoints/document_analytics.py
+++ b/apps/api/src/imbi/api/endpoints/document_analytics.py
@@ -1,0 +1,721 @@
+"""Read-analytics ingest and reporting for documents.
+
+Three surfaces:
+
+- ``POST .../read-events`` -- the heartbeat sink. Fire-and-forget: it
+  always answers 202 and a ClickHouse failure is logged, never
+  surfaced. A reader already has their document; a failed analytics
+  write must not look like a failed read.
+- ``GET .../analytics`` (+ ``/readers``) -- one document's numbers.
+- ``GET /document-analytics`` -- the org-wide report, whose main job
+  is surfacing stale and never-read documents.
+
+Every query filters to ``surface = 'web'`` unless asked otherwise:
+human readership is the default answer, and agent fetches (MCP,
+Assistant, Slackbot, API) would otherwise inflate it.
+
+The write policy -- clamping, classification, finalization -- lives in
+:mod:`_document_reads`; this module is the HTTP surface over it.
+"""
+
+import asyncio
+import datetime
+import logging
+import typing
+
+import fastapi
+import fastapi.responses
+import pydantic
+
+from imbi.api.auth import permissions
+from imbi.api.endpoints import _document_reads, _document_scope
+from imbi.api.endpoints._pagination import (
+    build_link_header,
+    decode_cursor,
+    encode_cursor,
+)
+from imbi.common import clickhouse, graph, valkey
+
+LOGGER = logging.getLogger(__name__)
+
+document_analytics_router = fastapi.APIRouter(tags=['Documents'])
+document_analytics_org_router = fastapi.APIRouter(tags=['Documents'])
+
+DEFAULT_LIMIT: int = 50
+MAX_LIMIT: int = 500
+#: Cap on heartbeats accepted in one request. A `sendBeacon` flush
+#: carries at most a couple; anything larger is a client bug or an
+#: attempt to bulk-write history.
+MAX_EVENTS_PER_REQUEST: int = 20
+DEFAULT_TREND_DAYS: int = 30
+
+IDENTITY_PERMISSION = 'document:analytics:read_identities'
+
+
+class ReadEvent(pydantic.BaseModel):
+    """One heartbeat from a reading client."""
+
+    session_id: str = pydantic.Field(min_length=1, max_length=64)
+    seq: int = pydantic.Field(ge=0, le=1_000_000)
+    session_started_at: datetime.datetime
+    engaged_ms: int
+    max_scroll_pct: int = pydantic.Field(default=0, ge=0, le=100)
+    is_final: bool = False
+    surface: _document_reads.Surface = 'web'
+
+
+class ReadEventBatch(pydantic.BaseModel):
+    events: list[ReadEvent] = pydantic.Field(min_length=1)
+
+
+class SurfaceCount(pydantic.BaseModel):
+    surface: str
+    views: int
+
+
+class TrendPoint(pydantic.BaseModel):
+    day: datetime.date
+    views: int
+    readers: int
+
+
+class DocumentAnalyticsResponse(pydantic.BaseModel):
+    last_read_at: datetime.datetime | None = None
+    readers: int = 0
+    views: int = 0
+    reads: int = 0
+    median_engaged_seconds: int = 0
+    p90_engaged_seconds: int = 0
+    completion_rate: float = 0.0
+    estimated_read_seconds: int = 0
+    by_surface: list[SurfaceCount] = []
+    trend: list[TrendPoint] = []
+    identities_visible: bool = False
+
+
+class ReaderRef(pydantic.BaseModel):
+    principal: str
+    last_read_at: datetime.datetime | None = None
+    views: int = 0
+    reads: int = 0
+    engaged_seconds: int = 0
+
+
+class ReaderListResponse(pydantic.BaseModel):
+    data: list[ReaderRef]
+
+
+class DocumentReadSummary(pydantic.BaseModel):
+    document_id: str
+    title: str = ''
+    last_read_at: datetime.datetime | None = None
+    readers: int = 0
+    views: int = 0
+
+
+class OrgAnalyticsResponse(pydantic.BaseModel):
+    data: list[DocumentReadSummary]
+
+
+# Collapses duplicate rows for one session before anything is counted.
+# ``document_read_sessions`` is a ReplacingMergeTree, so the client's own
+# final flush and a reaper sweep that raced it can both be live until a
+# background merge runs. Counting them directly would double the session.
+# Deduping explicitly makes every number independent of merge state.
+_DEDUPED_SESSIONS = """
+    SELECT session_id,
+           argMax(principal, finalized_at)        AS principal,
+           argMax(surface, finalized_at)          AS surface,
+           argMax(document_id, finalized_at)      AS document_id,
+           argMax(engaged_ms, finalized_at)       AS engaged_ms,
+           argMax(is_view, finalized_at)          AS is_view,
+           argMax(is_read, finalized_at)          AS is_read,
+           argMax(started_at, finalized_at)       AS started_at,
+           argMax(ended_at, finalized_at)         AS ended_at
+    FROM imbi.document_read_sessions
+    WHERE {filters}
+    GROUP BY session_id
+"""
+
+
+def _session_source(filters: str) -> str:
+    return _DEDUPED_SESSIONS.format(filters=filters)
+
+
+def _surface_filter(surface: str) -> str:
+    """SQL fragment restricting to one surface, or all of them."""
+    return '' if surface == 'all' else ' AND surface = {surface:String}'
+
+
+def _self_filter(include_self: bool) -> str:
+    """Exclude the document's own author unless asked to include them.
+
+    Editing a document should not inflate its readership.
+    """
+    return '' if include_self else ' AND principal != {author:String}'
+
+
+async def _identities_setting(db: graph.Pool, org_slug: str) -> str:
+    """The org's ``document_analytics_identities`` setting."""
+    query: typing.LiteralString = (
+        'MATCH (o:Organization {{slug: {org_slug}}}) '
+        'RETURN o.document_analytics_identities AS setting'
+    )
+    records = await db.execute(
+        query, {'org_slug': org_slug}, columns=['setting']
+    )
+    if not records:
+        return 'authors_only'
+    setting = graph.parse_agtype(records[0]['setting'])
+    return str(setting) if setting else 'authors_only'
+
+
+def _may_see_identities(
+    auth: permissions.AuthContext, setting: str, author: str | None
+) -> bool:
+    """Whether ``auth`` may see *which people* read this document.
+
+    A principal always sees their own history, which is handled by the
+    caller; this governs seeing everyone else's.
+    """
+    if setting == 'disabled':
+        return False
+    holds_permission = IDENTITY_PERMISSION in auth.permissions or auth.is_admin
+    if setting == 'enabled':
+        return holds_permission
+    # authors_only: the document's author sees its readers regardless of
+    # role -- learning who reads your own work is not surveillance.
+    return holds_permission or (
+        author is not None and auth.principal_name == author
+    )
+
+
+@document_analytics_router.post('/read-events', status_code=202)
+async def record_read_events(
+    org_slug: str,
+    document_id: str,
+    batch: ReadEventBatch,
+    db: graph.Pool,
+    client: valkey.Client,
+    auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(permissions.require_permission('document:read')),
+    ],
+    background_tasks: fastapi.BackgroundTasks,
+) -> fastapi.Response:
+    """Accept a batch of read heartbeats.
+
+    Always 202, even when the write fails: the reader has already got
+    what they came for and an analytics error is not their problem.
+    Returns 404 only when the document does not resolve within the org,
+    which is an authorization answer rather than an ingest one.
+    """
+    if len(batch.events) > MAX_EVENTS_PER_REQUEST:
+        raise fastapi.HTTPException(
+            status_code=400,
+            detail=f'At most {MAX_EVENTS_PER_REQUEST} events per request',
+        )
+
+    meta = await _document_reads.load_document_meta(
+        db, client, org_slug, document_id
+    )
+    if meta is None:
+        raise fastapi.HTTPException(
+            status_code=404, detail=f'Document {document_id!r} not found'
+        )
+
+    now = datetime.datetime.now(datetime.UTC)
+    rows: list[_document_reads.DocumentReadEventRow] = []
+    finalize: list[str] = []
+    for event in batch.events:
+        engaged, clamped = _document_reads.clamp_engaged_ms(event.engaged_ms)
+        rows.append(
+            _document_reads.DocumentReadEventRow(
+                org_slug=org_slug,
+                document_id=document_id,
+                session_id=event.session_id,
+                seq=event.seq,
+                principal=auth.principal_name,
+                surface=event.surface,
+                project_id=meta.project_id,
+                document_version=meta.document_version,
+                estimated_read_ms=meta.estimated_read_ms,
+                session_started_at=event.session_started_at,
+                recorded_at=now,
+                engaged_ms=engaged,
+                max_scroll_pct=event.max_scroll_pct,
+                clamped=int(clamped),
+                is_final=int(event.is_final),
+            )
+        )
+        if event.is_final:
+            finalize.append(event.session_id)
+
+    # Both run after the response so ClickHouse latency never lands in
+    # the reader's request.
+    background_tasks.add_task(_document_reads.record_events, rows)
+    if finalize:
+        background_tasks.add_task(
+            _document_reads.finalize_sessions, sorted(set(finalize))
+        )
+    return fastapi.Response(status_code=202)
+
+
+_SUMMARY_SQL = """
+SELECT maxIf(ended_at, is_read)                  AS last_read_at,
+       uniqExactIf(principal, is_read)           AS readers,
+       countIf(is_view)                          AS views,
+       countIf(is_read)                          AS reads,
+       quantileIf(0.5)(engaged_ms, is_view)      AS median_engaged_ms,
+       quantileIf(0.9)(engaged_ms, is_view)      AS p90_engaged_ms
+FROM ({source})
+"""
+
+_SURFACE_SQL = """
+SELECT surface, countIf(is_view) AS views
+FROM ({source})
+GROUP BY surface
+ORDER BY views DESC
+"""
+
+_TREND_SQL = """
+SELECT toDate(started_at)              AS day,
+       countIf(is_view)                AS views,
+       uniqExactIf(principal, is_read) AS readers
+FROM ({source})
+GROUP BY day
+ORDER BY day
+"""
+
+
+def _document_filters(surface: str, include_self: bool) -> str:
+    return (
+        'org_slug = {org_slug:String} AND document_id = {document_id:String}'
+        + _surface_filter(surface)
+        + _self_filter(include_self)
+    )
+
+
+@document_analytics_router.get(
+    '/analytics', response_model=DocumentAnalyticsResponse
+)
+async def get_document_analytics(
+    org_slug: str,
+    document_id: str,
+    db: graph.Pool,
+    client: valkey.Client,
+    auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(
+            permissions.require_permission('document:analytics:read')
+        ),
+    ],
+    surface: str = 'web',
+    include_self: bool = False,
+    trend_days: int = DEFAULT_TREND_DAYS,
+) -> DocumentAnalyticsResponse:
+    """Aggregate read analytics for one document."""
+    if trend_days < 1 or trend_days > 365:
+        raise fastapi.HTTPException(
+            status_code=400, detail='trend_days must be 1..365'
+        )
+    # Independent of each other and of the ClickHouse reads below, so
+    # they cost one round trip rather than two. The meta lookup doubles
+    # as the org-scoped existence check and carries the author.
+    meta, setting = await asyncio.gather(
+        _document_reads.load_document_meta(db, client, org_slug, document_id),
+        _identities_setting(db, org_slug),
+    )
+    if meta is None:
+        raise fastapi.HTTPException(
+            status_code=404, detail=f'Document {document_id!r} not found'
+        )
+    author = meta.created_by
+
+    params: dict[str, typing.Any] = {
+        'org_slug': org_slug,
+        'document_id': document_id,
+        'surface': surface,
+        'author': author,
+    }
+    source = _session_source(_document_filters(surface, include_self))
+    trend_source = _session_source(
+        _document_filters(surface, include_self)
+        + ' AND started_at > now() - INTERVAL {trend_days:UInt32} DAY'
+    )
+
+    try:
+        # Three independent scans of the same partition; running them
+        # concurrently costs the slowest rather than the sum.
+        summary_rows, surface_rows, trend_rows = await asyncio.gather(
+            clickhouse.query(_SUMMARY_SQL.format(source=source), params),
+            clickhouse.query(
+                _SURFACE_SQL.format(
+                    source=_session_source(
+                        _document_filters('all', include_self)
+                    )
+                ),
+                params,
+            ),
+            clickhouse.query(
+                _TREND_SQL.format(source=trend_source),
+                {**params, 'trend_days': trend_days},
+            ),
+        )
+    except Exception:
+        LOGGER.exception(
+            'failed to read analytics for document %s', document_id
+        )
+        raise fastapi.HTTPException(
+            status_code=503, detail='Analytics store unavailable'
+        ) from None
+
+    summary = summary_rows[0] if summary_rows else {}
+    views = int(summary.get('views') or 0)
+    reads = int(summary.get('reads') or 0)
+
+    return DocumentAnalyticsResponse(
+        last_read_at=clickhouse.as_utc_or_none(summary.get('last_read_at')),
+        readers=int(summary.get('readers') or 0),
+        views=views,
+        reads=reads,
+        median_engaged_seconds=int(
+            float(summary.get('median_engaged_ms') or 0) / 1000
+        ),
+        p90_engaged_seconds=int(
+            float(summary.get('p90_engaged_ms') or 0) / 1000
+        ),
+        completion_rate=(reads / views) if views else 0.0,
+        estimated_read_seconds=int(meta.estimated_read_ms / 1000),
+        by_surface=[
+            SurfaceCount(
+                surface=str(row.get('surface') or ''),
+                views=int(row.get('views') or 0),
+            )
+            for row in surface_rows
+        ],
+        trend=[
+            TrendPoint(
+                day=row['day'],
+                views=int(row.get('views') or 0),
+                readers=int(row.get('readers') or 0),
+            )
+            for row in trend_rows
+        ],
+        identities_visible=_may_see_identities(auth, setting, author),
+    )
+
+
+_READERS_SQL = """
+SELECT principal,
+       max(ended_at)      AS last_read_at,
+       countIf(is_view)   AS views,
+       countIf(is_read)   AS reads,
+       sum(engaged_ms)    AS engaged_ms
+FROM ({source})
+GROUP BY principal
+{having}
+ORDER BY last_read_at DESC, principal DESC
+LIMIT {{row_limit:UInt32}}
+"""
+
+
+@document_analytics_router.get(
+    '/analytics/readers', response_model=ReaderListResponse
+)
+async def list_document_readers(
+    request: fastapi.Request,
+    org_slug: str,
+    document_id: str,
+    db: graph.Pool,
+    client: valkey.Client,
+    auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(
+            permissions.require_permission('document:analytics:read')
+        ),
+    ],
+    surface: str = 'web',
+    include_self: bool = False,
+    limit: int = DEFAULT_LIMIT,
+    cursor: str | None = None,
+) -> fastapi.Response:
+    """Per-reader detail: who read it, when, how often, how long.
+
+    Gated by ``document:analytics:read_identities`` and the org's
+    ``document_analytics_identities`` setting -- a named list of who
+    read what is a different kind of data from an aggregate count.
+    """
+    if limit < 1 or limit > MAX_LIMIT:
+        raise fastapi.HTTPException(
+            status_code=400, detail=f'limit must be 1..{MAX_LIMIT}'
+        )
+    meta, setting = await asyncio.gather(
+        _document_reads.load_document_meta(db, client, org_slug, document_id),
+        _identities_setting(db, org_slug),
+    )
+    if meta is None:
+        raise fastapi.HTTPException(
+            status_code=404, detail=f'Document {document_id!r} not found'
+        )
+    author = meta.created_by
+    if not _may_see_identities(auth, setting, author):
+        raise fastapi.HTTPException(
+            status_code=403,
+            detail='Not permitted to see who read this document',
+        )
+
+    params: dict[str, typing.Any] = {
+        'org_slug': org_slug,
+        'document_id': document_id,
+        'surface': surface,
+        'author': author,
+        'row_limit': limit + 1,
+    }
+    having = ''
+    if cursor is not None:
+        decoded = decode_cursor(cursor)
+        if decoded is None:
+            raise fastapi.HTTPException(
+                status_code=400, detail='Invalid cursor'
+            )
+        cursor_ts, cursor_principal = decoded
+        having = (
+            'HAVING (last_read_at < {cursor_ts:DateTime64(3)}'
+            ' OR (last_read_at = {cursor_ts:DateTime64(3)}'
+            ' AND principal < {cursor_principal:String}))'
+        )
+        params['cursor_ts'] = cursor_ts
+        params['cursor_principal'] = cursor_principal
+
+    sql = _READERS_SQL.format(
+        source=_session_source(_document_filters(surface, include_self)),
+        having=having,
+    )
+    try:
+        rows = await clickhouse.query(sql, params)
+    except Exception:
+        LOGGER.exception('failed to list readers for document %s', document_id)
+        raise fastapi.HTTPException(
+            status_code=503, detail='Analytics store unavailable'
+        ) from None
+
+    readers = [
+        ReaderRef(
+            principal=str(row.get('principal') or ''),
+            last_read_at=clickhouse.as_utc_or_none(row.get('last_read_at')),
+            views=int(row.get('views') or 0),
+            reads=int(row.get('reads') or 0),
+            engaged_seconds=int(int(row.get('engaged_ms') or 0) / 1000),
+        )
+        for row in rows
+    ]
+    next_cursor: str | None = None
+    if len(readers) > limit:
+        readers = readers[:limit]
+        last = readers[-1]
+        if last.last_read_at is not None:
+            next_cursor = encode_cursor(last.last_read_at, last.principal)
+
+    adapter = pydantic.TypeAdapter(list[ReaderRef])
+    response = fastapi.responses.JSONResponse(
+        {'data': adapter.dump_python(readers, mode='json')}
+    )
+    response.headers['Link'] = build_link_header(request, next_cursor)
+    return response
+
+
+_ORG_SQL = """
+SELECT document_id,
+       max(ended_at)                   AS last_read_at,
+       uniqExactIf(principal, is_read) AS readers,
+       countIf(is_view)                AS views
+FROM ({source})
+GROUP BY document_id
+{having}
+ORDER BY {order}
+LIMIT {{row_limit:UInt32}}
+"""
+
+_ORG_ORDER = {
+    'most-read': 'readers DESC, views DESC',
+    'least-read': 'readers ASC, views ASC',
+    'stale': 'last_read_at ASC',
+}
+
+OrgMode = typing.Literal['most-read', 'least-read', 'stale', 'never-read']
+
+
+@document_analytics_org_router.get('', response_model=OrgAnalyticsResponse)
+async def get_org_document_analytics(
+    org_slug: str,
+    db: graph.Pool,
+    _auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(
+            permissions.require_permission('document:analytics:read')
+        ),
+    ],
+    mode: OrgMode = 'most-read',
+    surface: str = 'web',
+    stale_days: int = 90,
+    limit: int = DEFAULT_LIMIT,
+) -> OrgAnalyticsResponse:
+    """Org-wide read report.
+
+    ``never-read`` is answered from the graph rather than ClickHouse --
+    a document with no sessions has nothing to select -- by listing the
+    org's documents and subtracting the ones that have been read.
+    """
+    if limit < 1 or limit > MAX_LIMIT:
+        raise fastapi.HTTPException(
+            status_code=400, detail=f'limit must be 1..{MAX_LIMIT}'
+        )
+
+    if mode == 'never-read':
+        # The only mode that genuinely needs every document: what it
+        # reports is the ones ClickHouse has never heard of.
+        titles, read_ids = await asyncio.gather(
+            _org_document_titles(db, org_slug),
+            _read_document_ids(org_slug, surface),
+        )
+        never = [
+            DocumentReadSummary(document_id=doc_id, title=title)
+            for doc_id, title in titles.items()
+            if doc_id not in read_ids
+        ]
+        return OrgAnalyticsResponse(
+            data=sorted(never, key=lambda d: d.title)[:limit]
+        )
+
+    filters = 'org_slug = {org_slug:String}' + _surface_filter(surface)
+    having = ''
+    params: dict[str, typing.Any] = {
+        'org_slug': org_slug,
+        'surface': surface,
+        'row_limit': limit,
+    }
+    if mode == 'stale':
+        having = (
+            'HAVING last_read_at < now() - INTERVAL {stale_days:UInt32} DAY'
+        )
+        params['stale_days'] = stale_days
+
+    sql = _ORG_SQL.format(
+        source=_session_source(filters),
+        having=having,
+        order=_ORG_ORDER[mode],
+    )
+    try:
+        rows = await clickhouse.query(sql, params)
+    except Exception:
+        LOGGER.exception('failed to read org analytics for %s', org_slug)
+        raise fastapi.HTTPException(
+            status_code=503, detail='Analytics store unavailable'
+        ) from None
+
+    # Titles are fetched for the page ClickHouse returned, not for every
+    # document in the org -- these modes decorate at most ``limit`` rows.
+    titles = await _document_titles_by_id(
+        db, org_slug, [str(row.get('document_id') or '') for row in rows]
+    )
+    return OrgAnalyticsResponse(
+        data=[
+            DocumentReadSummary(
+                document_id=str(row.get('document_id') or ''),
+                title=titles.get(str(row.get('document_id') or ''), ''),
+                last_read_at=clickhouse.as_utc_or_none(
+                    row.get('last_read_at')
+                ),
+                readers=int(row.get('readers') or 0),
+                views=int(row.get('views') or 0),
+            )
+            for row in rows
+        ]
+    )
+
+
+async def _org_document_titles(
+    db: graph.Pool, org_slug: str
+) -> dict[str, str]:
+    """Every document in the org, as ``{id: title}``.
+
+    Titles are joined in application code rather than duplicated into
+    ClickHouse: the analytics tables key on ``document_id`` only, so a
+    renamed document never leaves a stale title behind in a report.
+    """
+    query: typing.LiteralString = (
+        _document_scope.ALL_IN_ORG
+        + '    RETURN DISTINCT d.id AS id, d.title AS title'
+    )
+    records = await db.execute(
+        query, {'org_slug': org_slug}, columns=['id', 'title']
+    )
+    return _parse_titles(records)
+
+
+async def _document_titles_by_id(
+    db: graph.Pool, org_slug: str, document_ids: list[str]
+) -> dict[str, str]:
+    """Titles for a known set of documents, as ``{id: title}``.
+
+    Bounded companion to :func:`_org_document_titles` for the modes that
+    only need to decorate the page ClickHouse already narrowed down.
+    """
+    ids = [doc_id for doc_id in dict.fromkeys(document_ids) if doc_id]
+    if not ids:
+        return {}
+    query: typing.LiteralString = (
+        # ``ALL_IN_ORG`` ends mid-WHERE, so this continues that clause
+        # rather than opening a second one.
+        _document_scope.ALL_IN_ORG
+        + '      AND d.id IN {document_ids}\n'
+        + '    RETURN DISTINCT d.id AS id, d.title AS title'
+    )
+    records = await db.execute(
+        query,
+        {'org_slug': org_slug, 'document_ids': ids},
+        columns=['id', 'title'],
+    )
+    return _parse_titles(records)
+
+
+def _parse_titles(
+    records: list[dict[str, typing.Any]],
+) -> dict[str, str]:
+    titles: dict[str, str] = {}
+    for record in records:
+        doc_id = graph.parse_agtype(record['id'])
+        if not doc_id:
+            continue
+        title = graph.parse_agtype(record['title'])
+        titles[str(doc_id)] = str(title) if title else ''
+    return titles
+
+
+_READ_DOCUMENT_IDS_SQL = """
+SELECT DISTINCT document_id
+FROM imbi.document_read_sessions
+WHERE org_slug = {{org_slug:String}} AND is_view = 1
+{surface_filter}
+"""
+
+
+async def _read_document_ids(org_slug: str, surface: str) -> set[str]:
+    """Ids of documents with at least one view, for ``never-read``."""
+    # The only interpolated value is a module literal from
+    # ``_surface_filter``; ``org_slug`` and ``surface`` reach ClickHouse
+    # as bound parameters, never as interpolated text.
+    sql = _READ_DOCUMENT_IDS_SQL.format(
+        surface_filter=_surface_filter(surface)
+    )
+    try:
+        rows = await clickhouse.query(
+            sql, {'org_slug': org_slug, 'surface': surface}
+        )
+    except Exception:
+        LOGGER.exception('failed to list read documents for %s', org_slug)
+        raise fastapi.HTTPException(
+            status_code=503, detail='Analytics store unavailable'
+        ) from None
+    return {str(row['document_id']) for row in rows if row.get('document_id')}

--- a/apps/api/src/imbi/api/endpoints/document_likes.py
+++ b/apps/api/src/imbi/api/endpoints/document_likes.py
@@ -1,0 +1,297 @@
+"""Thumbs-up likes on documents.
+
+A like is one person's thumbs-up on one document, held as a
+``(:User)-[:LIKED {at}]->(:Document)`` edge. Unlike comment
+acknowledgements -- which live in an ``acknowledged_by`` array property
+on the ``Comment`` vertex -- likes are edges for three reasons:
+
+- Toggling an array property is read-modify-write, so two people liking
+  at the same moment can lose one of the likes. A ``MERGE``/``DELETE``
+  of an edge is atomic per person.
+- The edge carries ``at``, so "who liked this, most recent first" is
+  answerable. An array has no ordering and no timestamps.
+- A popular document's liker list can grow past what belongs in a
+  vertex property that every document read has to load.
+
+Liking requires only ``document:read``: if you can read a document you
+can like it, and the liker list is visible to anyone who can read the
+document. A like is a public act, which is why it does not sit behind
+the ``document:analytics:read_identities`` gate that per-reader
+analytics does.
+
+Liking is not reading. Likes never feed the read-analytics counters
+(``readers``/``views``/``reads``) and a like never implies a read
+event; the two are reported side by side.
+"""
+
+import datetime
+import logging
+import typing
+
+import fastapi
+import fastapi.responses
+import pydantic
+
+from imbi.api.auth import permissions
+from imbi.api.endpoints import _document_events, _document_scope
+from imbi.api.endpoints._pagination import (
+    build_link_header,
+    decode_cursor,
+    encode_cursor,
+)
+from imbi.common import graph
+
+LOGGER = logging.getLogger(__name__)
+
+document_likes_router = fastapi.APIRouter(tags=['Documents'])
+
+DEFAULT_LIMIT: int = 50
+MAX_LIMIT: int = 500
+
+
+class LikeStateResponse(pydantic.BaseModel):
+    """The document's like count and whether the caller is one of them."""
+
+    like_count: int = 0
+    liked_by_me: bool = False
+
+
+class LikerRef(pydantic.BaseModel):
+    principal: str
+    display_name: str | None = None
+    liked_at: datetime.datetime
+
+
+class LikerListResponse(pydantic.BaseModel):
+    data: list[LikerRef]
+
+
+# Emitted by every route so the response always carries current state.
+# ``DISTINCT`` guards the count against a duplicate edge: ``MERGE`` makes
+# one impossible today, but a count that silently doubles would be a
+# nasty way to discover otherwise. Aggregates run stepwise so each
+# OPTIONAL MATCH cannot multiply the rows of the next. ``project_id``
+# rides along for the activity-feed event and is null for documents
+# attached to a project type or a user.
+_LIKE_STATE_TAIL: typing.LiteralString = """
+    OPTIONAL MATCH (liker:User)-[:LIKED]->(d)
+    WITH d, count(DISTINCT liker) AS like_count
+    OPTIONAL MATCH (me:User {{email: {principal}}})-[:LIKED]->(d)
+    WITH d, like_count, count(me) > 0 AS liked_by_me
+    OPTIONAL MATCH (d)-[:ATTACHED_TO]->(proj:Project)
+    RETURN like_count, liked_by_me, proj.id AS project_id
+"""
+
+_LIKE_STATE_COLUMNS: list[str] = ['like_count', 'liked_by_me', 'project_id']
+
+
+def _parse_like_state(
+    record: dict[str, typing.Any],
+) -> tuple[LikeStateResponse, str]:
+    """Split a ``_LIKE_STATE_TAIL`` row into response state + project id."""
+    project_id = graph.parse_agtype(record['project_id'])
+    return (
+        LikeStateResponse(
+            like_count=int(graph.parse_agtype(record['like_count']) or 0),
+            liked_by_me=bool(graph.parse_agtype(record['liked_by_me'])),
+        ),
+        str(project_id) if project_id else '',
+    )
+
+
+@document_likes_router.put('/like', response_model=LikeStateResponse)
+async def like_document(
+    org_slug: str,
+    document_id: str,
+    db: graph.Pool,
+    auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(permissions.require_permission('document:read')),
+    ],
+    background_tasks: fastapi.BackgroundTasks,
+) -> LikeStateResponse:
+    """Like the document as the calling principal.
+
+    Idempotent: liking a document twice leaves one like, and the second
+    call does not disturb the original ``at`` timestamp, so a
+    double-tapped button cannot reorder the liker list.
+    """
+    # AGE implements MERGE but not ``ON CREATE SET``, so ``coalesce``
+    # carries the original timestamp forward on a repeat like.
+    query: typing.LiteralString = (
+        _document_scope.BY_ID
+        + _document_scope.DISTINCT_DOCUMENT
+        + """
+    MATCH (me:User {{email: {principal}}})
+          -[:MEMBER_OF]->(:Organization {{slug: {org_slug}}})
+    MERGE (me)-[l:LIKED]->(d)
+    SET l.at = coalesce(l.at, {now})
+    WITH d
+    """
+        + _LIKE_STATE_TAIL
+    )
+    now = datetime.datetime.now(datetime.UTC)
+    records = await db.execute(
+        query,
+        {
+            'document_id': document_id,
+            'org_slug': org_slug,
+            'principal': auth.principal_name,
+            'now': now.isoformat(),
+        },
+        columns=_LIKE_STATE_COLUMNS,
+    )
+    if not records:
+        # Either the document is not in this org or the caller is not a
+        # member of it; both are a 404 from the caller's point of view.
+        raise fastapi.HTTPException(
+            status_code=404, detail=f'Document {document_id!r} not found'
+        )
+    state, project_id = _parse_like_state(records[0])
+    background_tasks.add_task(
+        _document_events.emit_like_event,
+        org_slug=org_slug,
+        project_id=project_id,
+        document_id=document_id,
+        principal=auth.principal_name,
+        action='like',
+        occurred_at=now,
+    )
+    return state
+
+
+@document_likes_router.delete('/like', response_model=LikeStateResponse)
+async def unlike_document(
+    org_slug: str,
+    document_id: str,
+    db: graph.Pool,
+    auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(permissions.require_permission('document:read')),
+    ],
+    background_tasks: fastapi.BackgroundTasks,
+) -> LikeStateResponse:
+    """Remove the calling principal's like.
+
+    Idempotent: unliking a document the caller never liked succeeds and
+    reports the unchanged count.
+    """
+    query: typing.LiteralString = (
+        _document_scope.BY_ID
+        + _document_scope.DISTINCT_DOCUMENT
+        + """
+    OPTIONAL MATCH (me:User {{email: {principal}}})-[l:LIKED]->(d)
+    DELETE l
+    WITH d
+    """
+        + _LIKE_STATE_TAIL
+    )
+    records = await db.execute(
+        query,
+        {
+            'document_id': document_id,
+            'org_slug': org_slug,
+            'principal': auth.principal_name,
+        },
+        columns=_LIKE_STATE_COLUMNS,
+    )
+    if not records:
+        raise fastapi.HTTPException(
+            status_code=404, detail=f'Document {document_id!r} not found'
+        )
+    state, project_id = _parse_like_state(records[0])
+    background_tasks.add_task(
+        _document_events.emit_like_event,
+        org_slug=org_slug,
+        project_id=project_id,
+        document_id=document_id,
+        principal=auth.principal_name,
+        action='unlike',
+        occurred_at=datetime.datetime.now(datetime.UTC),
+    )
+    return state
+
+
+@document_likes_router.get('/likes', response_model=LikerListResponse)
+async def list_document_likers(
+    request: fastapi.Request,
+    org_slug: str,
+    document_id: str,
+    db: graph.Pool,
+    _auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(permissions.require_permission('document:read')),
+    ],
+    limit: int = DEFAULT_LIMIT,
+    cursor: str | None = None,
+) -> fastapi.Response:
+    """List who liked the document, most recent first."""
+    if limit < 1 or limit > MAX_LIMIT:
+        raise fastapi.HTTPException(
+            status_code=400, detail=f'limit must be 1..{MAX_LIMIT}'
+        )
+
+    params: dict[str, typing.Any] = {
+        'document_id': document_id,
+        'org_slug': org_slug,
+        'row_limit': limit + 1,
+    }
+    cursor_clause: typing.LiteralString = ''
+    if cursor is not None:
+        decoded = decode_cursor(cursor)
+        if decoded is None:
+            raise fastapi.HTTPException(
+                status_code=400, detail='Invalid cursor'
+            )
+        cursor_ts, cursor_email = decoded
+        cursor_clause = (
+            ' WHERE (l.at < {cursor_ts}'
+            ' OR (l.at = {cursor_ts} AND liker.email < {cursor_email}))'
+        )
+        params['cursor_ts'] = cursor_ts.isoformat()
+        params['cursor_email'] = cursor_email
+
+    query: str = (
+        _document_scope.BY_ID
+        + _document_scope.DISTINCT_DOCUMENT
+        + """
+    MATCH (liker:User)-[l:LIKED]->(d)"""
+        + cursor_clause
+        + """
+    RETURN liker.email AS email,
+           liker.display_name AS display_name,
+           l.at AS liked_at
+    ORDER BY liked_at DESC, email DESC
+    LIMIT {row_limit}
+    """
+    )
+    records = await db.execute(
+        query, params, columns=['email', 'display_name', 'liked_at']
+    )
+
+    likers: list[LikerRef] = []
+    for record in records:
+        email = graph.parse_agtype(record['email'])
+        liked_at_raw = graph.parse_agtype(record['liked_at'])
+        if not email or not liked_at_raw:
+            continue
+        display_name = graph.parse_agtype(record['display_name'])
+        likers.append(
+            LikerRef(
+                principal=str(email),
+                display_name=str(display_name) if display_name else None,
+                liked_at=datetime.datetime.fromisoformat(str(liked_at_raw)),
+            )
+        )
+
+    next_cursor: str | None = None
+    if len(likers) > limit:
+        likers = likers[:limit]
+        next_cursor = encode_cursor(likers[-1].liked_at, likers[-1].principal)
+
+    adapter = pydantic.TypeAdapter(list[LikerRef])
+    response = fastapi.responses.JSONResponse(
+        {'data': adapter.dump_python(likers, mode='json')}
+    )
+    response.headers['Link'] = build_link_header(request, next_cursor)
+    return response

--- a/apps/api/src/imbi/api/endpoints/documents.py
+++ b/apps/api/src/imbi/api/endpoints/documents.py
@@ -49,6 +49,8 @@ _DOCUMENT_READONLY_PATHS: frozenset[str] = frozenset(
         '/project_id',
         '/attached_to',
         '/comment_count',
+        '/like_count',
+        '/liked_by_me',
         '/created_by',
         '/created_by_name',
         '/created_at',
@@ -92,6 +94,8 @@ class DocumentResponse(pydantic.BaseModel):
     attached_to: AttachmentRef | None = None
     is_pinned: bool = False
     comment_count: int = 0
+    like_count: int = 0
+    liked_by_me: bool = False
     tags: list[TagRef] = []
     version: int = 1
 
@@ -169,6 +173,8 @@ def _parse_document_row(
     document['comment_count'] = int(
         graph.parse_agtype(record['comment_count']) or 0
     )
+    document['like_count'] = int(graph.parse_agtype(record['like_count']) or 0)
+    document['liked_by_me'] = bool(graph.parse_agtype(record['liked_by_me']))
     document['created_by_name'] = (
         str(author.get('display_name', '')) or None if author else None
     )
@@ -195,7 +201,8 @@ _ATTACHMENT_MATCH: typing.LiteralString = """
 # Enrichment tail used by every query that returns a document. Runs
 # with ``n, p, team, pt, u`` in scope and emits the full column set.
 # Aggregates run stepwise so each OPTIONAL MATCH cannot multiply the
-# rows of the next.
+# rows of the next. Callers must bind ``principal`` (the caller's
+# email, or '' for an unattributed read) so ``liked_by_me`` resolves.
 _ENRICH_TAIL: typing.LiteralString = """
     OPTIONAL MATCH (p)-[:TYPE]->(ptype:ProjectType)
     WITH n, p, team, pt, u,
@@ -214,8 +221,15 @@ _ENRICH_TAIL: typing.LiteralString = """
           -[:ON_DOCUMENT]->(n)
     WITH n, p, team, pt, u, ptype_names, tags,
          count(c) AS comment_count
+    OPTIONAL MATCH (liker:User)-[:LIKED]->(n)
+    WITH n, p, team, pt, u, ptype_names, tags, comment_count,
+         count(DISTINCT liker) AS like_count
+    OPTIONAL MATCH (me:User {{email: {principal}}})-[:LIKED]->(n)
+    WITH n, p, team, pt, u, ptype_names, tags, comment_count, like_count,
+         count(me) > 0 AS liked_by_me
     OPTIONAL MATCH (author:User {{email: n.created_by}})
-    RETURN n, p, team, pt, u, ptype_names, tags, comment_count, author
+    RETURN n, p, team, pt, u, ptype_names, tags, comment_count,
+           like_count, liked_by_me, author
 """
 
 _DOCUMENT_COLUMNS: list[str] = [
@@ -227,6 +241,8 @@ _DOCUMENT_COLUMNS: list[str] = [
     'ptype_names',
     'tags',
     'comment_count',
+    'like_count',
+    'liked_by_me',
     'author',
 ]
 
@@ -510,6 +526,7 @@ async def _list_documents_impl(
     tag_slug: str | None = None,
     limit: int,
     cursor: str | None,
+    principal: str = '',
 ) -> fastapi.Response:
     if limit < 1 or limit > MAX_LIMIT:
         raise fastapi.HTTPException(
@@ -531,6 +548,7 @@ async def _list_documents_impl(
     params: dict[str, typing.Any] = {
         'org_slug': org_slug,
         'row_limit': limit + 1,
+        'principal': principal,
     }
     filters = ''
     if project_id is not None:
@@ -612,7 +630,7 @@ async def list_documents(
     request: fastapi.Request,
     org_slug: str,
     db: graph.Pool,
-    _auth: typing.Annotated[
+    auth: typing.Annotated[
         permissions.AuthContext,
         fastapi.Depends(permissions.require_permission('document:read')),
     ],
@@ -632,6 +650,7 @@ async def list_documents(
         request=request,
         db=db,
         org_slug=org_slug,
+        principal=auth.principal_name,
         project_id=project_id,
         project_type_slug=project_type,
         user_email=user,
@@ -647,7 +666,7 @@ async def list_project_documents(
     org_slug: str,
     project_id: str,
     db: graph.Pool,
-    _auth: typing.Annotated[
+    auth: typing.Annotated[
         permissions.AuthContext,
         fastapi.Depends(permissions.require_permission('document:read')),
     ],
@@ -660,6 +679,7 @@ async def list_project_documents(
         request=request,
         db=db,
         org_slug=org_slug,
+        principal=auth.principal_name,
         project_id=project_id,
         tag_slug=tag,
         limit=limit,
@@ -673,7 +693,7 @@ async def list_project_type_documents(
     org_slug: str,
     type_slug: str,
     db: graph.Pool,
-    _auth: typing.Annotated[
+    auth: typing.Annotated[
         permissions.AuthContext,
         fastapi.Depends(permissions.require_permission('document:read')),
     ],
@@ -686,6 +706,7 @@ async def list_project_type_documents(
         request=request,
         db=db,
         org_slug=org_slug,
+        principal=auth.principal_name,
         project_type_slug=type_slug,
         tag_slug=tag,
         limit=limit,
@@ -699,7 +720,7 @@ async def list_user_documents(
     org_slug: str,
     email: str,
     db: graph.Pool,
-    _auth: typing.Annotated[
+    auth: typing.Annotated[
         permissions.AuthContext,
         fastapi.Depends(permissions.require_permission('document:read')),
     ],
@@ -712,6 +733,7 @@ async def list_user_documents(
         request=request,
         db=db,
         org_slug=org_slug,
+        principal=auth.principal_name,
         user_email=email,
         tag_slug=tag,
         limit=limit,
@@ -733,6 +755,7 @@ async def fetch_document(
     org_slug: str,
     document_id: str,
     project_id: str | None = None,
+    principal: str = '',
 ) -> dict[str, typing.Any] | None:
     scope, scope_params = _scope_filter(project_id)
     query: str = (
@@ -751,6 +774,7 @@ async def fetch_document(
         {
             'document_id': document_id,
             'org_slug': org_slug,
+            'principal': principal,
             **scope_params,
         },
         columns=_DOCUMENT_COLUMNS,
@@ -765,7 +789,7 @@ async def get_org_document(
     org_slug: str,
     document_id: str,
     db: graph.Pool,
-    _auth: typing.Annotated[
+    auth: typing.Annotated[
         permissions.AuthContext,
         fastapi.Depends(permissions.require_permission('document:read')),
     ],
@@ -776,6 +800,7 @@ async def get_org_document(
         db,
         org_slug,
         document_id,
+        principal=auth.principal_name,
         detail=f'Document {document_id!r} not found',
     )
 
@@ -788,7 +813,7 @@ async def get_document(
     project_id: str,
     document_id: str,
     db: graph.Pool,
-    _auth: typing.Annotated[
+    auth: typing.Annotated[
         permissions.AuthContext,
         fastapi.Depends(permissions.require_permission('document:read')),
     ],
@@ -800,6 +825,7 @@ async def get_document(
         org_slug,
         document_id,
         project_id,
+        principal=auth.principal_name,
         detail=f'Document {document_id!r} not found',
     )
 

--- a/apps/api/src/imbi/api/endpoints/organizations.py
+++ b/apps/api/src/imbi/api/endpoints/organizations.py
@@ -14,6 +14,11 @@ from imbi.common import graph, models
 from imbi.common import patch as json_patch
 
 from .comments import comments_router
+from .document_analytics import (
+    document_analytics_org_router,
+    document_analytics_router,
+)
+from .document_likes import document_likes_router
 from .document_presence import document_presence_router
 from .document_templates import document_templates_router
 from .document_versions import document_versions_router
@@ -103,6 +108,13 @@ organizations_router.include_router(
     documents_router,
     prefix='/{org_slug}/documents',
 )
+# A sibling of ``/documents`` rather than a path under it: nested, its
+# literal ``/analytics`` segment competes with ``GET /documents/{document_id}``
+# and only wins while it is registered first. Mirrors ``document-templates``.
+organizations_router.include_router(
+    document_analytics_org_router,
+    prefix='/{org_slug}/document-analytics',
+)
 organizations_router.include_router(
     document_versions_router,
     prefix='/{org_slug}/documents/{document_id}/versions',
@@ -110,6 +122,14 @@ organizations_router.include_router(
 organizations_router.include_router(
     document_presence_router,
     prefix='/{org_slug}/documents/{document_id}/editing',
+)
+organizations_router.include_router(
+    document_likes_router,
+    prefix='/{org_slug}/documents/{document_id}',
+)
+organizations_router.include_router(
+    document_analytics_router,
+    prefix='/{org_slug}/documents/{document_id}',
 )
 organizations_router.include_router(
     documents_project_router,

--- a/apps/api/src/imbi/api/lifespans.py
+++ b/apps/api/src/imbi/api/lifespans.py
@@ -13,6 +13,7 @@ from collections import abc
 from imbi.api import openapi
 from imbi.api.commit_sync import queue as commit_sync_queue
 from imbi.api.deployment_sync import queue as deployment_sync_queue
+from imbi.api.documents import read_sweeper as document_read_sweeper
 from imbi.api.email.client import EmailClient
 from imbi.api.email.templates import TemplateManager
 from imbi.api.identity import sweeper as identity_sweeper
@@ -132,6 +133,40 @@ async def identity_refresh_hook() -> abc.AsyncGenerator[None]:
             pass
         except Exception:  # noqa: BLE001
             LOGGER.warning('Identity sweeper exited with error', exc_info=True)
+
+
+@contextlib.asynccontextmanager
+async def document_read_sweeper_hook() -> abc.AsyncGenerator[None]:
+    """Finalize abandoned document read sessions.
+
+    A reading session normally closes itself with a final `sendBeacon`
+    flush, but that is best-effort -- a killed tab or a dropped network
+    leaves the session open. This sweeper closes anything idle past
+    :data:`_document_reads.SESSION_IDLE_TIMEOUT_SECONDS` so its engaged
+    time still reaches the document's numbers.
+    """
+    try:
+        client = valkey.get_client()
+    except RuntimeError:
+        LOGGER.warning('Valkey unavailable; read sweeper not started')
+        yield None
+        return
+    stop = asyncio.Event()
+    LOGGER.info('Document read-session sweeper starting')
+    task = asyncio.create_task(
+        document_read_sweeper.run_sweeper(client, stop=stop)
+    )
+    try:
+        yield None
+    finally:
+        stop.set()
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+        except Exception:  # noqa: BLE001
+            LOGGER.warning('Read sweeper exited with error', exc_info=True)
 
 
 @contextlib.asynccontextmanager

--- a/apps/api/tests/endpoints/test_document_analytics.py
+++ b/apps/api/tests/endpoints/test_document_analytics.py
@@ -1,0 +1,130 @@
+"""Tests for document read-analytics reporting and its identity gate."""
+
+import unittest
+from unittest import mock
+
+from imbi.api.endpoints import document_analytics
+from imbi.api.endpoints.organizations import organizations_router
+
+
+class IdentityGateTestCase(unittest.TestCase):
+    """Who may see *which people* read a document.
+
+    Aggregate readership is an operational signal; a named list is a
+    different kind of data, so it needs both the permission and the
+    organization's blessing.
+    """
+
+    @staticmethod
+    def _auth(
+        *, principal: str, permissions: set[str], is_admin: bool = False
+    ):
+        auth = mock.Mock()
+        auth.permissions = permissions
+        auth.principal_name = principal
+        auth.is_admin = is_admin
+        return auth
+
+    def test_disabled_blocks_everyone(self) -> None:
+        """Not even the author, and not even an admin."""
+        for auth in (
+            self._auth(
+                principal='author@example.com',
+                permissions={document_analytics.IDENTITY_PERMISSION},
+            ),
+            self._auth(
+                principal='admin@example.com', permissions=set(), is_admin=True
+            ),
+        ):
+            with self.subTest(principal=auth.principal_name):
+                self.assertFalse(
+                    document_analytics._may_see_identities(
+                        auth, 'disabled', 'author@example.com'
+                    )
+                )
+
+    def test_enabled_requires_the_permission(self) -> None:
+        granted = self._auth(
+            principal='lead@example.com',
+            permissions={document_analytics.IDENTITY_PERMISSION},
+        )
+        denied = self._auth(principal='dev@example.com', permissions=set())
+        self.assertTrue(
+            document_analytics._may_see_identities(
+                granted, 'enabled', 'author@example.com'
+            )
+        )
+        self.assertFalse(
+            document_analytics._may_see_identities(
+                denied, 'enabled', 'author@example.com'
+            )
+        )
+
+    def test_enabled_does_not_admit_the_author_alone(self) -> None:
+        """Under 'enabled' the gate is the permission, not authorship."""
+        author = self._auth(principal='author@example.com', permissions=set())
+        self.assertFalse(
+            document_analytics._may_see_identities(
+                author, 'enabled', 'author@example.com'
+            )
+        )
+
+    def test_authors_only_admits_the_author(self) -> None:
+        author = self._auth(principal='author@example.com', permissions=set())
+        stranger = self._auth(principal='other@example.com', permissions=set())
+        self.assertTrue(
+            document_analytics._may_see_identities(
+                author, 'authors_only', 'author@example.com'
+            )
+        )
+        self.assertFalse(
+            document_analytics._may_see_identities(
+                stranger, 'authors_only', 'author@example.com'
+            )
+        )
+
+    def test_authors_only_still_admits_the_permission_holder(self) -> None:
+        lead = self._auth(
+            principal='lead@example.com',
+            permissions={document_analytics.IDENTITY_PERMISSION},
+        )
+        self.assertTrue(
+            document_analytics._may_see_identities(
+                lead, 'authors_only', 'author@example.com'
+            )
+        )
+
+
+class SurfaceFilterTestCase(unittest.TestCase):
+    """Human reads are the default answer; agents are opt-in."""
+
+    def test_named_surface_is_bound_not_interpolated(self) -> None:
+        fragment = document_analytics._surface_filter('web')
+        self.assertIn('{surface:String}', fragment)
+        self.assertNotIn("'web'", fragment)
+
+    def test_all_drops_the_filter(self) -> None:
+        self.assertEqual(document_analytics._surface_filter('all'), '')
+
+    def test_self_excluded_unless_requested(self) -> None:
+        """Editing a document must not inflate its readership."""
+        self.assertIn(
+            '{author:String}', document_analytics._self_filter(False)
+        )
+        self.assertEqual(document_analytics._self_filter(True), '')
+
+
+class OrgReportRouteTestCase(unittest.TestCase):
+    def test_org_report_is_a_sibling_of_documents(self) -> None:
+        """The org report must not sit under ``/documents/``.
+
+        Nested, its literal ``analytics`` segment competes with
+        ``GET /documents/{document_id}`` and resolves correctly only
+        while it happens to be registered first. As a sibling there is
+        no ordering to get wrong.
+        """
+        paths = {route.path for route in organizations_router.routes}
+        self.assertIn('/organizations/{org_slug}/document-analytics', paths)
+        self.assertNotIn(
+            '/organizations/{org_slug}/documents/analytics', paths
+        )

--- a/apps/api/tests/endpoints/test_document_likes.py
+++ b/apps/api/tests/endpoints/test_document_likes.py
@@ -1,0 +1,155 @@
+"""Tests for the document like endpoints."""
+
+import datetime
+from unittest import mock
+
+import fastapi.testclient
+
+from apps.api.tests import support
+from imbi.api import models
+
+
+class DocumentLikeEndpointsTestCase(support.SharedAppTestCase):
+    """Thumbs-up likes held as ``(:User)-[:LIKED]->(:Document)`` edges."""
+
+    def setUp(self) -> None:
+        from imbi.api.auth import permissions
+        from imbi.common import graph
+
+        self.user = models.User(
+            email='reader@example.com',
+            display_name='Reader',
+            password_hash='$argon2id$hashed',
+            is_active=True,
+            is_admin=False,
+            is_service_account=False,
+            created_at=datetime.datetime.now(datetime.UTC),
+        )
+        self.auth_context = permissions.AuthContext(
+            user=self.user,
+            session_id='test-session',
+            auth_method='jwt',
+            permissions={'document:read'},
+        )
+
+        async def mock_get_current_user():
+            return self.auth_context
+
+        self.test_app.dependency_overrides[permissions.get_current_user] = (
+            mock_get_current_user
+        )
+
+        self.mock_db = mock.AsyncMock()
+        self.test_app.dependency_overrides[graph._inject_graph] = (
+            lambda: self.mock_db
+        )
+
+        # TestClient runs background tasks inline, so without this the
+        # activity-feed emit would try to reach ClickHouse and burn
+        # several minutes on connection backoff per request.
+        self.emit = mock.AsyncMock()
+        patcher = mock.patch(
+            'imbi.api.endpoints.document_likes._document_events'
+            '.emit_like_event',
+            self.emit,
+        )
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+        self.client = fastapi.testclient.TestClient(self.test_app)
+
+    @staticmethod
+    def _state_row(
+        like_count: int, liked_by_me: bool, project_id: str | None = None
+    ) -> dict[str, object]:
+        return {
+            'like_count': like_count,
+            'liked_by_me': liked_by_me,
+            'project_id': project_id,
+        }
+
+    def test_like_returns_updated_state(self) -> None:
+        self.mock_db.execute.return_value = [self._state_row(3, True)]
+        response = self.client.put(
+            '/organizations/engineering/documents/document-1/like'
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.json(), {'like_count': 3, 'liked_by_me': True}
+        )
+
+    def test_like_preserves_original_timestamp(self) -> None:
+        """A repeat like must not reorder the liker list.
+
+        AGE has no ``ON CREATE SET``, so the MERGE writes
+        ``coalesce(l.at, {now})`` -- the original ``at`` survives.
+        """
+        self.mock_db.execute.return_value = [self._state_row(1, True)]
+        self.client.put('/organizations/engineering/documents/document-1/like')
+        query = self.mock_db.execute.call_args.args[0]
+        self.assertIn('MERGE (me)-[l:LIKED]->(d)', query)
+        self.assertIn('SET l.at = coalesce(l.at, {now})', query)
+
+    def test_like_unknown_document_is_404(self) -> None:
+        self.mock_db.execute.return_value = []
+        response = self.client.put(
+            '/organizations/engineering/documents/nope/like'
+        )
+        self.assertEqual(response.status_code, 404)
+
+    def test_unlike_returns_updated_state(self) -> None:
+        self.mock_db.execute.return_value = [self._state_row(0, False)]
+        response = self.client.delete(
+            '/organizations/engineering/documents/document-1/like'
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.json(), {'like_count': 0, 'liked_by_me': False}
+        )
+
+    def test_unlike_is_idempotent(self) -> None:
+        """Unliking something never liked succeeds rather than 404ing."""
+        self.mock_db.execute.return_value = [self._state_row(2, False)]
+        response = self.client.delete(
+            '/organizations/engineering/documents/document-1/like'
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(response.json()['liked_by_me'])
+
+    def test_like_count_uses_distinct_likers(self) -> None:
+        """A duplicate edge must not double a document's like count."""
+        self.mock_db.execute.return_value = [self._state_row(1, True)]
+        self.client.put('/organizations/engineering/documents/document-1/like')
+        query = self.mock_db.execute.call_args.args[0]
+        self.assertIn('count(DISTINCT liker) AS like_count', query)
+
+    def test_list_likers_most_recent_first(self) -> None:
+        self.mock_db.execute.return_value = [
+            {
+                'email': 'zoe@example.com',
+                'display_name': 'Zoe',
+                'liked_at': '2026-07-29T12:00:00+00:00',
+            },
+            {
+                'email': 'abe@example.com',
+                'display_name': None,
+                'liked_at': '2026-07-28T12:00:00+00:00',
+            },
+        ]
+        response = self.client.get(
+            '/organizations/engineering/documents/document-1/likes'
+        )
+        self.assertEqual(response.status_code, 200)
+        data = response.json()['data']
+        self.assertEqual(
+            [row['principal'] for row in data],
+            ['zoe@example.com', 'abe@example.com'],
+        )
+        self.assertEqual(data[0]['display_name'], 'Zoe')
+        self.assertIsNone(data[1]['display_name'])
+
+    def test_list_likers_rejects_bad_limit(self) -> None:
+        response = self.client.get(
+            '/organizations/engineering/documents/document-1/likes?limit=0'
+        )
+        self.assertEqual(response.status_code, 400)

--- a/apps/api/tests/endpoints/test_document_reads.py
+++ b/apps/api/tests/endpoints/test_document_reads.py
@@ -1,0 +1,230 @@
+"""Tests for read-tracking policy: clamping, classification, ingest."""
+
+import datetime
+import unittest
+from unittest import mock
+
+import fastapi.testclient
+
+from apps.api.tests import support
+from imbi.api import models
+from imbi.api.endpoints import _document_reads
+
+
+class ClampEngagedTimeTestCase(unittest.TestCase):
+    """A heartbeat may not claim more time than it could have accrued."""
+
+    def test_normal_delta_passes_through(self) -> None:
+        value, clamped = _document_reads.clamp_engaged_ms(12_000)
+        self.assertEqual(value, 12_000)
+        self.assertFalse(clamped)
+
+    def test_delta_above_ceiling_is_clamped_and_flagged(self) -> None:
+        value, clamped = _document_reads.clamp_engaged_ms(8 * 60 * 60 * 1000)
+        self.assertEqual(value, _document_reads.MAX_ENGAGED_DELTA_MS)
+        self.assertTrue(clamped)
+
+    def test_ceiling_allows_a_late_beat(self) -> None:
+        """One interval plus the 1.5x cushion is legitimate, not clamped."""
+        value, clamped = _document_reads.clamp_engaged_ms(
+            _document_reads.HEARTBEAT_INTERVAL_SECONDS * 1000
+        )
+        self.assertEqual(
+            value, _document_reads.HEARTBEAT_INTERVAL_SECONDS * 1000
+        )
+        self.assertFalse(clamped)
+
+    def test_negative_delta_clamps_to_zero(self) -> None:
+        """A backwards clock cannot subtract engagement."""
+        value, clamped = _document_reads.clamp_engaged_ms(-5_000)
+        self.assertEqual(value, 0)
+        self.assertTrue(clamped)
+
+
+class ClassifySessionTestCase(unittest.TestCase):
+    """View/read classification from a finalized session's totals."""
+
+    def test_below_view_floor_is_neither(self) -> None:
+        is_view, is_read = _document_reads.classify(
+            surface='web', engaged_ms=2_000, max_scroll_pct=100, read_ms=60_000
+        )
+        self.assertFalse(is_view)
+        self.assertFalse(is_read)
+
+    def test_scroll_depth_makes_a_long_document_read(self) -> None:
+        is_view, is_read = _document_reads.classify(
+            surface='web',
+            engaged_ms=30_000,
+            max_scroll_pct=85,
+            read_ms=600_000,
+        )
+        self.assertTrue(is_view)
+        self.assertTrue(is_read)
+
+    def test_dwell_makes_a_short_document_read(self) -> None:
+        is_view, is_read = _document_reads.classify(
+            surface='web', engaged_ms=45_000, max_scroll_pct=10, read_ms=30_000
+        )
+        self.assertTrue(is_view)
+        self.assertTrue(is_read)
+
+    def test_skim_is_a_view_but_not_a_read(self) -> None:
+        is_view, is_read = _document_reads.classify(
+            surface='web',
+            engaged_ms=8_000,
+            max_scroll_pct=20,
+            read_ms=600_000,
+        )
+        self.assertTrue(is_view)
+        self.assertFalse(is_read)
+
+    def test_agent_fetch_is_a_view_never_a_read(self) -> None:
+        """Agents have no attention to measure, so they never 'read'."""
+        for surface in ('mcp', 'assistant', 'slackbot', 'api'):
+            with self.subTest(surface=surface):
+                is_view, is_read = _document_reads.classify(
+                    surface=surface,
+                    engaged_ms=0,
+                    max_scroll_pct=0,
+                    read_ms=60_000,
+                )
+                self.assertTrue(is_view)
+                self.assertFalse(is_read)
+
+
+class EstimatedReadTimeTestCase(unittest.TestCase):
+    def test_empty_content_has_no_estimate(self) -> None:
+        self.assertEqual(_document_reads.estimated_read_ms(''), 0)
+
+    def test_estimate_tracks_word_count(self) -> None:
+        content = ' '.join(['word'] * _document_reads.WORDS_PER_MINUTE)
+        self.assertEqual(_document_reads.estimated_read_ms(content), 60_000)
+
+
+class ReadEventIngestTestCase(support.SharedAppTestCase):
+    """The heartbeat sink."""
+
+    def setUp(self) -> None:
+        from imbi.api.auth import permissions
+        from imbi.common import graph, valkey
+
+        self.user = models.User(
+            email='reader@example.com',
+            display_name='Reader',
+            password_hash='$argon2id$hashed',
+            is_active=True,
+            is_admin=False,
+            is_service_account=False,
+            created_at=datetime.datetime.now(datetime.UTC),
+        )
+        self.auth_context = permissions.AuthContext(
+            user=self.user,
+            session_id='test-session',
+            auth_method='jwt',
+            permissions={'document:read'},
+        )
+
+        async def mock_get_current_user():
+            return self.auth_context
+
+        self.test_app.dependency_overrides[permissions.get_current_user] = (
+            mock_get_current_user
+        )
+        self.mock_db = mock.AsyncMock()
+        self.test_app.dependency_overrides[graph._inject_graph] = (
+            lambda: self.mock_db
+        )
+        self.mock_valkey = mock.AsyncMock()
+        self.mock_valkey.get.return_value = None
+        self.test_app.dependency_overrides[valkey._inject_client] = (
+            lambda: self.mock_valkey
+        )
+
+        # The document resolves in the org, with 220 words of content.
+        self.mock_db.execute.return_value = [
+            {
+                'project_id': 'proj-1',
+                'version': 3,
+                'content': ' '.join(['word'] * 220),
+                'created_by': 'author@example.com',
+            }
+        ]
+
+        # Background tasks run inline under TestClient; stub the writes so
+        # nothing reaches ClickHouse.
+        self.record = mock.AsyncMock()
+        self.finalize = mock.AsyncMock(return_value=1)
+        for target, replacement in (
+            ('_document_reads.record_events', self.record),
+            ('_document_reads.finalize_sessions', self.finalize),
+        ):
+            patcher = mock.patch(
+                f'imbi.api.endpoints.document_analytics.{target}', replacement
+            )
+            patcher.start()
+            self.addCleanup(patcher.stop)
+
+        self.client = fastapi.testclient.TestClient(self.test_app)
+
+    def _event(self, **overrides: object) -> dict[str, object]:
+        event: dict[str, object] = {
+            'session_id': 'session-1',
+            'seq': 0,
+            'session_started_at': '2026-07-30T12:00:00+00:00',
+            'engaged_ms': 12_000,
+            'max_scroll_pct': 40,
+            'is_final': False,
+        }
+        event.update(overrides)
+        return event
+
+    def _post(self, *events: dict[str, object]):
+        return self.client.post(
+            '/organizations/engineering/documents/document-1/read-events',
+            json={'events': list(events)},
+        )
+
+    def test_accepts_a_heartbeat(self) -> None:
+        response = self._post(self._event())
+        self.assertEqual(response.status_code, 202)
+        rows = self.record.await_args.args[0]
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0].engaged_ms, 12_000)
+        self.assertEqual(rows[0].principal, 'reader@example.com')
+        self.assertEqual(rows[0].project_id, 'proj-1')
+        self.assertEqual(rows[0].document_version, 3)
+        self.assertEqual(rows[0].estimated_read_ms, 60_000)
+        self.assertEqual(rows[0].clamped, 0)
+
+    def test_clamps_an_inflated_delta(self) -> None:
+        self._post(self._event(engaged_ms=8 * 60 * 60 * 1000))
+        rows = self.record.await_args.args[0]
+        self.assertEqual(
+            rows[0].engaged_ms, _document_reads.MAX_ENGAGED_DELTA_MS
+        )
+        self.assertEqual(rows[0].clamped, 1)
+
+    def test_final_heartbeat_finalizes_the_session(self) -> None:
+        self._post(self._event(is_final=True))
+        self.finalize.assert_awaited_once_with(['session-1'])
+
+    def test_unknown_document_is_404(self) -> None:
+        self.mock_db.execute.return_value = []
+        self.assertEqual(self._post(self._event()).status_code, 404)
+        self.record.assert_not_awaited()
+
+    def test_rejects_an_oversized_batch(self) -> None:
+        events = [self._event(seq=i) for i in range(25)]
+        self.assertEqual(self._post(*events).status_code, 400)
+
+    def test_rejects_an_empty_batch(self) -> None:
+        response = self.client.post(
+            '/organizations/engineering/documents/document-1/read-events',
+            json={'events': []},
+        )
+        self.assertEqual(response.status_code, 422)
+
+    def test_rejects_an_out_of_range_scroll_depth(self) -> None:
+        self.assertEqual(
+            self._post(self._event(max_scroll_pct=140)).status_code, 422
+        )

--- a/apps/api/tests/endpoints/test_document_versions.py
+++ b/apps/api/tests/endpoints/test_document_versions.py
@@ -84,6 +84,8 @@ class DocumentVersionEndpointsTestCase(support.SharedAppTestCase):
             'ptype_names': [],
             'tags': kwargs.get('tags', []),
             'comment_count': 0,
+            'like_count': 0,
+            'liked_by_me': False,
             'author': None,
         }
 

--- a/apps/api/tests/endpoints/test_documents.py
+++ b/apps/api/tests/endpoints/test_documents.py
@@ -98,6 +98,8 @@ class DocumentEndpointsTestCase(support.SharedAppTestCase):
         ptype_names: list[str] | None = None,
         tags: list[dict] | None = None,
         comment_count: int = 0,
+        like_count: int = 0,
+        liked_by_me: bool = False,
         author: dict | None = None,
     ) -> dict[str, typing.Any]:
         """A full document row as returned by the enriched queries."""
@@ -110,6 +112,8 @@ class DocumentEndpointsTestCase(support.SharedAppTestCase):
             'ptype_names': ptype_names or [],
             'tags': tags or [],
             'comment_count': comment_count,
+            'like_count': like_count,
+            'liked_by_me': liked_by_me,
             'author': author,
         }
 

--- a/libraries/common/src/imbi/common/clickhouse/schemata.toml
+++ b/libraries/common/src/imbi/common/clickhouse/schemata.toml
@@ -245,3 +245,67 @@ ORDER BY (task_id, run_id)
 TTL fired_at + INTERVAL 90 DAY;
 """
 enabled = true
+
+[document_read_events]
+query = """
+CREATE TABLE IF NOT EXISTS imbi.document_read_events {on_cluster}(
+  org_slug           LowCardinality(String),
+  document_id        String,
+  session_id         String,
+  seq                UInt32,
+  principal          String,
+  surface            LowCardinality(String) DEFAULT 'web',
+  project_id         LowCardinality(String) DEFAULT '',
+  document_version   UInt32 DEFAULT 0,
+  estimated_read_ms  UInt32 DEFAULT 0,
+  session_started_at DateTime64(3, 'UTC'),
+  recorded_at        DateTime64(3, 'UTC'),
+  engaged_ms         UInt32 DEFAULT 0,
+  max_scroll_pct     UInt8  DEFAULT 0,
+  clamped            UInt8  DEFAULT 0,
+  is_final           UInt8  DEFAULT 0
+) ENGINE = {replicated}ReplacingMergeTree(recorded_at)
+PARTITION BY toYYYYMM(session_started_at)
+ORDER BY (org_slug, document_id, session_id, seq)
+-- `(session_id, seq)` in the key makes a retried or double-delivered
+-- heartbeat dedup to one row, so the `sendBeacon` flush racing the interval
+-- heartbeat cannot double-count engaged time.
+--
+-- TTL is on `session_started_at`, which every row of a session shares, rather
+-- than on the per-row `recorded_at`. TTL is evaluated per row at merge time,
+-- so keying on `recorded_at` would expire a session's early heartbeats while
+-- its later ones survive, leaving a truncated session whose engaged total is
+-- silently short. Sessions expire whole instead.
+TTL toDateTime(session_started_at) + INTERVAL 90 DAY;
+"""
+enabled = true
+
+[document_read_sessions]
+query = """
+CREATE TABLE IF NOT EXISTS imbi.document_read_sessions {on_cluster}(
+  org_slug          LowCardinality(String),
+  document_id       String,
+  session_id        String,
+  principal         String,
+  surface           LowCardinality(String) DEFAULT 'web',
+  project_id        LowCardinality(String) DEFAULT '',
+  document_version  UInt32 DEFAULT 0,
+  started_at        DateTime64(3, 'UTC'),
+  ended_at          DateTime64(3, 'UTC'),
+  engaged_ms        UInt32 DEFAULT 0,
+  max_scroll_pct    UInt8  DEFAULT 0,
+  is_view           UInt8  DEFAULT 0,
+  is_read           UInt8  DEFAULT 0,
+  finalized_at      DateTime64(3, 'UTC')
+) ENGINE = {replicated}ReplacingMergeTree(finalized_at)
+PARTITION BY toYYYYMM(started_at)
+ORDER BY (org_slug, document_id, session_id)
+-- One row per finalized session, written by the finalizer once a session's
+-- engaged total and scroll depth are both known. Every reported number
+-- (last read, readers, views, engaged-time distribution, trends) comes from
+-- this table, so it outlives the raw heartbeats it was derived from. Keyed on
+-- `session_id` alone within a document so a reaper finalizing a session the
+-- client also finalized dedups to one row rather than double-counting it.
+TTL toDateTime(started_at) + INTERVAL 2 YEAR;
+"""
+enabled = true

--- a/libraries/common/src/imbi/common/models.py
+++ b/libraries/common/src/imbi/common/models.py
@@ -319,8 +319,22 @@ SEMVER_TAG_FORMAT: typing.Final[TagFormat] = TagFormat(
 )
 
 
+#: Who may see *which people* read a document, as opposed to how many.
+#: Aggregate readership is an operational signal; a named list of who
+#: read what and for how long is surveillance-shaped, so it is gated
+#: separately from the aggregate and defaults to the narrowest setting
+#: that still lets an author learn who reads their own work.
+DocumentAnalyticsIdentities = typing.Literal[
+    'enabled',  # anyone holding document:analytics:read_identities
+    'authors_only',  # that, plus the document's own author
+    'disabled',  # nobody; aggregate counts only
+]
+
+
 class Organization(Node):
     tag_formats: list[TagFormat] = []
+
+    document_analytics_identities: DocumentAnalyticsIdentities = 'authors_only'
 
 
 BelongsToOrganization = typing.Annotated[

--- a/ui/.fallowrc.json
+++ b/ui/.fallowrc.json
@@ -20,6 +20,7 @@
       "file": "src/api/endpoints.ts",
       "exports": [
         "getMonthlyImprovement",
+        "getOrgDocumentAnalytics",
         "getOrgPullRequests",
         "getProjectPullRequests",
         "getScoreHistoryByTeam",

--- a/ui/src/api/endpoints.ts
+++ b/ui/src/api/endpoints.ts
@@ -33,9 +33,18 @@ import type {
   DeploymentTriggerRequest,
   DeploymentTriggerResponse,
   Document,
+  DocumentAnalytics,
   DocumentCreate,
   DocumentEditorsResponse,
+  DocumentLiker,
+  DocumentLikerListResponse,
+  DocumentLikeState,
   DocumentListResponse,
+  DocumentReader,
+  DocumentReaderListResponse,
+  DocumentReadEvent,
+  DocumentReadSummary,
+  DocumentReadSummaryResponse,
   DocumentTemplate,
   DocumentTemplateCreate,
   DocumentVersion,
@@ -1781,11 +1790,87 @@ export const deleteOrgDocument = (orgSlug: string, documentId: string) =>
     `/organizations/${encodeURIComponent(orgSlug)}/documents/${encodeURIComponent(documentId)}`,
   )
 
+// Thumbs-up likes. PUT/DELETE are idempotent and both return the
+// document's current like state, so an optimistic toggle can reconcile
+// against the response without a follow-up read.
+const documentPath = (orgSlug: string, documentId: string) =>
+  `/organizations/${encodeURIComponent(orgSlug)}/documents/${encodeURIComponent(documentId)}`
+
+export const likeDocument = (orgSlug: string, documentId: string) =>
+  apiClient.put<DocumentLikeState>(`${documentPath(orgSlug, documentId)}/like`)
+
+export const unlikeDocument = (orgSlug: string, documentId: string) =>
+  apiClient.delete<DocumentLikeState>(
+    `${documentPath(orgSlug, documentId)}/like`,
+  )
+
+export const listDocumentLikers = async (
+  orgSlug: string,
+  documentId: string,
+  signal?: AbortSignal,
+): Promise<DocumentLiker[]> => {
+  const response = await apiClient.get<DocumentLikerListResponse>(
+    `${documentPath(orgSlug, documentId)}/likes`,
+    undefined,
+    signal,
+  )
+  return response?.data ?? []
+}
+
+// Read tracking. The server answers 202 and swallows storage failures,
+// so callers never need to handle an error here — a lost heartbeat costs
+// at most one interval of engaged time.
+export const postDocumentReadEvents = (
+  orgSlug: string,
+  documentId: string,
+  events: DocumentReadEvent[],
+) =>
+  apiClient.post<void>(`${documentPath(orgSlug, documentId)}/read-events`, {
+    events,
+  })
+
+export const getDocumentAnalytics = (
+  orgSlug: string,
+  documentId: string,
+  signal?: AbortSignal,
+) =>
+  apiClient.get<DocumentAnalytics>(
+    `${documentPath(orgSlug, documentId)}/analytics`,
+    undefined,
+    signal,
+  )
+
+export const listDocumentReaders = async (
+  orgSlug: string,
+  documentId: string,
+  signal?: AbortSignal,
+): Promise<DocumentReader[]> => {
+  const response = await apiClient.get<DocumentReaderListResponse>(
+    `${documentPath(orgSlug, documentId)}/analytics/readers`,
+    undefined,
+    signal,
+  )
+  return response?.data ?? []
+}
+
+export const getOrgDocumentAnalytics = async (
+  orgSlug: string,
+  params: { limit?: number; mode?: string; stale_days?: number },
+  signal?: AbortSignal,
+): Promise<DocumentReadSummary[]> => {
+  const response = await apiClient.get<DocumentReadSummaryResponse>(
+    `/organizations/${encodeURIComponent(orgSlug)}/document-analytics`,
+    params as Record<string, unknown>,
+    signal,
+  )
+  return response?.data ?? []
+}
+
 // Document version history (attachment-agnostic). Full snapshots are
 // recorded server-side on every content-affecting change; restore
 // applies an old snapshot as a normal update (a new version).
 const documentVersionsPath = (orgSlug: string, documentId: string) =>
-  `/organizations/${encodeURIComponent(orgSlug)}/documents/${encodeURIComponent(documentId)}/versions`
+  `${documentPath(orgSlug, documentId)}/versions`
 
 export const listDocumentVersions = async (
   orgSlug: string,
@@ -1826,7 +1911,7 @@ export const restoreDocumentVersion = (
 // registers/refreshes the caller and returns every active editor;
 // markers expire server-side after `ttl_seconds` without a heartbeat.
 const documentEditingPath = (orgSlug: string, documentId: string) =>
-  `/organizations/${encodeURIComponent(orgSlug)}/documents/${encodeURIComponent(documentId)}/editing`
+  `${documentPath(orgSlug, documentId)}/editing`
 
 export const getDocumentEditors = (
   orgSlug: string,

--- a/ui/src/components/documents/DocumentAnalyticsStrip.tsx
+++ b/ui/src/components/documents/DocumentAnalyticsStrip.tsx
@@ -1,0 +1,164 @@
+import { useState } from 'react'
+
+import { useQuery } from '@tanstack/react-query'
+import { BarChart3, Clock, Eye, Users } from 'lucide-react'
+
+import { getDocumentAnalytics, listDocumentReaders } from '@/api/endpoints'
+import { queryKeys } from '@/lib/queryKeys'
+
+import { relativeShort } from './documentsHelpers'
+
+interface Props {
+  documentId: string
+  orgSlug: string
+}
+
+/**
+ * One dense line of read analytics under a document, expanding into the
+ * per-reader detail.
+ *
+ * Numbers cover human reads only — agent fetches (MCP, Assistant,
+ * Slackbot, API) are recorded but filtered out server-side, so this
+ * never reports a document as widely read because an agent indexed it.
+ *
+ * The reader list is only requested when the caller is allowed to see
+ * it (`identities_visible`) *and* has expanded the panel; a 403 is a
+ * legitimate answer here, not an error worth surfacing.
+ */
+export function DocumentAnalyticsStrip({ documentId, orgSlug }: Props) {
+  const [expanded, setExpanded] = useState(false)
+
+  const { data: analytics } = useQuery({
+    enabled: !!orgSlug && !!documentId,
+    queryFn: ({ signal }) => getDocumentAnalytics(orgSlug, documentId, signal),
+    queryKey: queryKeys.documentAnalytics(orgSlug, documentId),
+    retry: false,
+    staleTime: 60_000,
+  })
+
+  const { data: readers } = useQuery({
+    enabled: expanded && !!analytics?.identities_visible,
+    queryFn: ({ signal }) => listDocumentReaders(orgSlug, documentId, signal),
+    queryKey: queryKeys.documentReaders(orgSlug, documentId),
+    retry: false,
+    staleTime: 60_000,
+  })
+
+  if (!analytics) return null
+
+  const neverRead = !analytics.last_read_at
+
+  return (
+    <div className="border-primary text-tertiary mt-5 border-t pt-2.5 text-xs">
+      <button
+        className="hover:text-secondary flex flex-wrap items-center gap-3 transition-colors"
+        onClick={() => setExpanded((v) => !v)}
+        type="button"
+      >
+        <span className="inline-flex items-center gap-1">
+          <Clock className="size-3" />
+          {neverRead
+            ? 'Never read'
+            : `Last read ${relativeShort(analytics.last_read_at)}`}
+        </span>
+        <span className="inline-flex items-center gap-1">
+          <Users className="size-3" />
+          <span className="tabular-nums">{analytics.readers}</span>
+          {analytics.readers === 1 ? 'reader' : 'readers'}
+        </span>
+        <span className="inline-flex items-center gap-1">
+          <Eye className="size-3" />
+          <span className="tabular-nums">{analytics.views}</span>
+          {analytics.views === 1 ? 'view' : 'views'}
+        </span>
+        <span className="inline-flex items-center gap-1">
+          <BarChart3 className="size-3" />
+          {formatDuration(analytics.median_engaged_seconds)} median
+        </span>
+      </button>
+
+      {expanded && (
+        <div className="mt-2.5 space-y-2.5">
+          <dl className="grid grid-cols-2 gap-x-5 gap-y-1 sm:grid-cols-4">
+            <Stat
+              label="Completion"
+              value={`${Math.round(analytics.completion_rate * 100)}%`}
+            />
+            <Stat label="Reads" value={String(analytics.reads)} />
+            <Stat
+              label="p90 engaged"
+              value={formatDuration(analytics.p90_engaged_seconds)}
+            />
+            <Stat
+              label="Est. read time"
+              value={formatDuration(analytics.estimated_read_seconds)}
+            />
+          </dl>
+
+          {analytics.by_surface.length > 1 && (
+            <div className="flex flex-wrap gap-2.5">
+              {analytics.by_surface.map((entry) => (
+                <span key={entry.surface}>
+                  {entry.surface}{' '}
+                  <span className="text-secondary tabular-nums">
+                    {entry.views}
+                  </span>
+                </span>
+              ))}
+            </div>
+          )}
+
+          {analytics.identities_visible ? (
+            readers && readers.length > 0 ? (
+              <table className="w-full">
+                <thead className="text-tertiary text-left">
+                  <tr>
+                    <th className="font-normal">Reader</th>
+                    <th className="font-normal">Last read</th>
+                    <th className="text-right font-normal">Views</th>
+                    <th className="text-right font-normal">Engaged</th>
+                  </tr>
+                </thead>
+                <tbody className="text-secondary">
+                  {readers.map((reader) => (
+                    <tr key={reader.principal}>
+                      <td className="truncate">{reader.principal}</td>
+                      <td>{relativeShort(reader.last_read_at)}</td>
+                      <td className="text-right tabular-nums">
+                        {reader.views}
+                      </td>
+                      <td className="text-right tabular-nums">
+                        {formatDuration(reader.engaged_seconds)}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            ) : (
+              <div>No individual reads recorded yet.</div>
+            )
+          ) : (
+            <div>Individual readers are not shown for this organization.</div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function formatDuration(seconds: number): string {
+  if (seconds <= 0) return '—'
+  if (seconds < 60) return `${seconds}s`
+  const minutes = Math.floor(seconds / 60)
+  if (minutes < 60) return `${minutes}m`
+  return `${Math.floor(minutes / 60)}h ${minutes % 60}m`
+}
+
+function Stat({ label, value }: { label: string; value: string }) {
+  return (
+    <div>
+      <dt className="text-tertiary">{label}</dt>
+      <dd className="text-secondary tabular-nums">{value}</dd>
+    </div>
+  )
+}

--- a/ui/src/components/documents/DocumentLikeButton.tsx
+++ b/ui/src/components/documents/DocumentLikeButton.tsx
@@ -1,0 +1,129 @@
+import { useEffect, useRef, useState } from 'react'
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { ThumbsUp } from 'lucide-react'
+
+import {
+  likeDocument,
+  listDocumentLikers,
+  unlikeDocument,
+} from '@/api/endpoints'
+import { Button } from '@/components/ui/button'
+import { queryKeys } from '@/lib/queryKeys'
+import { cn } from '@/lib/utils'
+import type { DocumentLikeState } from '@/types'
+
+interface Props {
+  documentId: string
+  initialCount: number
+  initialLiked: boolean
+  orgSlug: string
+}
+
+/**
+ * Thumbs-up toggle for a document.
+ *
+ * Mirrors the comment-acknowledgement affordance (same icon, same
+ * amber-when-active treatment) so the gesture reads identically in both
+ * places. The toggle is optimistic and reconciles against the server's
+ * returned count rather than a refetch; PUT and DELETE are both
+ * idempotent, so a double-tap cannot desync the count.
+ *
+ * The liker list is fetched only when the popover is opened — most
+ * readers never ask who liked a document, and the count alone comes
+ * free on the document itself.
+ */
+export function DocumentLikeButton({
+  documentId,
+  initialCount,
+  initialLiked,
+  orgSlug,
+}: Props) {
+  const queryClient = useQueryClient()
+  const [state, setState] = useState<DocumentLikeState>({
+    like_count: initialCount,
+    liked_by_me: initialLiked,
+  })
+  const [showLikers, setShowLikers] = useState(false)
+  // Arm the liker fetch only after a deliberate hover, so merely
+  // sweeping the cursor across the toolbar costs no request.
+  const hoverTimer = useRef<number | undefined>(undefined)
+  useEffect(() => () => window.clearTimeout(hoverTimer.current), [])
+
+  const armLikers = () => {
+    hoverTimer.current = window.setTimeout(() => setShowLikers(true), 300)
+  }
+  const disarmLikers = () => {
+    window.clearTimeout(hoverTimer.current)
+    setShowLikers(false)
+  }
+
+  const { data: likers } = useQuery({
+    enabled: showLikers && state.like_count > 0,
+    queryFn: ({ signal }) => listDocumentLikers(orgSlug, documentId, signal),
+    queryKey: queryKeys.documentLikers(orgSlug, documentId),
+    staleTime: 30_000,
+  })
+
+  const toggle = useMutation({
+    mutationFn: (like: boolean) =>
+      like
+        ? likeDocument(orgSlug, documentId)
+        : unlikeDocument(orgSlug, documentId),
+    onError: (_error, _like, context) => {
+      // Put the pre-click state back; the click did not land.
+      if (context) setState(context)
+    },
+    onMutate: (like: boolean): DocumentLikeState => {
+      const previous = state
+      setState({
+        like_count: Math.max(0, state.like_count + (like ? 1 : -1)),
+        liked_by_me: like,
+      })
+      return previous
+    },
+    onSuccess: (result) => {
+      setState(result)
+      void queryClient.invalidateQueries({
+        queryKey: queryKeys.documentLikers(orgSlug, documentId),
+      })
+    },
+  })
+
+  return (
+    <div className="relative">
+      <Button
+        aria-label={state.liked_by_me ? 'Remove like' : 'Like this document'}
+        aria-pressed={state.liked_by_me}
+        className={cn('gap-1.5', state.liked_by_me && 'text-action')}
+        onClick={() => toggle.mutate(!state.liked_by_me)}
+        onMouseEnter={armLikers}
+        onMouseLeave={disarmLikers}
+        size="sm"
+        variant="ghost"
+      >
+        <ThumbsUp className="size-3" />
+        {state.like_count > 0 && (
+          <span className="tabular-nums">{state.like_count}</span>
+        )}
+      </Button>
+      {showLikers && likers && likers.length > 0 && (
+        <div className="border-primary bg-primary absolute top-full right-0 z-20 mt-1 w-56 border p-2 text-xs shadow-sm">
+          <div className="text-tertiary mb-1">Liked by</div>
+          <ul className="space-y-0.5">
+            {likers.slice(0, 8).map((liker) => (
+              <li className="text-secondary truncate" key={liker.principal}>
+                {liker.display_name || liker.principal}
+              </li>
+            ))}
+          </ul>
+          {likers.length > 8 && (
+            <div className="text-tertiary mt-1">
+              and {likers.length - 8} more
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/ui/src/components/documents/DocumentsPinboardReader.tsx
+++ b/ui/src/components/documents/DocumentsPinboardReader.tsx
@@ -27,6 +27,7 @@ import {
 } from '@/components/ui/segmented-control'
 import { IconTooltip } from '@/components/ui/tooltip'
 import { UserIdentity } from '@/components/ui/user-identity'
+import { useDocumentReadTracking } from '@/hooks/useDocumentReadTracking'
 import { cn } from '@/lib/utils'
 import type { Document } from '@/types'
 import type { CommentAnchor, CommentThread } from '@/types/comments'
@@ -37,7 +38,9 @@ import { RightCommentBar } from './comments/RightCommentBar'
 import { SelectionToolbar } from './comments/SelectionToolbar'
 import { useCommentLastVisit } from './comments/useCommentLastVisit'
 import { useInlineComments } from './comments/useInlineComments'
+import { DocumentAnalyticsStrip } from './DocumentAnalyticsStrip'
 import { DocumentAttachmentBadge } from './DocumentAttachmentBadge'
+import { DocumentLikeButton } from './DocumentLikeButton'
 import { DocumentsFilterRail } from './DocumentsFilterRail'
 import {
   documentTitle,
@@ -164,6 +167,9 @@ export function DocumentsPinboardReader({
   )
 
   const lastVisit = useCommentLastVisit(orgSlug, projectId, document.id)
+  // Engagement is only measured while this reader is mounted, so opening
+  // the document is what starts a session and leaving it ends one.
+  useDocumentReadTracking(orgSlug, document.id)
 
   // Deep-link: ?thread=<id> (e.g. from the activity feed) scrolls to and
   // flashes a page thread; for an inline one it shows + focuses the reader
@@ -329,6 +335,12 @@ export function DocumentsPinboardReader({
                 </Button>
                 <span className="bg-tertiary mx-1 h-5 w-px" />
               </div>
+              <DocumentLikeButton
+                documentId={document.id}
+                initialCount={document.like_count ?? 0}
+                initialLiked={document.liked_by_me ?? false}
+                orgSlug={orgSlug}
+              />
               <Button
                 className="gap-1.5"
                 onClick={() => setShowHistory(true)}
@@ -453,6 +465,11 @@ export function DocumentsPinboardReader({
                 </>
               )}
             </div>
+
+            <DocumentAnalyticsStrip
+              documentId={document.id}
+              orgSlug={orgSlug}
+            />
           </article>
 
           <div className="flex flex-col gap-4 lg:sticky lg:top-5">

--- a/ui/src/components/documents/documentsHelpers.ts
+++ b/ui/src/components/documents/documentsHelpers.ts
@@ -85,7 +85,10 @@ export function formatUpdated(document: Document): string {
   return relativeShort(iso)
 }
 
-function relativeShort(iso: null | string | undefined): string {
+// Exported for callers that hold a bare timestamp rather than a
+// Document (read analytics reports "last read at", which belongs to no
+// single document field).
+export function relativeShort(iso: null | string | undefined): string {
   if (!iso) return ''
   const then = parseServerTs(iso).getTime()
   if (!Number.isFinite(then)) return ''

--- a/ui/src/components/reports/DocumentReadershipReport.tsx
+++ b/ui/src/components/reports/DocumentReadershipReport.tsx
@@ -1,0 +1,133 @@
+import { useState } from 'react'
+
+import { useQuery } from '@tanstack/react-query'
+
+import { getOrgDocumentAnalytics } from '@/api/endpoints'
+import { relativeShort } from '@/components/documents/documentsHelpers'
+import {
+  SegmentedControl,
+  SegmentedControlItem,
+} from '@/components/ui/segmented-control'
+import { useOrganization } from '@/contexts/OrganizationContext'
+
+type Mode = 'least-read' | 'most-read' | 'never-read' | 'stale'
+
+const MODES: { description: string; id: Mode; label: string }[] = [
+  {
+    description: 'Documents with the most distinct readers',
+    id: 'most-read',
+    label: 'Most read',
+  },
+  {
+    description: 'Read by someone, but not for a long time',
+    id: 'stale',
+    label: 'Stale',
+  },
+  {
+    description: 'Read by at least one person, fewest readers first',
+    id: 'least-read',
+    label: 'Least read',
+  },
+  {
+    description: 'Never opened by anyone',
+    id: 'never-read',
+    label: 'Never read',
+  },
+]
+
+/**
+ * Org-wide document readership.
+ *
+ * The point of this report is the bottom of the list, not the top:
+ * `never-read` and `stale` are what tell you which documentation is not
+ * carrying its weight. Counts are human reads only — agent fetches are
+ * filtered out server-side.
+ */
+export function DocumentReadershipReport() {
+  const { selectedOrganization } = useOrganization()
+  const orgSlug = selectedOrganization?.slug ?? ''
+  const [mode, setMode] = useState<Mode>('most-read')
+
+  const { data, isPending } = useQuery({
+    enabled: !!orgSlug,
+    queryFn: ({ signal }) =>
+      getOrgDocumentAnalytics(orgSlug, { limit: 100, mode }, signal),
+    queryKey: ['orgDocumentAnalytics', orgSlug, mode],
+    staleTime: 60_000,
+  })
+
+  const active = MODES.find((m) => m.id === mode) ?? MODES[0]
+  // 'never-read' rows have no reads by definition, so the read columns
+  // would be a column of zeroes.
+  const showCounts = mode !== 'never-read'
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-center gap-3">
+        <SegmentedControl
+          ariaLabel="Readership view"
+          onValueChange={(value) => setMode(value as Mode)}
+          value={mode}
+        >
+          {MODES.map((m) => (
+            <SegmentedControlItem key={m.id} value={m.id}>
+              {m.label}
+            </SegmentedControlItem>
+          ))}
+        </SegmentedControl>
+        <span className="text-tertiary text-xs">{active.description}</span>
+      </div>
+
+      <div className="border-tertiary bg-primary rounded-lg border">
+        {isPending ? (
+          <div className="text-tertiary p-4 text-sm">Loading…</div>
+        ) : !data || data.length === 0 ? (
+          <div className="text-tertiary p-4 text-sm">
+            {mode === 'never-read'
+              ? 'Every document in this organization has been read.'
+              : 'No documents match this view yet.'}
+          </div>
+        ) : (
+          <table className="w-full text-sm">
+            <thead className="border-tertiary text-tertiary border-b text-left">
+              <tr>
+                <th className="px-4 py-2 font-normal">Document</th>
+                <th className="px-4 py-2 font-normal">Last read</th>
+                {showCounts && (
+                  <>
+                    <th className="px-4 py-2 text-right font-normal">
+                      Readers
+                    </th>
+                    <th className="px-4 py-2 text-right font-normal">Views</th>
+                  </>
+                )}
+              </tr>
+            </thead>
+            <tbody className="text-secondary">
+              {data.map((row) => (
+                <tr className="border-tertiary border-b" key={row.document_id}>
+                  <td className="truncate px-4 py-2">
+                    {row.title || row.document_id}
+                  </td>
+                  <td className="px-4 py-2">
+                    {row.last_read_at ? relativeShort(row.last_read_at) : '—'}
+                  </td>
+                  {showCounts && (
+                    <>
+                      <td className="px-4 py-2 text-right tabular-nums">
+                        {row.readers}
+                      </td>
+                      <td className="px-4 py-2 text-right tabular-nums">
+                        {row.views}
+                      </td>
+                    </>
+                  )}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/ui/src/hooks/__tests__/useDocumentReadTracking.test.tsx
+++ b/ui/src/hooks/__tests__/useDocumentReadTracking.test.tsx
@@ -1,0 +1,130 @@
+import { renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import * as endpoints from '@/api/endpoints'
+
+import { useDocumentReadTracking } from '../useDocumentReadTracking'
+
+const HEARTBEAT_MS = 15_000
+
+/** Drive the focus and visibility signals the hook gates accrual on. */
+function setFocused(value: boolean) {
+  vi.spyOn(document, 'hasFocus').mockReturnValue(value)
+}
+
+function setVisibility(value: 'hidden' | 'visible') {
+  Object.defineProperty(document, 'visibilityState', {
+    configurable: true,
+    get: () => value,
+  })
+  document.dispatchEvent(new Event('visibilitychange'))
+}
+
+describe('useDocumentReadTracking', () => {
+  let post: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    post = vi
+      .spyOn(endpoints, 'postDocumentReadEvents')
+      .mockResolvedValue(undefined)
+    // sendBeacon is only used for the final flush; stub it so unmount
+    // does not blow up in jsdom.
+    Object.defineProperty(navigator, 'sendBeacon', {
+      configurable: true,
+      value: vi.fn().mockReturnValue(true),
+      writable: true,
+    })
+    setVisibility('visible')
+    setFocused(true)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  it('accrues engaged time while visible, focused, and active', () => {
+    renderHook(() => useDocumentReadTracking('acme', 'doc-1'))
+
+    vi.advanceTimersByTime(HEARTBEAT_MS)
+
+    expect(post).toHaveBeenCalledTimes(1)
+    const [, , events] = post.mock.calls[0] as [
+      string,
+      string,
+      { engaged_ms: number; seq: number }[],
+    ]
+    expect(events[0].seq).toBe(0)
+    expect(events[0].engaged_ms).toBeGreaterThan(0)
+  })
+
+  it('sends nothing for an interval spent on a hidden tab', () => {
+    renderHook(() => useDocumentReadTracking('acme', 'doc-1'))
+
+    // Hiding flushes whatever was engaged so far, then stops accrual.
+    // Anything after that must not produce a heartbeat.
+    setVisibility('hidden')
+    post.mockClear()
+
+    vi.advanceTimersByTime(HEARTBEAT_MS * 4)
+
+    expect(post).not.toHaveBeenCalled()
+  })
+
+  it('stops accruing once the reader goes idle', () => {
+    renderHook(() => useDocumentReadTracking('acme', 'doc-1'))
+
+    // First beat covers a genuinely engaged interval.
+    vi.advanceTimersByTime(HEARTBEAT_MS)
+    expect(post).toHaveBeenCalledTimes(1)
+
+    // No further input: once past the 60s idle threshold the reader is
+    // treated as gone, and idle intervals send nothing at all.
+    post.mockClear()
+    vi.advanceTimersByTime(HEARTBEAT_MS * 10)
+
+    const idleBeats = post.mock.calls.length
+    expect(idleBeats).toBeLessThanOrEqual(4)
+
+    // Every beat that did land covers the window before the threshold,
+    // never the long idle stretch after it.
+    for (const call of post.mock.calls) {
+      const events = call[2] as { engaged_ms: number }[]
+      expect(events[0].engaged_ms).toBeLessThanOrEqual(HEARTBEAT_MS * 1.5)
+    }
+  })
+
+  it('does not track when no document is open', () => {
+    renderHook(() => useDocumentReadTracking('acme', null))
+    vi.advanceTimersByTime(HEARTBEAT_MS * 3)
+    expect(post).not.toHaveBeenCalled()
+  })
+
+  it('flushes through the API client on unmount, not a beacon', () => {
+    // An in-SPA navigation is not a page teardown: the normal client is
+    // available and carries auth, which `sendBeacon` cannot.
+    const { unmount } = renderHook(() =>
+      useDocumentReadTracking('acme', 'doc-1'),
+    )
+    vi.advanceTimersByTime(5_000)
+    post.mockClear()
+    unmount()
+
+    expect(post).toHaveBeenCalledTimes(1)
+    const events = post.mock.calls[0][2] as { is_final: boolean }[]
+    expect(events[0].is_final).toBe(true)
+    expect(navigator.sendBeacon).not.toHaveBeenCalled()
+  })
+
+  it('uses a beacon when the page itself is going away', () => {
+    // A closing tab will not wait for fetch, so the tail of the session
+    // has to go out via sendBeacon even though it cannot set headers.
+    renderHook(() => useDocumentReadTracking('acme', 'doc-1'))
+    vi.advanceTimersByTime(5_000)
+
+    window.dispatchEvent(new Event('pagehide'))
+
+    expect(navigator.sendBeacon).toHaveBeenCalledTimes(1)
+  })
+})

--- a/ui/src/hooks/useDocumentReadTracking.ts
+++ b/ui/src/hooks/useDocumentReadTracking.ts
@@ -1,0 +1,190 @@
+import { useEffect } from 'react'
+
+import { apiUrl } from '@/api/client'
+import { postDocumentReadEvents } from '@/api/endpoints'
+import type { DocumentReadEvent } from '@/types'
+
+// How often a heartbeat is sent while the reader is engaged. Must match
+// the server's `HEARTBEAT_INTERVAL_SECONDS`, which clamps each beat's
+// claimed engaged time to 1.5x this — raising one without the other
+// silently truncates every session.
+const HEARTBEAT_MS = 15_000
+
+// No input for this long means the reader has stopped reading, even
+// with the tab visible and focused. Accrual resumes on the next input.
+const IDLE_THRESHOLD_MS = 60_000
+
+// Activity only has to be observed once per this window: it feeds a
+// 60s threshold, so re-deriving it per `pointermove` would run the
+// whole accrual path hundreds of times a second to no effect.
+const ACTIVITY_RESOLUTION_MS = 1_000
+
+// Input events that count as "still here". Deliberately passive and
+// coarse: this only needs to distinguish a person from an empty chair.
+const ACTIVITY_EVENTS = [
+  'keydown',
+  'pointerdown',
+  'pointermove',
+  'touchstart',
+  'wheel',
+] as const
+
+/**
+ * Measures how long a reader is actually engaged with a document.
+ *
+ * Time accrues only while the document is visible, the window is
+ * focused, and an input event has occurred within `IDLE_THRESHOLD_MS`.
+ * A tab left open overnight therefore reports the seconds actually
+ * read, not the hours the tab existed — the entire point of measuring
+ * engagement client-side is that only the client can see these three
+ * signals.
+ *
+ * Heartbeats carry the *delta* since the previous beat rather than a
+ * running total, so a dropped beat costs one interval instead of
+ * corrupting the session. An interval with no engaged time sends
+ * nothing at all, so an idle reader generates no traffic.
+ *
+ * Only the page-teardown flush uses `sendBeacon`, because a closing tab
+ * will not wait for `fetch`; every other path goes through the normal
+ * API client so it carries auth. Both are idempotent server-side —
+ * heartbeats dedup on `(session_id, seq)` — so a beacon racing the
+ * interval timer cannot double-count.
+ */
+export function useDocumentReadTracking(
+  orgSlug: string,
+  documentId: null | string,
+): void {
+  useEffect(() => {
+    if (!orgSlug || !documentId) return
+
+    // Effect-local: every closure below captures these, and the effect
+    // re-runs (starting a new session) only when the document changes.
+    const sessionId = crypto.randomUUID()
+    const sessionStartedAt = new Date().toISOString()
+    let engagedMs = 0
+    let lastActivityAt = Date.now()
+    let lastTickAt = Date.now()
+    let maxScrollPct = 0
+    let seq = 0
+    // Cached so a scroll burst does not force a layout per event.
+    let scrollable = document.documentElement.scrollHeight - window.innerHeight
+
+    const engaged = (): boolean =>
+      document.visibilityState === 'visible' &&
+      document.hasFocus() &&
+      Date.now() - lastActivityAt < IDLE_THRESHOLD_MS
+
+    // Fold the time since the last accrual into the running delta, then
+    // reset the clock. Called before every read of `engagedMs` so the
+    // in-flight interval is never lost or double-counted.
+    const accrue = (): void => {
+      const now = Date.now()
+      if (engaged()) engagedMs += now - lastTickAt
+      lastTickAt = now
+    }
+
+    const onActivity = (): void => {
+      // Cheap early-out for high-frequency events; the marker only has
+      // to be accurate to within `ACTIVITY_RESOLUTION_MS`.
+      if (Date.now() - lastActivityAt < ACTIVITY_RESOLUTION_MS) return
+      // Accrue *before* moving the activity marker: the span just ended
+      // is only engaged time if the reader was already non-idle, and
+      // stamping first would retroactively credit an idle gap.
+      accrue()
+      lastActivityAt = Date.now()
+    }
+
+    const onScroll = (): void => {
+      onActivity()
+      if (scrollable > 0) {
+        const pct = Math.round((window.scrollY / scrollable) * 100)
+        maxScrollPct = Math.min(100, Math.max(maxScrollPct, pct))
+      } else {
+        // Nothing to scroll: the whole document is on screen, which is
+        // full depth. Without this a short document could never reach
+        // the read threshold by scrolling.
+        maxScrollPct = 100
+      }
+    }
+
+    const onResize = (): void => {
+      scrollable = document.documentElement.scrollHeight - window.innerHeight
+    }
+
+    const flush = (isFinal: boolean, teardown = false): void => {
+      accrue()
+      // A non-final beat with nothing to report is not worth a request;
+      // a final one still is, because it closes the session out.
+      if (engagedMs <= 0 && !isFinal) return
+      const event: DocumentReadEvent = {
+        engaged_ms: engagedMs,
+        is_final: isFinal,
+        max_scroll_pct: maxScrollPct,
+        seq,
+        session_id: sessionId,
+        session_started_at: sessionStartedAt,
+        surface: 'web',
+      }
+      seq += 1
+      engagedMs = 0
+      if (teardown) {
+        sendBeacon(event)
+      } else {
+        void postDocumentReadEvents(orgSlug, documentId, [event]).catch(
+          () => {},
+        )
+      }
+    }
+
+    // Only for a page that is going away: `sendBeacon` cannot set an
+    // Authorization header, so this relies on the session cookie.
+    const sendBeacon = (event: DocumentReadEvent): void => {
+      const body = JSON.stringify({ events: [event] })
+      const url = apiUrl(
+        `/organizations/${encodeURIComponent(orgSlug)}/documents/${encodeURIComponent(documentId)}/read-events`,
+      )
+      if (typeof navigator.sendBeacon === 'function') {
+        navigator.sendBeacon(
+          url,
+          new Blob([body], { type: 'application/json' }),
+        )
+      }
+    }
+
+    const onVisibility = (): void => {
+      accrue()
+      if (document.visibilityState === 'hidden') flush(true, true)
+    }
+    const onPageHide = (): void => flush(true, true)
+
+    const timer = window.setInterval(() => flush(false), HEARTBEAT_MS)
+    for (const name of ACTIVITY_EVENTS) {
+      window.addEventListener(name, onActivity, { passive: true })
+    }
+    window.addEventListener('scroll', onScroll, { passive: true })
+    window.addEventListener('resize', onResize, { passive: true })
+    document.addEventListener('visibilitychange', onVisibility)
+    window.addEventListener('pagehide', onPageHide)
+    // Focus changes gate accrual, so fold the elapsed span in at the
+    // boundary rather than letting the next accrue() attribute it to
+    // whichever side happened to be current.
+    window.addEventListener('blur', accrue)
+    window.addEventListener('focus', accrue)
+
+    return () => {
+      window.clearInterval(timer)
+      for (const name of ACTIVITY_EVENTS) {
+        window.removeEventListener(name, onActivity)
+      }
+      window.removeEventListener('scroll', onScroll)
+      window.removeEventListener('resize', onResize)
+      document.removeEventListener('visibilitychange', onVisibility)
+      window.removeEventListener('pagehide', onPageHide)
+      window.removeEventListener('blur', accrue)
+      window.removeEventListener('focus', accrue)
+      // An in-SPA navigation, not a page teardown — the normal client
+      // is available here and carries auth.
+      flush(true)
+    }
+  }, [orgSlug, documentId])
+}

--- a/ui/src/lib/queryKeys.ts
+++ b/ui/src/lib/queryKeys.ts
@@ -15,8 +15,14 @@ export const queryKeys = {
     anchorSlug: string,
     relType: string,
   ) => ['anchor-edges', kind, orgSlug, anchorSlug, relType] as const,
+  documentAnalytics: (orgSlug: string, documentId: string) =>
+    ['documentAnalytics', orgSlug, documentId] as const,
   documentEditors: (orgSlug: string, documentId: string) =>
     ['documentEditors', orgSlug, documentId] as const,
+  documentLikers: (orgSlug: string, documentId: string) =>
+    ['documentLikers', orgSlug, documentId] as const,
+  documentReaders: (orgSlug: string, documentId: string) =>
+    ['documentReaders', orgSlug, documentId] as const,
   documentVersion: (orgSlug: string, documentId: string, version: number) =>
     ['documentVersion', orgSlug, documentId, version] as const,
   documentVersions: (orgSlug: string, documentId: string) =>

--- a/ui/src/pages/ReportsPage.tsx
+++ b/ui/src/pages/ReportsPage.tsx
@@ -2,9 +2,11 @@ import { useEffect } from 'react'
 
 import { Link, useNavigate, useParams } from 'react-router-dom'
 
+import type { LucideIcon } from 'lucide-react'
 import {
   Activity,
   BarChart3,
+  BookOpen,
   GitCommitHorizontal,
   GitPullRequest,
   Network,
@@ -13,6 +15,7 @@ import {
 
 import { CommandBar } from '@/components/CommandBar'
 import { Navigation } from '@/components/Navigation'
+import { DocumentReadershipReport } from '@/components/reports/DocumentReadershipReport'
 import { MonthlyImprovementReport } from '@/components/reports/MonthlyImprovementReport'
 import { OpenPullRequestsReport } from '@/components/reports/OpenPullRequestsReport'
 import { PRActivityReport } from '@/components/reports/PRActivityReport'
@@ -23,6 +26,9 @@ import { usePageTitle } from '@/hooks/usePageTitle'
 
 interface Report {
   description: string
+  // Owned by the report definition so adding a report is a single
+  // entry here rather than an entry plus a branch in the sidebar.
+  icon: LucideIcon
   id: string
   label: string
   subtitle: string
@@ -31,36 +37,49 @@ interface Report {
 const REPORTS: Report[] = [
   {
     description: 'Month-over-month score delta',
+    icon: TrendingUp,
     id: 'monthly-improvement',
     label: 'Monthly Improvement',
     subtitle: 'Score improvement by team for a selected month',
   },
   {
     description: 'Open pull requests across the org',
+    icon: GitPullRequest,
     id: 'open-pull-requests',
     label: 'Open Pull Requests',
     subtitle: 'Open pull requests, filterable by team and project type',
   },
   {
     description: 'PRs created and merged per member',
+    icon: Activity,
     id: 'pr-activity',
     label: 'PR Activity',
     subtitle: 'PRs created and merged per team member, since a chosen date',
   },
   {
     description: 'Service dependency graph',
+    icon: Network,
     id: 'projects-graph',
     label: 'Projects Graph',
     subtitle: 'Project relationships across the org',
   },
   {
     description: 'Score trends over time per team',
+    icon: GitCommitHorizontal,
     id: 'score-history',
     label: 'Score History',
     subtitle: 'Avg score trend per team over time',
   },
   {
+    description: 'Which documents get read, and which do not',
+    icon: BookOpen,
+    id: 'document-readership',
+    label: 'Document Readership',
+    subtitle: 'Most-read, stale, and never-read documents across the org',
+  },
+  {
     description: 'Avg quality score per team',
+    icon: BarChart3,
     id: 'team-kpi',
     label: 'Team KPI',
     subtitle: 'Quality score rollup by team',
@@ -117,19 +136,7 @@ export function ReportsPage() {
                       key={r.id}
                       to={`/reports/${r.id}`}
                     >
-                      {r.id === 'team-kpi' ? (
-                        <BarChart3 className="mt-0.5 size-3.5 shrink-0" />
-                      ) : r.id === 'score-history' ? (
-                        <GitCommitHorizontal className="mt-0.5 size-3.5 shrink-0" />
-                      ) : r.id === 'projects-graph' ? (
-                        <Network className="mt-0.5 size-3.5 shrink-0" />
-                      ) : r.id === 'open-pull-requests' ? (
-                        <GitPullRequest className="mt-0.5 size-3.5 shrink-0" />
-                      ) : r.id === 'pr-activity' ? (
-                        <Activity className="mt-0.5 size-3.5 shrink-0" />
-                      ) : (
-                        <TrendingUp className="mt-0.5 size-3.5 shrink-0" />
-                      )}
+                      <r.icon className="mt-0.5 size-3.5 shrink-0" />
                       <div>
                         <div className="text-[13px] font-medium">{r.label}</div>
                         <div className="mt-0.5 text-[11px] opacity-70">
@@ -157,6 +164,7 @@ export function ReportsPage() {
             {activeId === 'pr-activity' && <PRActivityReport />}
             {activeId === 'score-history' && <ScoreHistoryReport />}
             {activeId === 'projects-graph' && <ProjectsGraphReport />}
+            {activeId === 'document-readership' && <DocumentReadershipReport />}
           </div>
         </div>
       </main>

--- a/ui/src/types/index.ts
+++ b/ui/src/types/index.ts
@@ -728,12 +728,35 @@ export interface Document {
   created_by_name?: null | string
   id: string
   is_pinned: boolean
+  like_count?: number
+  liked_by_me?: boolean
   project_id: null | string
   tags: TagRef[]
   title: string
   updated_at?: null | string
   updated_by?: null | string
   version?: number
+}
+
+// Aggregate read analytics for one document. Headline counts cover
+// human (`web`) reads only unless the request asked for another
+// surface; `by_surface` always reports every surface so agent traffic
+// stays visible without being mixed into the human numbers.
+export interface DocumentAnalytics {
+  by_surface: DocumentSurfaceCount[]
+  completion_rate: number
+  estimated_read_seconds: number
+  // Whether the caller may load the per-reader list. Driven by the
+  // `document:analytics:read_identities` permission and the org's
+  // `document_analytics_identities` setting.
+  identities_visible: boolean
+  last_read_at?: null | string
+  median_engaged_seconds: number
+  p90_engaged_seconds: number
+  readers: number
+  reads: number
+  trend: DocumentTrendPoint[]
+  views: number
 }
 
 // The vertex a document is attached to. `id` is the project id, the
@@ -759,7 +782,60 @@ export interface DocumentEditorsResponse {
   ttl_seconds: number
 }
 
+export interface DocumentLiker {
+  display_name?: null | string
+  liked_at: string
+  principal: string
+}
+
+export type DocumentLikerListResponse = CollectionResponse<DocumentLiker>
+
+export interface DocumentLikeState {
+  like_count: number
+  liked_by_me: boolean
+}
+
 export type DocumentListResponse = CollectionResponse<Document>
+
+export interface DocumentReader {
+  engaged_seconds: number
+  last_read_at?: null | string
+  principal: string
+  reads: number
+  views: number
+}
+
+export type DocumentReaderListResponse = CollectionResponse<DocumentReader>
+
+// One heartbeat from a reading client. `engaged_ms` is the delta since
+// the previous beat, not a running total: deltas keep every beat
+// independent, so a dropped beat costs one interval instead of
+// corrupting the session total.
+export interface DocumentReadEvent {
+  engaged_ms: number
+  is_final?: boolean
+  max_scroll_pct?: number
+  seq: number
+  session_id: string
+  session_started_at: string
+  surface?: 'api' | 'assistant' | 'mcp' | 'slackbot' | 'web'
+}
+
+export interface DocumentReadSummary {
+  document_id: string
+  last_read_at?: null | string
+  readers: number
+  title: string
+  views: number
+}
+
+export type DocumentReadSummaryResponse =
+  CollectionResponse<DocumentReadSummary>
+
+export interface DocumentSurfaceCount {
+  surface: string
+  views: number
+}
 
 export interface DocumentTemplate {
   content: string
@@ -802,6 +878,12 @@ export type DocumentTemplateType =
   | 'project'
   | 'project_type'
   | 'user'
+
+export interface DocumentTrendPoint {
+  day: string
+  readers: number
+  views: number
+}
 
 // Full snapshot of a single document version.
 export interface DocumentVersion extends DocumentVersionInfo {


### PR DESCRIPTION
Implements `docs/document-analytics-prd.md` (that PRD lives in the dev-env repo, not here).

Documents already carry versions, comments, tags, and editing presence, but nothing recorded that anyone *read* one. This adds read/engagement tracking and a thumbs-up like.

## Likes

`(:User)-[:LIKED {at}]->(:Document)`, with `PUT`/`DELETE /documents/{id}/like` and `GET /documents/{id}/likes`. `like_count` and `liked_by_me` come back on every document response, so the index and reader get them without an extra call.

This deliberately diverges from comment acknowledgements, which hold likers in an `acknowledged_by` array on the vertex. Toggling an array is read-modify-write, so two simultaneous likes can lose one; a `MERGE` is atomic per person. The edge also carries `at`, which the "who liked this, most recent first" list needs and an array has nowhere to put. Comments keep their array — converging them is follow-up, not this PR.

Liking needs only `document:read`. A like is a public act, which is why it does not sit behind the identity gate that per-reader analytics does.

## Read analytics

Engagement is measured on the client, because only the client can see whether the tab is visible, focused, and being interacted with — the three signals that separate reading from a tab left open overnight. Time accrues only while all three hold; 60s without input stops it.

- Heartbeats carry **deltas**, not running totals, so a dropped beat costs one interval instead of corrupting the session.
- The server clamps each delta to 1.5x the heartbeat interval and stores it *flagged*, so a clock jump or a hand-rolled client cannot inflate a document's numbers.
- Only page teardown uses `sendBeacon` (it cannot set an `Authorization` header); every other flush goes through the normal API client.
- Sessions dedup on `(session_id, seq)`, so a beacon racing the interval timer cannot double-count.
- A Valkey-locked sweeper finalizes sessions abandoned past 5 minutes — a killed tab never sends its final beat.

**Agent reads are separated.** MCP, Assistant, Slackbot, and API fetches record with a `surface` dimension and are filtered out of every default query, so indexing a document does not make it look widely read.

## Schema

Two ClickHouse tables, not the PRD's three. The PRD specified a per-session materialized view plus a daily rollup, but classification needs a session's engaged total *and* scroll depth together, which an MV firing per insert block cannot see. The finalizer writes one durable session row; trends come from `GROUP BY toDate(started_at)`.

Both tables TTL on a column every row of a session shares. A TTL on the per-row `recorded_at` would expire a session's early heartbeats while later ones survive, silently truncating the total — the same trap the `scheduled_task_runs` table documents.

## Privacy

Aggregate readership is an operational signal; a named list of who read what and for how long is not. The reader list needs both `document:analytics:read_identities` **and** the org's `document_analytics_identities` setting, which defaults to `authors_only` (the author sees their own document's readers; nobody else does without the grant). Author self-views are excluded from counts by default.

The setting is currently only reachable via an organization PATCH — no admin UI. Worth a follow-up.

## Verification

`ruff check` + `format --check` clean · 117 API tests · 659 UI tests · `tsc` clean · `oxlint` clean · `fallow` at baseline.

**Not verified:** the ClickHouse SQL and the AGE Cypher are exercised against mocks only — neither has run against a live server. The `MERGE ... coalesce(l.at, {now})` in the like path and `count(DISTINCT liker)` are the two I would exercise first, since AGE's Cypher coverage is uneven.

Two pre-existing lifespan tests (`test_successful_lifespan_startup`, `test_openapi_refresh_blueprint_failure`) fail identically with and without this branch — they need ClickHouse on `localhost:8123`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
