### PR TITLE
Seed service accounts and credentials for imbi-scheduler and imbi-gateway

### DIFF
--- a/apps/api/src/imbi/api/auth/internal_services.py
+++ b/apps/api/src/imbi/api/auth/internal_services.py
@@ -16,7 +16,7 @@ Credentials come from the environment when it supplies them, so a
 deployment whose secret already lives in a Helm values file or an
 ``.env`` gets an account matching the value it already hands the
 service. Otherwise one is generated and returned for the caller to
-print once -- it cannot be read back afterwards.
+print once -- it cannot be read back afterward.
 """
 
 import asyncio

--- a/apps/api/src/imbi/api/auth/internal_services.py
+++ b/apps/api/src/imbi/api/auth/internal_services.py
@@ -1,0 +1,409 @@
+"""Service accounts for Imbi's own services.
+
+``imbi-scheduler`` runs every ``api``-target task as its own service
+account -- per ADR 0002 there is no credential store, so a client
+credential of its own is the only identity a system task can run as --
+and ``imbi-gateway`` calls back into imbi-api with a bearer token to
+patch projects and record releases. Neither is created by hand any more:
+``imbi-api setup`` seeds both, and ``setup-service-accounts`` brings an
+existing install up to date.
+
+imbi-assistant, imbi-mcp, and imbi-slackbot deliberately have no entry
+here. Each forwards the *caller's* token to imbi-api rather than acting
+as itself, so an account for them would carry privileges nothing uses.
+
+Credentials come from the environment when it supplies them, so a
+deployment whose secret already lives in a Helm values file or an
+``.env`` gets an account matching the value it already hands the
+service. Otherwise one is generated and returned for the caller to
+print once -- it cannot be read back afterwards.
+"""
+
+import asyncio
+import logging
+import os
+import secrets
+import typing
+
+from imbi.api import models
+from imbi.api.auth import password
+from imbi.common import graph
+
+LOGGER = logging.getLogger(__name__)
+
+#: What ``seed_internal_services`` did with a service's credential.
+#: ``supplied`` -- written to match the environment; ``generated`` -- a
+#: new one was minted and must be emitted; ``unchanged`` -- a credential
+#: was already present and was left alone.
+Outcome = typing.Literal['supplied', 'generated', 'unchanged']
+
+
+class InternalService(typing.NamedTuple):
+    """One of Imbi's services, and how it authenticates to imbi-api."""
+
+    slug: str
+    display_name: str
+    description: str
+    role_slug: str
+    #: ``client_credential`` mints a token per run through
+    #: ``/auth/token``; ``api_key`` is a static bearer sent as-is.
+    credential: typing.Literal['client_credential', 'api_key']
+    #: Environment variable carrying the public half. ``None`` for API
+    #: keys, whose ``ik_<id>_<secret>`` form carries both halves in
+    #: ``secret_var``.
+    client_id_var: str | None
+    secret_var: str
+
+
+INTERNAL_SERVICES: tuple[InternalService, ...] = (
+    InternalService(
+        slug='imbi-scheduler',
+        display_name='Imbi Scheduler',
+        description=(
+            'Runs scheduled tasks that target the Imbi API (ADR 0002)'
+        ),
+        role_slug='imbi-scheduler',
+        credential='client_credential',
+        client_id_var='IMBI_SCHEDULER_SA_CLIENT_ID',
+        secret_var='IMBI_SCHEDULER_SA_CLIENT_SECRET',
+    ),
+    InternalService(
+        slug='imbi-gateway',
+        display_name='Imbi Gateway',
+        description=(
+            'Attributes inbound webhook events and patches projects '
+            'and releases on their behalf'
+        ),
+        role_slug='imbi-gateway',
+        credential='api_key',
+        client_id_var=None,
+        secret_var='ACTIONS_IMBI_TOKEN',
+    ),
+)
+
+
+class SeededService(typing.NamedTuple):
+    """Result of seeding one :class:`InternalService`."""
+
+    service: InternalService
+    account_created: bool
+    outcome: Outcome
+    #: Environment assignments a deployment must adopt. Populated only
+    #: when ``outcome`` is ``generated`` -- the values are unrecoverable
+    #: once the caller discards them.
+    env: dict[str, str]
+
+
+class SeedError(Exception):
+    """Seeding could not complete.
+
+    Raised rather than logged so ``setup`` exits non-zero: a service
+    account without its role grants nothing, and a malformed supplied
+    credential authenticates nobody.
+    """
+
+
+async def seed_internal_services(
+    db: graph.Graph,
+    org_slug: str,
+    environ: typing.Mapping[str, str] | None = None,
+) -> list[SeededService]:
+    """Seed a service account and credential for each internal service.
+
+    Idempotent: an account that exists is left in place (including a
+    role an operator has since widened, and an ``is_active`` they have
+    since cleared), and an existing credential is never rotated. What
+    the environment supplies is always written, so a values file stays
+    the source of truth for its own secret.
+
+    Args:
+        db: Graph database connection.
+        org_slug: Organization the accounts become members of.
+        environ: Environment to read credentials from. Defaults to
+            ``os.environ``.
+
+    Returns:
+        One :class:`SeededService` per :data:`INTERNAL_SERVICES`, in
+        declaration order.
+
+    Raises:
+        SeedError: A role or the organization is missing, or a supplied
+            credential is malformed.
+
+    """
+    env = os.environ if environ is None else environ
+    results: list[SeededService] = []
+    for service in INTERNAL_SERVICES:
+        created = await _ensure_account(db, service, org_slug)
+        if service.credential == 'client_credential':
+            outcome, emit = await _ensure_client_credential(db, service, env)
+        else:
+            outcome, emit = await _ensure_api_key(db, service, env)
+        LOGGER.info(
+            'Service account %s: account %s, credential %s',
+            service.slug,
+            'created' if created else 'already existed',
+            outcome,
+        )
+        results.append(SeededService(service, created, outcome, emit))
+    return results
+
+
+async def _ensure_account(
+    db: graph.Graph,
+    service: InternalService,
+    org_slug: str,
+) -> bool:
+    """Create the ``ServiceAccount`` node and its membership.
+
+    Returns True when the account was newly created.
+    """
+    existing = await db.match(models.ServiceAccount, {'slug': service.slug})
+    created = not existing
+    if created:
+        await db.create(
+            models.ServiceAccount(
+                slug=service.slug,
+                display_name=service.display_name,
+                description=service.description,
+                is_active=True,
+            )
+        )
+    await _ensure_membership(db, service, org_slug)
+    return created
+
+
+async def _ensure_membership(
+    db: graph.Graph,
+    service: InternalService,
+    org_slug: str,
+) -> None:
+    """Give the account its role in *org_slug*, once.
+
+    The role is set on the edge only when the edge is new. Re-seeding
+    must not undo a role an operator widened deliberately -- silently
+    narrowing a running service's privileges is the kind of failure
+    that surfaces as a 403 in an unrelated scheduled task hours later.
+    """
+    edge = await db.execute(
+        'MATCH (s:ServiceAccount {{slug: {slug}}})'
+        '-[m:MEMBER_OF]->(o:Organization {{slug: {org_slug}}})'
+        ' RETURN m.role AS role',
+        {'slug': service.slug, 'org_slug': org_slug},
+        ['role'],
+    )
+    if edge:
+        return
+    records = await db.execute(
+        'MATCH (s:ServiceAccount {{slug: {slug}}})'
+        ' MATCH (o:Organization {{slug: {org_slug}}})'
+        ' MATCH (r:Role {{slug: {role_slug}}})'
+        ' MERGE (s)-[m:MEMBER_OF]->(o)'
+        ' SET m.role = {role_slug}'
+        ' RETURN m',
+        {
+            'slug': service.slug,
+            'org_slug': org_slug,
+            'role_slug': service.role_slug,
+        },
+        ['m'],
+    )
+    if not records:
+        # Empty result means the MATCH did not bind, so no edge was
+        # written. An account with no membership resolves to an empty
+        # permission set, which reads as a plain 403 at the far end.
+        raise SeedError(
+            f'Cannot grant {service.slug!r} the {service.role_slug!r} '
+            f'role in organization {org_slug!r}: role or organization '
+            f'not found'
+        )
+
+
+async def _ensure_client_credential(
+    db: graph.Graph,
+    service: InternalService,
+    env: typing.Mapping[str, str],
+) -> tuple[Outcome, dict[str, str]]:
+    """Ensure the account owns a usable ``ClientCredential``.
+
+    Both halves are required to adopt an environment-supplied
+    credential: a client id without its secret cannot be verified, and a
+    secret without its id names nothing to verify it against.
+    """
+    id_var = service.client_id_var
+    client_id = env.get(id_var) if id_var else None
+    secret = env.get(service.secret_var)
+    if client_id and secret:
+        await _write_client_credential(db, service, client_id, secret)
+        return 'supplied', {}
+    if await _has_credential(db, service.slug, 'ClientCredential'):
+        return 'unchanged', {}
+    client_id = f'cc_{secrets.token_urlsafe(16)}'
+    secret = secrets.token_urlsafe(32)
+    await _write_client_credential(db, service, client_id, secret)
+    emit = {service.secret_var: secret}
+    if id_var:
+        emit[id_var] = client_id
+    return 'generated', emit
+
+
+async def _write_client_credential(
+    db: graph.Graph,
+    service: InternalService,
+    client_id: str,
+    secret: str,
+) -> None:
+    """Create the credential, or point an existing one at *secret*.
+
+    Rewriting the hash of a credential the environment names is not a
+    rotation: the plaintext the deployment holds is unchanged, and the
+    stored hash is what has to follow it.
+    """
+    secret_hash = await asyncio.to_thread(password.hash_password, secret)
+    updated = await db.execute(
+        'MATCH (c:ClientCredential {{client_id: {client_id}}})'
+        '-[:OWNED_BY]->(s:ServiceAccount {{slug: {slug}}})'
+        ' SET c.client_secret_hash = {secret_hash}, c.revoked = false'
+        ' RETURN c',
+        {
+            'client_id': client_id,
+            'slug': service.slug,
+            'secret_hash': secret_hash,
+        },
+        ['c'],
+    )
+    if updated:
+        return
+    credential = models.ClientCredential(
+        client_id=client_id,
+        client_secret_hash=secret_hash,
+        name=f'{service.display_name} (seeded)',
+        description=(
+            f'Seeded by imbi-api setup for {service.slug}. '
+            f'Supplied via {service.secret_var}.'
+        ),
+    )
+    props = credential.model_dump(mode='json')
+    props.pop('service_account', None)
+    await _create_owned_node(db, 'ClientCredential', props, service.slug)
+
+
+async def _ensure_api_key(
+    db: graph.Graph,
+    service: InternalService,
+    env: typing.Mapping[str, str],
+) -> tuple[Outcome, dict[str, str]]:
+    """Ensure the account owns a usable ``APIKey``."""
+    supplied = env.get(service.secret_var)
+    if supplied:
+        parsed = _parse_api_key(supplied)
+        if parsed is None:
+            raise SeedError(
+                f'{service.secret_var} is not a valid Imbi API key: '
+                f'expected the ik_<id>_<secret> form issued by '
+                f'POST /service-accounts/{service.slug}/api-keys'
+            )
+        key_id, secret = parsed
+        await _write_api_key(db, service, key_id, secret)
+        return 'supplied', {}
+    if await _has_credential(db, service.slug, 'APIKey'):
+        return 'unchanged', {}
+    key_id = f'ik_{secrets.token_hex(16)}'
+    secret = secrets.token_urlsafe(32)
+    await _write_api_key(db, service, key_id, secret)
+    return 'generated', {service.secret_var: f'{key_id}_{secret}'}
+
+
+def _parse_api_key(value: str) -> tuple[str, str] | None:
+    """Split ``ik_<id>_<secret>`` into ``(key_id, secret)``.
+
+    Mirrors the split in ``imbi.common.auth.permissions``
+    ``authenticate_api_key``; anything it would reject at request time
+    is rejected here instead of being seeded and never working.
+    """
+    parts = value.split('_', 2)
+    if len(parts) != 3 or parts[0] != 'ik' or not parts[1] or not parts[2]:
+        return None
+    return f'ik_{parts[1]}', parts[2]
+
+
+async def _write_api_key(
+    db: graph.Graph,
+    service: InternalService,
+    key_id: str,
+    secret: str,
+) -> None:
+    """Create the API key, or point an existing one at *secret*."""
+    key_hash = await asyncio.to_thread(password.hash_password, secret)
+    updated = await db.execute(
+        'MATCH (k:APIKey {{key_id: {key_id}}})'
+        '-[:OWNED_BY]->(s:ServiceAccount {{slug: {slug}}})'
+        ' SET k.key_hash = {key_hash}, k.revoked = false'
+        ' RETURN k',
+        {
+            'key_id': key_id,
+            'slug': service.slug,
+            'key_hash': key_hash,
+        },
+        ['k'],
+    )
+    if updated:
+        return
+    api_key = models.APIKey(
+        key_id=key_id,
+        key_hash=key_hash,
+        name=f'{service.display_name} (seeded)',
+        description=(
+            f'Seeded by imbi-api setup for {service.slug}. '
+            f'Supplied via {service.secret_var}.'
+        ),
+    )
+    props = api_key.model_dump(mode='json')
+    props.pop('user', None)
+    await _create_owned_node(db, 'APIKey', props, service.slug)
+
+
+async def _has_credential(
+    db: graph.Graph,
+    slug: str,
+    label: typing.Literal['ClientCredential', 'APIKey'],
+) -> bool:
+    """Report whether *slug* already owns a live credential.
+
+    Revoked credentials do not count: one left behind by an operator
+    would otherwise suppress seeding forever, leaving the service with
+    nothing it can authenticate with.
+    """
+    records = await db.execute(
+        f'MATCH (c:{label})-[:OWNED_BY]->'
+        '(s:ServiceAccount {{slug: {slug}}})'
+        ' WHERE c.revoked = false'
+        ' RETURN count(c) AS live',
+        {'slug': slug},
+        ['live'],
+    )
+    if not records:
+        return False
+    return bool(graph.parse_agtype(records[0].get('live')))
+
+
+async def _create_owned_node(
+    db: graph.Graph,
+    label: typing.Literal['ClientCredential', 'APIKey'],
+    props: dict[str, typing.Any],
+    slug: str,
+) -> None:
+    """``CREATE`` *label* wired to the ``ServiceAccount`` *slug*."""
+    prop_map = ', '.join(f'{key}: {{{key}}}' for key in props)
+    records = await db.execute(
+        f'MATCH (s:ServiceAccount {{{{slug: {{slug}}}}}})'
+        f' CREATE (n:{label} {{{{{prop_map}}}}})'
+        f'-[:OWNED_BY]->(s) RETURN n',
+        {**props, 'slug': slug},
+        ['n'],
+    )
+    if not records:
+        raise SeedError(
+            f'Cannot create {label} for service account {slug!r}: '
+            f'account not found'
+        )

--- a/apps/api/src/imbi/api/auth/internal_services.py
+++ b/apps/api/src/imbi/api/auth/internal_services.py
@@ -25,6 +25,8 @@ import os
 import secrets
 import typing
 
+import psycopg
+
 from imbi.api import models
 from imbi.api.auth import password
 from imbi.common import graph
@@ -275,22 +277,21 @@ async def _write_client_credential(
     stored hash is what has to follow it.
     """
     secret_hash = await asyncio.to_thread(password.hash_password, secret)
-    await _reject_foreign_owner(
-        db, 'ClientCredential', 'client_id', client_id, service.slug
-    )
-    updated = await db.execute(
+    repoint: typing.LiteralString = (
         'MATCH (c:ClientCredential {{client_id: {client_id}}})'
         '-[:OWNED_BY]->(s:ServiceAccount {{slug: {slug}}})'
         ' SET c.client_secret_hash = {secret_hash}, c.revoked = false'
-        ' RETURN c',
-        {
-            'client_id': client_id,
-            'slug': service.slug,
-            'secret_hash': secret_hash,
-        },
-        ['c'],
+        ' RETURN c'
     )
-    if updated:
+    params = {
+        'client_id': client_id,
+        'slug': service.slug,
+        'secret_hash': secret_hash,
+    }
+    await _reject_foreign_owner(
+        db, 'ClientCredential', 'client_id', client_id, service.slug
+    )
+    if await db.execute(repoint, params, ['c']):
         return
     credential = models.ClientCredential(
         client_id=client_id,
@@ -303,7 +304,20 @@ async def _write_client_credential(
     )
     props = credential.model_dump(mode='json')
     props.pop('service_account', None)
-    await _create_owned_node(db, 'ClientCredential', props, service.slug)
+    try:
+        await _create_owned_node(db, 'ClientCredential', props, service.slug)
+    except psycopg.errors.UniqueViolation:
+        # ``client_id`` carries a unique index (see schemata.toml), so
+        # losing this race means a concurrent setup created the node
+        # first -- two `all`-mode replicas booting together both run
+        # `setup-service-accounts`. Re-point what they created instead
+        # of failing: concurrent runs have to end up as idempotent as
+        # sequential ones.
+        await _reject_foreign_owner(
+            db, 'ClientCredential', 'client_id', client_id, service.slug
+        )
+        if not await db.execute(repoint, params, ['c']):
+            raise
 
 
 async def _ensure_api_key(
@@ -353,20 +367,19 @@ async def _write_api_key(
 ) -> None:
     """Create the API key, or point an existing one at *secret*."""
     key_hash = await asyncio.to_thread(password.hash_password, secret)
-    await _reject_foreign_owner(db, 'APIKey', 'key_id', key_id, service.slug)
-    updated = await db.execute(
+    repoint: typing.LiteralString = (
         'MATCH (k:APIKey {{key_id: {key_id}}})'
         '-[:OWNED_BY]->(s:ServiceAccount {{slug: {slug}}})'
         ' SET k.key_hash = {key_hash}, k.revoked = false'
-        ' RETURN k',
-        {
-            'key_id': key_id,
-            'slug': service.slug,
-            'key_hash': key_hash,
-        },
-        ['k'],
+        ' RETURN k'
     )
-    if updated:
+    params = {
+        'key_id': key_id,
+        'slug': service.slug,
+        'key_hash': key_hash,
+    }
+    await _reject_foreign_owner(db, 'APIKey', 'key_id', key_id, service.slug)
+    if await db.execute(repoint, params, ['k']):
         return
     api_key = models.APIKey(
         key_id=key_id,
@@ -379,7 +392,16 @@ async def _write_api_key(
     )
     props = api_key.model_dump(mode='json')
     props.pop('user', None)
-    await _create_owned_node(db, 'APIKey', props, service.slug)
+    try:
+        await _create_owned_node(db, 'APIKey', props, service.slug)
+    except psycopg.errors.UniqueViolation:
+        # ``key_id`` is uniquely indexed too -- same race, same handling
+        # as the client credential above.
+        await _reject_foreign_owner(
+            db, 'APIKey', 'key_id', key_id, service.slug
+        )
+        if not await db.execute(repoint, params, ['k']):
+            raise
 
 
 async def _reject_foreign_owner(

--- a/apps/api/src/imbi/api/auth/internal_services.py
+++ b/apps/api/src/imbi/api/auth/internal_services.py
@@ -275,6 +275,9 @@ async def _write_client_credential(
     stored hash is what has to follow it.
     """
     secret_hash = await asyncio.to_thread(password.hash_password, secret)
+    await _reject_foreign_owner(
+        db, 'ClientCredential', 'client_id', client_id, service.slug
+    )
     updated = await db.execute(
         'MATCH (c:ClientCredential {{client_id: {client_id}}})'
         '-[:OWNED_BY]->(s:ServiceAccount {{slug: {slug}}})'
@@ -350,6 +353,7 @@ async def _write_api_key(
 ) -> None:
     """Create the API key, or point an existing one at *secret*."""
     key_hash = await asyncio.to_thread(password.hash_password, secret)
+    await _reject_foreign_owner(db, 'APIKey', 'key_id', key_id, service.slug)
     updated = await db.execute(
         'MATCH (k:APIKey {{key_id: {key_id}}})'
         '-[:OWNED_BY]->(s:ServiceAccount {{slug: {slug}}})'
@@ -376,6 +380,48 @@ async def _write_api_key(
     props = api_key.model_dump(mode='json')
     props.pop('user', None)
     await _create_owned_node(db, 'APIKey', props, service.slug)
+
+
+async def _reject_foreign_owner(
+    db: graph.Graph,
+    label: typing.Literal['ClientCredential', 'APIKey'],
+    id_field: typing.Literal['client_id', 'key_id'],
+    identifier: str,
+    slug: str,
+) -> None:
+    """Fail when *identifier* already belongs to a different account.
+
+    The write helpers re-point an existing credential through an
+    owner-scoped ``MATCH``, which does not bind when the credential
+    belongs to someone else -- so without this they would fall through
+    and ``CREATE`` a second node carrying the same identifier. Nothing in
+    the graph enforces uniqueness, and the token grant in
+    ``endpoints/auth.py`` matches a ``client_id`` with no owner
+    constraint and takes the first row, so a duplicate makes *which*
+    account authenticates a matter of row order.
+
+    Reachable because both identifiers can be operator-supplied: naming
+    one that a human-created service account already holds would
+    otherwise be silently accepted.
+    """
+    records = await db.execute(
+        f'MATCH (c:{label} {{{{{id_field}: {{identifier}}}}}})'
+        '-[:OWNED_BY]->(s:ServiceAccount)'
+        ' WHERE s.slug <> {slug}'
+        ' RETURN s.slug AS owner',
+        {'identifier': identifier, 'slug': slug},
+        ['owner'],
+    )
+    if not records:
+        return
+    owner = graph.parse_agtype(records[0].get('owner'))
+    raise SeedError(
+        f'{label} {identifier!r} already belongs to service account '
+        f'{str(owner)!r}, not {slug!r}. Seeding it would create a second '
+        f'credential with the same identifier, and authentication does '
+        f'not distinguish them. Use a different value or remove the '
+        f'existing credential.'
+    )
 
 
 async def _has_credential(

--- a/apps/api/src/imbi/api/auth/internal_services.py
+++ b/apps/api/src/imbi/api/auth/internal_services.py
@@ -228,7 +228,11 @@ async def _ensure_client_credential(
 
     Both halves are required to adopt an environment-supplied
     credential: a client id without its secret cannot be verified, and a
-    secret without its id names nothing to verify it against.
+    secret without its id names nothing to verify it against. Half of one
+    raises rather than falling through to generation -- the deployment
+    holds a value it means to be in use, and quietly seeding a different
+    credential instead would start the service with one that
+    authenticates nobody.
     """
     id_var = service.client_id_var
     client_id = env.get(id_var) if id_var else None
@@ -236,6 +240,17 @@ async def _ensure_client_credential(
     if client_id and secret:
         await _write_client_credential(db, service, client_id, secret)
         return 'supplied', {}
+    if client_id or secret:
+        present, missing = (
+            (id_var, service.secret_var)
+            if client_id
+            else (service.secret_var, id_var)
+        )
+        raise SeedError(
+            f'{present} is set but {missing} is not: a client credential '
+            f'for {service.slug!r} needs both halves. Set {missing}, or '
+            f'unset {present} to have one generated.'
+        )
     if await _has_credential(db, service.slug, 'ClientCredential'):
         return 'unchanged', {}
     client_id = f'cc_{secrets.token_urlsafe(16)}'
@@ -373,11 +388,17 @@ async def _has_credential(
     Revoked credentials do not count: one left behind by an operator
     would otherwise suppress seeding forever, leaving the service with
     nothing it can authenticate with.
+
+    ``coalesce`` because a bare ``c.revoked = false`` is null, not true,
+    on a node predating the property -- and this is the query that
+    decides whether to mint. Reading a live credential as missing would
+    make every run add another and print another secret while the one in
+    use stays active, which is the opposite of idempotent.
     """
     records = await db.execute(
         f'MATCH (c:{label})-[:OWNED_BY]->'
         '(s:ServiceAccount {{slug: {slug}}})'
-        ' WHERE c.revoked = false'
+        ' WHERE coalesce(c.revoked, false) = false'
         ' RETURN count(c) AS live',
         {'slug': slug},
         ['live'],

--- a/apps/api/src/imbi/api/auth/seed.py
+++ b/apps/api/src/imbi/api/auth/seed.py
@@ -675,6 +675,64 @@ DEFAULT_ROLES: list[tuple[str, str, str, int, list[str], bool]] = [
         ],
         False,
     ),
+    # Roles for the service accounts Imbi's own services authenticate as
+    # (see :mod:`imbi.api.auth.internal_services`). Each grants only what
+    # its service calls, so a compromised internal credential is not a
+    # general-purpose one. Priority sits above `developer` because these
+    # are infrastructure principals, not people, and neither is
+    # `is_default` -- they are attached by the seed, never on first login.
+    (
+        'imbi-scheduler',
+        'Imbi Scheduler',
+        'Service role for imbi-scheduler: manage and fire scheduled '
+        'tasks, and read the entities a task inspects',
+        900,
+        [
+            'scheduled_task:read',
+            'scheduled_task:create',
+            'scheduled_task:write',
+            'scheduled_task:delete',
+            'scheduled_task:run',
+            # `system` tasks belong to no user, so firing and managing
+            # them is an :admin operation by definition.
+            'scheduled_task:admin',
+            'blueprint:read',
+            'document:read',
+            'document_template:read',
+            'environment:read',
+            'link_definition:read',
+            'operations_log:read',
+            'organization:read',
+            'project:read',
+            'project_type:read',
+            'role:read',
+            'search:read',
+            'tag:read',
+            'team:read',
+            'integration:read',
+            'upload:read',
+            'user:read',
+            'webhook:read',
+        ],
+        False,
+    ),
+    (
+        'imbi-gateway',
+        'Imbi Gateway',
+        'Service role for imbi-gateway: patch projects, record '
+        'releases, and attribute events to users',
+        900,
+        [
+            # `project:write` covers releases and SBOMs too -- every
+            # write endpoint imbi-gateway calls guards on it.
+            'project:read',
+            'project:write',
+            # /users/by-identity, used to attribute an inbound event to
+            # the Imbi user behind an external identity.
+            'user:read',
+        ],
+        False,
+    ),
 ]
 
 # Invariant: exactly one seeded role is the auto-assignment target so
@@ -759,12 +817,20 @@ async def seed_permissions(db: graph.Graph) -> int:
 
 
 async def seed_default_roles(db: graph.Graph) -> int:
-    """Seed default roles and GRANTS edges in a single batched query.
+    """Seed default roles, then their GRANTS edges.
 
-    Must run after ``seed_permissions``: the second UNWIND below does a
+    Must run after ``seed_permissions``: the grant query below does a
     ``MATCH (gp:Permission {{name: grant.perm}})`` that will silently
     produce no GRANTS edges if any referenced permission is missing.
     ``bootstrap_auth_system`` enforces this ordering.
+
+    The grants are a *second* statement, not a trailing ``UNWIND`` on the
+    role query. Appending ``RETURN created LIMIT 1`` to that pipeline made
+    AGE stop pulling rows after the first one, so exactly one GRANTS edge
+    was ever written -- every seeded role came up with no permissions at
+    all, and every principal holding one resolved an empty permission set.
+    The count aggregate in the grant query forces the whole UNWIND to be
+    consumed instead.
     """
     role_maps: list[str] = []
     grant_maps: list[str] = []
@@ -803,20 +869,32 @@ async def seed_default_roles(db: graph.Graph) -> int:
         'r.priority = role.priority, '
         'r.is_default = role.is_default, '
         'r.is_system = true '
-        'WITH sum(CASE WHEN existing IS NULL THEN 1 ELSE 0 END) '
-        'AS created '
-        'UNWIND [' + ', '.join(grant_maps) + '] AS grant '
-        'MATCH (gr:Role {{slug: grant.slug}}), '
-        '(gp:Permission {{name: grant.perm}}) '
-        'MERGE (gr)-[:GRANTS]->(gp) '
-        'RETURN created LIMIT 1'
+        'RETURN sum(CASE WHEN existing IS NULL THEN 1 ELSE 0 END) '
+        'AS created'
     )
     records = await db.execute(query, params, columns=['created'])
     created_count = 0
     if records:
         raw = graph.parse_agtype(records[0].get('created'))
         created_count = int(raw or 0)
-    LOGGER.info('Seeded %d default roles', created_count)
+
+    grant_query: str = (
+        'UNWIND [' + ', '.join(grant_maps) + '] AS grant '
+        'MATCH (gr:Role {{slug: grant.slug}}) '
+        'MATCH (gp:Permission {{name: grant.perm}}) '
+        'MERGE (gr)-[:GRANTS]->(gp) '
+        'RETURN count(gp) AS granted'
+    )
+    grant_records = await db.execute(grant_query, params, columns=['granted'])
+    granted = 0
+    if grant_records:
+        raw = graph.parse_agtype(grant_records[0].get('granted'))
+        granted = int(raw or 0)
+    LOGGER.info(
+        'Seeded %d default roles with %d permission grants',
+        created_count,
+        granted,
+    )
     return created_count
 
 

--- a/apps/api/src/imbi/api/entrypoint.py
+++ b/apps/api/src/imbi/api/entrypoint.py
@@ -7,8 +7,8 @@ import nanoid
 import typer
 
 from imbi.api import models
+from imbi.api.auth import internal_services, seed
 from imbi.api.auth import password as password_auth
-from imbi.api.auth import seed
 from imbi.api.graph_sql import set_clause
 from imbi.common import clickhouse, graph, server
 
@@ -82,7 +82,7 @@ def setup_clickhouse() -> None:
     """Apply the ClickHouse schema without running the full setup.
 
     Executes the enabled DDL from the packaged ``schemata.toml`` — the
-    same work as step 3 of ``setup`` — so a deployment that adds tables
+    same work as the last step of ``setup`` — so a deployment that adds tables
     or materialized views can roll them out without re-seeding auth or
     re-prompting for an admin user. Idempotent.
     """
@@ -162,6 +162,116 @@ async def _setup_permissions_async() -> None:
     typer.echo('\n✓ Permissions and roles are up to date')
 
 
+@main.command('setup-service-accounts')
+def setup_service_accounts(
+    organization: typing.Annotated[
+        str | None,
+        typer.Option(
+            help=(
+                'Organization the service accounts join. Defaults to the '
+                'only organization when there is exactly one.'
+            ),
+        ),
+    ] = None,
+) -> None:
+    """Seed the service accounts imbi-scheduler and imbi-gateway use.
+
+    The credential-seeding half of ``setup``, for an install that was
+    set up before it existed. Requires ``setup-permissions`` to have run
+    first: each account is granted a seeded role by name. Idempotent —
+    an existing credential is never rotated.
+    """
+    asyncio.run(_setup_service_accounts_async(organization))
+
+
+async def _setup_service_accounts_async(org_slug: str | None) -> None:
+    """Async body of ``setup-service-accounts``."""
+    db = graph.Graph()
+    try:
+        await db.open()
+    except Exception as e:
+        typer.echo(f'✗ Failed to connect to PostgreSQL: {e}', err=True)
+        raise typer.Exit(code=1) from e
+
+    try:
+        if org_slug is None:
+            org_slug = await _sole_organization_slug(db)
+        results = await internal_services.seed_internal_services(db, org_slug)
+    except internal_services.SeedError as e:
+        typer.echo(f'✗ {e}', err=True)
+        raise typer.Exit(code=1) from e
+    except typer.Exit:
+        # `_sole_organization_slug` has already reported the problem;
+        # `typer.Exit` is a `RuntimeError`, so without this the generic
+        # handler below would bury that message under its own.
+        raise
+    except Exception as e:
+        typer.echo(f'✗ Failed to seed service accounts: {e}', err=True)
+        raise typer.Exit(code=1) from e
+    finally:
+        await db.close()
+
+    _report_service_accounts(results)
+
+
+async def _sole_organization_slug(db: graph.Graph) -> str:
+    """Return the only organization's slug.
+
+    Raises ``typer.Exit`` when there is not exactly one: guessing which
+    organization owns the internal service accounts would put them in a
+    tenant whose projects they were never meant to touch.
+    """
+    records = await db.execute(
+        'MATCH (o:Organization) RETURN o.slug AS slug ORDER BY o.slug',
+        columns=['slug'],
+    )
+    slugs = [graph.parse_agtype(record['slug']) for record in records]
+    if len(slugs) == 1:
+        return str(slugs[0])
+    if not slugs:
+        typer.echo(
+            '✗ No organization exists yet. Run `imbi-api setup` first.',
+            err=True,
+        )
+        raise typer.Exit(code=1)
+    typer.echo(
+        '✗ Multiple organizations exist; pass --organization with one of: '
+        + ', '.join(str(slug) for slug in slugs),
+        err=True,
+    )
+    raise typer.Exit(code=1)
+
+
+def _report_service_accounts(
+    results: list[internal_services.SeededService],
+) -> None:
+    """Print what was seeded, emitting generated credentials once.
+
+    A generated secret is unrecoverable after this, so it is printed as
+    an assignment a deployment can paste straight into its environment
+    rather than described in prose.
+    """
+    emit: dict[str, str] = {}
+    for result in results:
+        account = 'created' if result.account_created else 'already exists'
+        if result.outcome == 'supplied':
+            detail = f'credential matches ${result.service.secret_var}'
+        elif result.outcome == 'unchanged':
+            detail = 'existing credential left in place'
+        else:
+            detail = 'credential generated (shown once below)'
+            emit.update(result.env)
+        typer.echo(f'  ✓ {result.service.slug}: {account}, {detail}')
+    if not emit:
+        return
+    typer.echo(
+        '\n  Set these before starting the services — the secrets cannot '
+        'be read back:'
+    )
+    for name, value in emit.items():
+        typer.echo(f'    {name}={value}')
+
+
 @main.command()
 def setup() -> None:
     """
@@ -170,6 +280,8 @@ def setup() -> None:
     This command sets up a new Imbi instance by:
     1. Seeding permissions and default roles (admin, developer, readonly)
     2. Creating the initial admin user with interactive prompts
+    3. Seeding the service accounts imbi-scheduler and imbi-gateway
+       authenticate to imbi-api as
 
     Run this command once when setting up a new Imbi instance.
     """
@@ -285,8 +397,19 @@ async def _setup_async() -> None:
             typer.echo(f'✗ Failed to create admin user: {e}', err=True)
             raise typer.Exit(code=1) from e
 
-        # Step 3: Set up ClickHouse schema
-        typer.echo('\nStep 3: Setting up ClickHouse schema...')
+        # Step 3: Seed the service accounts Imbi's own services use
+        typer.echo('\nStep 3: Seeding internal service accounts...')
+        try:
+            seeded = await internal_services.seed_internal_services(
+                db, org_slug
+            )
+        except internal_services.SeedError as e:
+            typer.echo(f'✗ {e}', err=True)
+            raise typer.Exit(code=1) from e
+        _report_service_accounts(seeded)
+
+        # Step 4: Set up ClickHouse schema
+        typer.echo('\nStep 4: Setting up ClickHouse schema...')
         await _apply_clickhouse_schema()
 
         # Success message

--- a/apps/api/src/imbi/api/entrypoint.py
+++ b/apps/api/src/imbi/api/entrypoint.py
@@ -282,6 +282,7 @@ def setup() -> None:
     2. Creating the initial admin user with interactive prompts
     3. Seeding the service accounts imbi-scheduler and imbi-gateway
        authenticate to imbi-api as
+    4. Applying the ClickHouse schema
 
     Run this command once when setting up a new Imbi instance.
     """

--- a/apps/api/src/imbi/api/entrypoint.py
+++ b/apps/api/src/imbi/api/entrypoint.py
@@ -406,6 +406,9 @@ async def _setup_async() -> None:
         except internal_services.SeedError as e:
             typer.echo(f'✗ {e}', err=True)
             raise typer.Exit(code=1) from e
+        except Exception as e:
+            typer.echo(f'✗ Failed to seed service accounts: {e}', err=True)
+            raise typer.Exit(code=1) from e
         _report_service_accounts(seeded)
 
         # Step 4: Set up ClickHouse schema

--- a/apps/api/tests/auth/test_internal_services.py
+++ b/apps/api/tests/auth/test_internal_services.py
@@ -1,0 +1,364 @@
+"""Tests for internal service account seeding."""
+
+import typing
+import unittest
+from unittest import mock
+
+from imbi.api.auth import internal_services
+
+SCHEDULER = internal_services.INTERNAL_SERVICES[0]
+GATEWAY = internal_services.INTERNAL_SERVICES[1]
+
+
+class FakeGraph:
+    """A ``graph.Graph`` stand-in that answers queries by substring.
+
+    The seeding path issues several distinct queries per service, so a
+    single ``return_value`` cannot express "the membership edge is
+    missing but the role exists". Responses are matched against the
+    Cypher text in insertion order, and every query is recorded so a
+    test can assert what was *not* issued.
+    """
+
+    def __init__(self, responses: dict[str, list[dict[str, object]]]) -> None:
+        self._responses = responses
+        self.queries: list[str] = []
+        self.created: list[object] = []
+        self.matched: list[dict[str, typing.Any] | None] = []
+        self.match_result: list[object] = []
+
+    async def execute(
+        self,
+        query: str,
+        params: dict[str, typing.Any] | None = None,
+        columns: list[str] | None = None,
+    ) -> list[dict[str, object]]:
+        self.queries.append(query)
+        for fragment, response in self._responses.items():
+            if fragment in query:
+                return response
+        if 'CREATE (n:' in query:
+            # A CREATE against an existing account always returns its
+            # row; an empty result there means "account not found",
+            # which is a different test's business.
+            return [{'n': 'created'}]
+        return []
+
+    async def match(
+        self,
+        node_type: type,
+        params: dict[str, typing.Any] | None = None,
+        order_by: str | None = None,
+    ) -> list[object]:
+        self.matched.append(params)
+        return self.match_result
+
+    async def create(self, node: object) -> object:
+        self.created.append(node)
+        return node
+
+    def issued(self, fragment: str) -> list[str]:
+        """Return the recorded queries containing *fragment*."""
+        return [query for query in self.queries if fragment in query]
+
+
+class InternalServiceSeedTestCase(unittest.IsolatedAsyncioTestCase):
+    """Behavior shared by both internal services."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        # Argon2 is deliberately slow; the hash's content is irrelevant
+        # here, only that it reaches the query.
+        self.enterContext(
+            mock.patch.object(
+                internal_services.password,
+                'hash_password',
+                side_effect=lambda secret: f'hashed:{secret}',
+            )
+        )
+        self.enterContext(
+            mock.patch(
+                'imbi.common.graph.parse_agtype',
+                side_effect=lambda value: value,
+            )
+        )
+
+    async def test_accounts_and_memberships_created(self) -> None:
+        """A fresh install creates both accounts and both memberships."""
+        db = FakeGraph({'MERGE (s)-[m:MEMBER_OF]->(o)': [{'m': 'edge'}]})
+
+        results = await internal_services.seed_internal_services(
+            db, 'aweber', {}
+        )
+
+        self.assertEqual(len(results), 2)
+        self.assertEqual(
+            [result.service.slug for result in results],
+            ['imbi-scheduler', 'imbi-gateway'],
+        )
+        self.assertTrue(all(result.account_created for result in results))
+        self.assertEqual(
+            [node.slug for node in db.created],  # pyright: ignore[reportAttributeAccessIssue]
+            ['imbi-scheduler', 'imbi-gateway'],
+        )
+        self.assertEqual(len(db.issued('MERGE (s)-[m:MEMBER_OF]->(o)')), 2)
+
+    async def test_existing_membership_is_left_alone(self) -> None:
+        """A role an operator widened is not reset to the seeded one."""
+        db = FakeGraph({'RETURN m.role AS role': [{'role': 'admin'}]})
+
+        await internal_services.seed_internal_services(db, 'aweber', {})
+
+        self.assertEqual(db.issued('MERGE (s)-[m:MEMBER_OF]->(o)'), [])
+
+    async def test_missing_role_raises(self) -> None:
+        """A role the seed has not created yet fails loudly."""
+        db = FakeGraph({})
+
+        with self.assertRaises(internal_services.SeedError) as ctx:
+            await internal_services.seed_internal_services(db, 'aweber', {})
+
+        self.assertIn('imbi-scheduler', str(ctx.exception))
+        self.assertIn('role or organization not found', str(ctx.exception))
+
+    async def test_existing_account_is_not_recreated(self) -> None:
+        """An account already present is not written again."""
+        db = FakeGraph({'MERGE (s)-[m:MEMBER_OF]->(o)': [{'m': 'edge'}]})
+        db.match_result = [object()]
+
+        results = await internal_services.seed_internal_services(
+            db, 'aweber', {}
+        )
+
+        self.assertFalse(any(result.account_created for result in results))
+        self.assertEqual(db.created, [])
+
+
+class ClientCredentialTestCase(unittest.IsolatedAsyncioTestCase):
+    """Credential handling for imbi-scheduler."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.enterContext(
+            mock.patch.object(
+                internal_services.password,
+                'hash_password',
+                side_effect=lambda secret: f'hashed:{secret}',
+            )
+        )
+        self.enterContext(
+            mock.patch(
+                'imbi.common.graph.parse_agtype',
+                side_effect=lambda value: value,
+            )
+        )
+
+    async def test_environment_value_is_written(self) -> None:
+        """A supplied credential is created with the supplied client id."""
+        db = FakeGraph({'MERGE (s)-[m:MEMBER_OF]->(o)': [{'m': 'edge'}]})
+
+        outcome, emit = await internal_services._ensure_client_credential(
+            db,
+            SCHEDULER,
+            {
+                'IMBI_SCHEDULER_SA_CLIENT_ID': 'cc_supplied',
+                'IMBI_SCHEDULER_SA_CLIENT_SECRET': 'shhh',
+            },
+        )
+
+        self.assertEqual(outcome, 'supplied')
+        self.assertEqual(emit, {})
+        self.assertEqual(len(db.issued('CREATE (n:ClientCredential')), 1)
+
+    async def test_environment_value_repoints_existing(self) -> None:
+        """A credential the environment names has its hash rewritten."""
+        db = FakeGraph({'SET c.client_secret_hash': [{'c': 'credential'}]})
+
+        outcome, emit = await internal_services._ensure_client_credential(
+            db,
+            SCHEDULER,
+            {
+                'IMBI_SCHEDULER_SA_CLIENT_ID': 'cc_supplied',
+                'IMBI_SCHEDULER_SA_CLIENT_SECRET': 'shhh',
+            },
+        )
+
+        self.assertEqual(outcome, 'supplied')
+        self.assertEqual(db.issued('CREATE (n:ClientCredential'), [])
+
+    async def test_existing_credential_is_not_rotated(self) -> None:
+        """Re-seeding leaves a live credential exactly as it was."""
+        db = FakeGraph({'RETURN count(c) AS live': [{'live': 1}]})
+
+        outcome, emit = await internal_services._ensure_client_credential(
+            db, SCHEDULER, {}
+        )
+
+        self.assertEqual(outcome, 'unchanged')
+        self.assertEqual(emit, {})
+        self.assertEqual(db.issued('CREATE (n:ClientCredential'), [])
+        self.assertEqual(db.issued('SET c.client_secret_hash'), [])
+
+    async def test_revoked_credential_does_not_suppress_seeding(self) -> None:
+        """A revoked credential is not a credential."""
+        db = FakeGraph({'RETURN count(c) AS live': [{'live': 0}]})
+
+        outcome, _emit = await internal_services._ensure_client_credential(
+            db, SCHEDULER, {}
+        )
+
+        self.assertEqual(outcome, 'generated')
+
+    async def test_generated_credential_is_emitted(self) -> None:
+        """Nothing supplied and nothing stored mints a printable pair."""
+        db = FakeGraph({})
+
+        outcome, emit = await internal_services._ensure_client_credential(
+            db, SCHEDULER, {}
+        )
+
+        self.assertEqual(outcome, 'generated')
+        self.assertEqual(
+            sorted(emit),
+            [
+                'IMBI_SCHEDULER_SA_CLIENT_ID',
+                'IMBI_SCHEDULER_SA_CLIENT_SECRET',
+            ],
+        )
+        self.assertTrue(
+            emit['IMBI_SCHEDULER_SA_CLIENT_ID'].startswith('cc_'),
+        )
+        self.assertEqual(len(db.issued('CREATE (n:ClientCredential')), 1)
+
+
+class ApiKeyTestCase(unittest.IsolatedAsyncioTestCase):
+    """Credential handling for imbi-gateway."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.enterContext(
+            mock.patch.object(
+                internal_services.password,
+                'hash_password',
+                side_effect=lambda secret: f'hashed:{secret}',
+            )
+        )
+        self.enterContext(
+            mock.patch(
+                'imbi.common.graph.parse_agtype',
+                side_effect=lambda value: value,
+            )
+        )
+
+    async def test_supplied_key_is_written(self) -> None:
+        """The ik_<id>_<secret> form is split the way auth splits it."""
+        db = FakeGraph({})
+
+        outcome, emit = await internal_services._ensure_api_key(
+            db, GATEWAY, {'ACTIONS_IMBI_TOKEN': 'ik_abc123_s3cret_value'}
+        )
+
+        self.assertEqual(outcome, 'supplied')
+        self.assertEqual(emit, {})
+        created = db.issued('CREATE (n:APIKey')
+        self.assertEqual(len(created), 1)
+
+    async def test_malformed_key_raises(self) -> None:
+        """A token no request could authenticate is refused at seed time."""
+        db = FakeGraph({})
+
+        with self.assertRaises(internal_services.SeedError) as ctx:
+            await internal_services._ensure_api_key(
+                db, GATEWAY, {'ACTIONS_IMBI_TOKEN': 'not-an-imbi-key'}
+            )
+
+        self.assertIn('ACTIONS_IMBI_TOKEN', str(ctx.exception))
+
+    async def test_generated_key_is_emitted_whole(self) -> None:
+        """The emitted value is the full key, not just its secret half."""
+        db = FakeGraph({})
+
+        outcome, emit = await internal_services._ensure_api_key(
+            db, GATEWAY, {}
+        )
+
+        self.assertEqual(outcome, 'generated')
+        self.assertTrue(emit['ACTIONS_IMBI_TOKEN'].startswith('ik_'))
+        self.assertIsNotNone(
+            internal_services._parse_api_key(emit['ACTIONS_IMBI_TOKEN']),
+        )
+
+    async def test_supplied_key_repoints_existing(self) -> None:
+        """A key the environment names has its hash rewritten."""
+        db = FakeGraph({'SET k.key_hash': [{'k': 'key'}]})
+
+        outcome, _emit = await internal_services._ensure_api_key(
+            db, GATEWAY, {'ACTIONS_IMBI_TOKEN': 'ik_abc123_s3cret'}
+        )
+
+        self.assertEqual(outcome, 'supplied')
+        self.assertEqual(db.issued('CREATE (n:APIKey'), [])
+
+    async def test_missing_account_raises(self) -> None:
+        """A credential cannot be wired to an account that is not there."""
+        db = FakeGraph({'CREATE (n:APIKey': []})
+
+        with self.assertRaises(internal_services.SeedError) as ctx:
+            await internal_services._ensure_api_key(
+                db, GATEWAY, {'ACTIONS_IMBI_TOKEN': 'ik_abc123_s3cret'}
+            )
+
+        self.assertIn('imbi-gateway', str(ctx.exception))
+
+    async def test_existing_key_is_not_rotated(self) -> None:
+        """Re-seeding leaves a live API key exactly as it was."""
+        db = FakeGraph({'RETURN count(c) AS live': [{'live': 1}]})
+
+        outcome, emit = await internal_services._ensure_api_key(
+            db, GATEWAY, {}
+        )
+
+        self.assertEqual(outcome, 'unchanged')
+        self.assertEqual(emit, {})
+        self.assertEqual(db.issued('CREATE (n:APIKey'), [])
+
+
+class ParseApiKeyTestCase(unittest.TestCase):
+    """``_parse_api_key`` accepts exactly what authentication accepts."""
+
+    def test_valid_key(self) -> None:
+        self.assertEqual(
+            internal_services._parse_api_key('ik_abcd_secret_with_underscore'),
+            ('ik_abcd', 'secret_with_underscore'),
+        )
+
+    def test_rejected_forms(self) -> None:
+        for value in ('', 'ik', 'ik_abcd', 'xx_abcd_secret', 'ik__secret'):
+            with self.subTest(value=value):
+                self.assertIsNone(internal_services._parse_api_key(value))
+
+
+class InternalServiceTableTestCase(unittest.TestCase):
+    """Invariants of the :data:`INTERNAL_SERVICES` table."""
+
+    def test_client_id_var_present_for_client_credentials(self) -> None:
+        """Only API keys may omit ``client_id_var``.
+
+        ``_ensure_client_credential`` reads it unconditionally, so a
+        client-credential entry without one would fail at seed time.
+        """
+        for service in internal_services.INTERNAL_SERVICES:
+            with self.subTest(service=service.slug):
+                if service.credential == 'client_credential':
+                    self.assertIsNotNone(service.client_id_var)
+                else:
+                    self.assertIsNone(service.client_id_var)
+
+    def test_roles_are_seeded(self) -> None:
+        """Every role named here is one ``seed_default_roles`` creates."""
+        from imbi.api.auth import seed
+
+        seeded = {role[0] for role in seed.DEFAULT_ROLES}
+        for service in internal_services.INTERNAL_SERVICES:
+            with self.subTest(service=service.slug):
+                self.assertIn(service.role_slug, seeded)

--- a/apps/api/tests/auth/test_internal_services.py
+++ b/apps/api/tests/auth/test_internal_services.py
@@ -186,6 +186,32 @@ class ClientCredentialTestCase(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(outcome, 'supplied')
         self.assertEqual(db.issued('CREATE (n:ClientCredential'), [])
 
+    async def test_client_id_owned_by_another_account_raises(self) -> None:
+        """A supplied client id another account holds is not duplicated.
+
+        The owner-scoped re-point MATCH would not bind, so seeding would
+        CREATE a second node with the same client_id. Nothing enforces
+        uniqueness and the token grant matches client_id without an owner
+        constraint, so which account authenticates would come down to row
+        order.
+        """
+        db = FakeGraph({'RETURN s.slug AS owner': [{'owner': 'someone-else'}]})
+
+        with self.assertRaises(internal_services.SeedError) as ctx:
+            await internal_services._ensure_client_credential(
+                db,
+                SCHEDULER,
+                {
+                    'IMBI_SCHEDULER_SA_CLIENT_ID': 'cc_taken',
+                    'IMBI_SCHEDULER_SA_CLIENT_SECRET': 'shhh',
+                },
+            )
+
+        self.assertIn('someone-else', str(ctx.exception))
+        self.assertIn('cc_taken', str(ctx.exception))
+        self.assertEqual(db.issued('CREATE (n:ClientCredential'), [])
+        self.assertEqual(db.issued('SET c.client_secret_hash'), [])
+
     async def test_existing_credential_is_not_rotated(self) -> None:
         """Re-seeding leaves a live credential exactly as it was."""
         db = FakeGraph({'RETURN count(c) AS live': [{'live': 1}]})
@@ -309,6 +335,20 @@ class ApiKeyTestCase(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(emit, {})
         created = db.issued('CREATE (n:APIKey')
         self.assertEqual(len(created), 1)
+
+    async def test_key_id_owned_by_another_account_raises(self) -> None:
+        """A supplied key id another account holds is not duplicated."""
+        db = FakeGraph({'RETURN s.slug AS owner': [{'owner': 'someone-else'}]})
+
+        with self.assertRaises(internal_services.SeedError) as ctx:
+            await internal_services._ensure_api_key(
+                db, GATEWAY, {'ACTIONS_IMBI_TOKEN': 'ik_taken_s3cret'}
+            )
+
+        self.assertIn('someone-else', str(ctx.exception))
+        self.assertIn('ik_taken', str(ctx.exception))
+        self.assertEqual(db.issued('CREATE (n:APIKey'), [])
+        self.assertEqual(db.issued('SET k.key_hash'), [])
 
     async def test_malformed_key_raises(self) -> None:
         """A token no request could authenticate is refused at seed time."""

--- a/apps/api/tests/auth/test_internal_services.py
+++ b/apps/api/tests/auth/test_internal_services.py
@@ -174,7 +174,7 @@ class ClientCredentialTestCase(unittest.IsolatedAsyncioTestCase):
         """A credential the environment names has its hash rewritten."""
         db = FakeGraph({'SET c.client_secret_hash': [{'c': 'credential'}]})
 
-        outcome, emit = await internal_services._ensure_client_credential(
+        outcome, _emit = await internal_services._ensure_client_credential(
             db,
             SCHEDULER,
             {
@@ -209,6 +209,24 @@ class ClientCredentialTestCase(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(outcome, 'generated')
 
+    async def test_live_check_tolerates_a_missing_revoked_property(
+        self,
+    ) -> None:
+        """The liveness filter coalesces rather than comparing to null.
+
+        ``c.revoked = false`` is null on a node predating the property,
+        so a live credential would read as missing and every run would
+        mint another one and print another secret.
+        """
+        db = FakeGraph({'RETURN count(c) AS live': [{'live': 1}]})
+
+        await internal_services._ensure_client_credential(db, SCHEDULER, {})
+
+        self.assertIn(
+            'coalesce(c.revoked, false) = false',
+            db.issued('RETURN count(c) AS live')[0],
+        )
+
     async def test_generated_credential_is_emitted(self) -> None:
         """Nothing supplied and nothing stored mints a printable pair."""
         db = FakeGraph({})
@@ -229,6 +247,35 @@ class ClientCredentialTestCase(unittest.IsolatedAsyncioTestCase):
             emit['IMBI_SCHEDULER_SA_CLIENT_ID'].startswith('cc_'),
         )
         self.assertEqual(len(db.issued('CREATE (n:ClientCredential')), 1)
+
+    async def test_client_id_without_secret_raises(self) -> None:
+        """Half a supplied credential fails loudly, seeding nothing.
+
+        Generating a different pair instead would leave the deployment
+        holding a client id whose secret the database has never seen, so
+        the service starts and authenticates nobody.
+        """
+        db = FakeGraph({})
+
+        with self.assertRaises(internal_services.SeedError) as ctx:
+            await internal_services._ensure_client_credential(
+                db, SCHEDULER, {'IMBI_SCHEDULER_SA_CLIENT_ID': 'cc_supplied'}
+            )
+
+        self.assertIn('IMBI_SCHEDULER_SA_CLIENT_SECRET', str(ctx.exception))
+        self.assertEqual(db.issued('CREATE (n:ClientCredential'), [])
+
+    async def test_secret_without_client_id_raises(self) -> None:
+        """The mirror case: a secret naming nothing to verify it."""
+        db = FakeGraph({})
+
+        with self.assertRaises(internal_services.SeedError) as ctx:
+            await internal_services._ensure_client_credential(
+                db, SCHEDULER, {'IMBI_SCHEDULER_SA_CLIENT_SECRET': 'shhh'}
+            )
+
+        self.assertIn('IMBI_SCHEDULER_SA_CLIENT_ID', str(ctx.exception))
+        self.assertEqual(db.issued('CREATE (n:ClientCredential'), [])
 
 
 class ApiKeyTestCase(unittest.IsolatedAsyncioTestCase):

--- a/apps/api/tests/auth/test_internal_services.py
+++ b/apps/api/tests/auth/test_internal_services.py
@@ -4,6 +4,8 @@ import typing
 import unittest
 from unittest import mock
 
+import psycopg
+
 from imbi.api.auth import internal_services
 
 SCHEDULER = internal_services.INTERNAL_SERVICES[0]
@@ -60,6 +62,38 @@ class FakeGraph:
     def issued(self, fragment: str) -> list[str]:
         """Return the recorded queries containing *fragment*."""
         return [query for query in self.queries if fragment in query]
+
+
+class RacingGraph(FakeGraph):
+    """A graph where a concurrent writer wins the ``CREATE``.
+
+    Two ``all``-mode replicas booting together both run
+    ``setup-service-accounts``, so both can pass the foreign-owner check
+    before either writes. The identifier is uniquely indexed, so the
+    loser's ``CREATE`` raises rather than duplicating: the re-point finds
+    nothing on the first pass, the ``CREATE`` raises the way a lost race
+    does, and the re-point then finds what the winner created.
+    """
+
+    def __init__(self, repoint: str, create: str) -> None:
+        super().__init__({})
+        self._repoint = repoint
+        self._create = create
+        self.lost_race = False
+
+    async def execute(
+        self,
+        query: str,
+        params: dict[str, typing.Any] | None = None,
+        columns: list[str] | None = None,
+    ) -> list[dict[str, object]]:
+        self.queries.append(query)
+        if self._create in query:
+            self.lost_race = True
+            raise psycopg.errors.UniqueViolation('duplicate key value')
+        if self._repoint in query:
+            return [{'c': 'credential'}] if self.lost_race else []
+        return []
 
 
 class InternalServiceSeedTestCase(unittest.IsolatedAsyncioTestCase):
@@ -212,6 +246,28 @@ class ClientCredentialTestCase(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(db.issued('CREATE (n:ClientCredential'), [])
         self.assertEqual(db.issued('SET c.client_secret_hash'), [])
 
+    async def test_concurrent_create_repoints_instead_of_failing(
+        self,
+    ) -> None:
+        """Losing the CREATE race re-points the winner's node.
+
+        ``client_id`` is uniquely indexed, so a concurrent seed cannot
+        duplicate it -- but without handling, the loser surfaced a raw
+        UniqueViolation and setup exited non-zero for a credential that
+        by then existed and was correct.
+        """
+        db = RacingGraph(
+            'SET c.client_secret_hash', 'CREATE (n:ClientCredential'
+        )
+
+        await internal_services._write_client_credential(
+            db, SCHEDULER, 'cc_supplied', 'shhh'
+        )
+
+        self.assertTrue(db.lost_race)
+        # Once before the CREATE, once after losing the race to it.
+        self.assertEqual(len(db.issued('SET c.client_secret_hash')), 2)
+
     async def test_existing_credential_is_not_rotated(self) -> None:
         """Re-seeding leaves a live credential exactly as it was."""
         db = FakeGraph({'RETURN count(c) AS live': [{'live': 1}]})
@@ -349,6 +405,19 @@ class ApiKeyTestCase(unittest.IsolatedAsyncioTestCase):
         self.assertIn('ik_taken', str(ctx.exception))
         self.assertEqual(db.issued('CREATE (n:APIKey'), [])
         self.assertEqual(db.issued('SET k.key_hash'), [])
+
+    async def test_concurrent_create_repoints_instead_of_failing(
+        self,
+    ) -> None:
+        """Same lost-race handling as the client credential path."""
+        db = RacingGraph('SET k.key_hash', 'CREATE (n:APIKey')
+
+        await internal_services._write_api_key(
+            db, GATEWAY, 'ik_abc123', 's3cret'
+        )
+
+        self.assertTrue(db.lost_race)
+        self.assertEqual(len(db.issued('SET k.key_hash')), 2)
 
     async def test_malformed_key_raises(self) -> None:
         """A token no request could authenticate is refused at seed time."""

--- a/apps/api/tests/auth/test_seed.py
+++ b/apps/api/tests/auth/test_seed.py
@@ -88,7 +88,7 @@ class SeedDefaultRolesTestCase(unittest.IsolatedAsyncioTestCase):
     """Test default role seeding functionality."""
 
     async def test_seed_default_roles_creates_all(self) -> None:
-        """Verify all 3 default roles are created."""
+        """Verify every default role is created."""
         mock_db = mock.AsyncMock()
         mock_db.execute.return_value = [{'created': len(seed.DEFAULT_ROLES)}]
 
@@ -99,7 +99,8 @@ class SeedDefaultRolesTestCase(unittest.IsolatedAsyncioTestCase):
             count = await seed.seed_default_roles(mock_db)
 
         self.assertEqual(count, len(seed.DEFAULT_ROLES))
-        mock_db.execute.assert_awaited_once()
+        # One statement for the roles, a second for their GRANTS edges.
+        self.assertEqual(mock_db.execute.await_count, 2)
 
     async def test_seed_default_roles_idempotent(self) -> None:
         """Second run creates no duplicate roles."""
@@ -113,14 +114,50 @@ class SeedDefaultRolesTestCase(unittest.IsolatedAsyncioTestCase):
             count = await seed.seed_default_roles(mock_db)
 
         self.assertEqual(count, 0)
-        mock_db.execute.assert_awaited_once()
+        self.assertEqual(mock_db.execute.await_count, 2)
+
+    async def test_grants_are_a_separate_unlimited_statement(self) -> None:
+        """Every GRANTS row must be consumed, not just the first.
+
+        Regression: the grants used to be a trailing ``UNWIND`` on the
+        role query ending in ``RETURN created LIMIT 1``. AGE stopped
+        pulling rows at the limit, so exactly one GRANTS edge was ever
+        written and every seeded role came up granting nothing. The
+        grant statement must stand alone and end in an aggregate, which
+        forces the whole UNWIND to be evaluated.
+        """
+        mock_db = mock.AsyncMock()
+        mock_db.execute.return_value = [{'created': 0, 'granted': 0}]
+
+        with mock.patch(
+            'imbi.common.graph.parse_agtype',
+            side_effect=lambda x: x,
+        ):
+            await seed.seed_default_roles(mock_db)
+
+        role_query = mock_db.execute.await_args_list[0].args[0]
+        grant_query = mock_db.execute.await_args_list[1].args[0]
+        self.assertNotIn('GRANTS', role_query)
+        self.assertNotIn('LIMIT', grant_query)
+        self.assertIn('MERGE (gr)-[:GRANTS]->(gp)', grant_query)
+        self.assertIn('count(gp) AS granted', grant_query)
+        # One grant row per (role, permission) pair in the table.
+        expected = sum(len(role[4]) for role in seed.DEFAULT_ROLES)
+        self.assertEqual(grant_query.count('perm:'), expected)
 
     def test_default_roles_structure(self) -> None:
         """Verify default role definitions are well-formed."""
         role_slugs = {role[0] for role in seed.DEFAULT_ROLES}
         self.assertEqual(
             role_slugs,
-            {'admin', 'developer', 'default', 'readonly'},
+            {
+                'admin',
+                'developer',
+                'default',
+                'readonly',
+                'imbi-scheduler',
+                'imbi-gateway',
+            },
         )
 
         # Verify admin has all permissions
@@ -179,6 +216,48 @@ class SeedDefaultRolesTestCase(unittest.IsolatedAsyncioTestCase):
             with self.subTest(role=slug):
                 role = next(r for r in seed.DEFAULT_ROLES if r[0] == slug)
                 self.assertIn('scheduled_task:read', role[4])
+
+    def test_internal_service_roles_grant_seeded_permissions(self) -> None:
+        """The service roles reference permissions that actually exist.
+
+        ``seed_default_roles`` MATCHes each permission by name, so a typo
+        here costs the service that grant silently rather than failing.
+        """
+        perm_names = {p[0] for p in seed.STANDARD_PERMISSIONS}
+        for slug in ('imbi-scheduler', 'imbi-gateway'):
+            with self.subTest(role=slug):
+                role = next(r for r in seed.DEFAULT_ROLES if r[0] == slug)
+                self.assertLessEqual(set(role[4]), perm_names)
+
+    def test_internal_service_roles_are_least_privilege(self) -> None:
+        """Neither service role can write outside what it calls.
+
+        The scheduler manages the schedule and reads everything else; the
+        gateway writes only projects (which covers releases and SBOMs).
+        Widening either is a deliberate decision, not a drive-by edit.
+        """
+        scheduler = next(
+            r for r in seed.DEFAULT_ROLES if r[0] == 'imbi-scheduler'
+        )
+        non_read = {
+            perm
+            for perm in scheduler[4]
+            if ':read' not in perm and not perm.startswith('scheduled_task:')
+        }
+        self.assertEqual(non_read, set())
+
+        gateway = next(r for r in seed.DEFAULT_ROLES if r[0] == 'imbi-gateway')
+        self.assertEqual(
+            {perm for perm in gateway[4] if ':read' not in perm},
+            {'project:write'},
+        )
+
+    def test_internal_service_roles_are_not_auto_assigned(self) -> None:
+        """A person logging in never lands in a service role."""
+        for slug in ('imbi-scheduler', 'imbi-gateway'):
+            with self.subTest(role=slug):
+                role = next(r for r in seed.DEFAULT_ROLES if r[0] == slug)
+                self.assertFalse(role[5])
 
     def test_no_group_permissions(self) -> None:
         """Verify no group permissions exist."""

--- a/apps/api/tests/test_entrypoint.py
+++ b/apps/api/tests/test_entrypoint.py
@@ -106,6 +106,27 @@ class SetupTestCase(unittest.TestCase):
         )
         self.mock_create_admin.return_value = self.admin_user
 
+        # Internal service accounts
+        self.seeded_services = [
+            entrypoint.internal_services.SeededService(
+                service=service,
+                account_created=True,
+                outcome='unchanged',
+                env={},
+            )
+            for service in entrypoint.internal_services.INTERNAL_SERVICES
+        ]
+        self.mock_seed_services = self.enterContext(
+            mock.patch.object(
+                entrypoint.internal_services,
+                'seed_internal_services',
+                new_callable=mock.AsyncMock,
+            )
+        )
+        self.mock_seed_services.side_effect = lambda *_a, **_kw: list(
+            self.seeded_services
+        )
+
         # Password input (getpass reads /dev/tty, not stdin)
         self.mock_getpass = self.enterContext(
             mock.patch.object(
@@ -273,6 +294,202 @@ class SetupTestCase(unittest.TestCase):
         self.assertIn('Failed to set up ClickHouse schema', result.output)
         self.mock_graph.close.assert_awaited_once()
         self.mock_ch_close.assert_awaited_once()
+
+    def test_setup_seeds_service_accounts_in_the_new_org(self) -> None:
+        """Service accounts join the organization setup just created."""
+        result = self.runner.invoke(
+            entrypoint.main, ['setup'], input='\n\n\n\n'
+        )
+
+        self.assertEqual(result.exit_code, 0)
+        self.mock_seed_services.assert_awaited_once_with(mock.ANY, 'aweber')
+        self.assertIn('imbi-scheduler: created', result.output)
+        self.assertIn('imbi-gateway: created', result.output)
+
+    def test_setup_emits_generated_credentials_once(self) -> None:
+        """A generated secret is printed as a pasteable assignment."""
+        scheduler = entrypoint.internal_services.INTERNAL_SERVICES[0]
+        self.seeded_services[0] = entrypoint.internal_services.SeededService(
+            service=scheduler,
+            account_created=True,
+            outcome='generated',
+            env={
+                'IMBI_SCHEDULER_SA_CLIENT_ID': 'cc_generated',
+                'IMBI_SCHEDULER_SA_CLIENT_SECRET': 'sup3rs3cret',
+            },
+        )
+
+        result = self.runner.invoke(
+            entrypoint.main, ['setup'], input='\n\n\n\n'
+        )
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn('cannot be read back', result.output)
+        self.assertIn(
+            'IMBI_SCHEDULER_SA_CLIENT_ID=cc_generated', result.output
+        )
+        self.assertIn(
+            'IMBI_SCHEDULER_SA_CLIENT_SECRET=sup3rs3cret', result.output
+        )
+
+    def test_setup_reports_supplied_credentials(self) -> None:
+        """An environment-supplied credential is not printed back."""
+        gateway = entrypoint.internal_services.INTERNAL_SERVICES[1]
+        self.seeded_services[1] = entrypoint.internal_services.SeededService(
+            service=gateway,
+            account_created=False,
+            outcome='supplied',
+            env={},
+        )
+
+        result = self.runner.invoke(
+            entrypoint.main, ['setup'], input='\n\n\n\n'
+        )
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn(
+            'imbi-gateway: already exists, credential matches '
+            '$ACTIONS_IMBI_TOKEN',
+            result.output,
+        )
+        self.assertNotIn('cannot be read back', result.output)
+
+    def test_setup_service_account_seed_failure(self) -> None:
+        """A seed error stops setup before the ClickHouse schema runs."""
+        self.mock_seed_services.side_effect = (
+            entrypoint.internal_services.SeedError('role not found')
+        )
+
+        result = self.runner.invoke(
+            entrypoint.main, ['setup'], input='\n\n\n\n'
+        )
+
+        self.assertEqual(result.exit_code, 1)
+        self.assertIn('role not found', result.output)
+        self.mock_ch_schema.assert_not_awaited()
+
+
+class SetupServiceAccountsTestCase(unittest.TestCase):
+    """Test cases for the ``setup-service-accounts`` command.
+
+    Uses regular TestCase because the command calls asyncio.run() which
+    creates its own event loop.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.runner = typer.testing.CliRunner()
+        self.mock_graph = mock.MagicMock()
+        self.mock_graph.open = mock.AsyncMock()
+        self.mock_graph.close = mock.AsyncMock()
+        self.mock_graph.execute = mock.AsyncMock(
+            return_value=[{'slug': 'aweber'}]
+        )
+        self.enterContext(
+            mock.patch.object(
+                entrypoint.graph, 'Graph', return_value=self.mock_graph
+            )
+        )
+        self.enterContext(
+            mock.patch.object(
+                entrypoint.graph, 'parse_agtype', side_effect=lambda x: x
+            )
+        )
+        self.mock_seed_services = self.enterContext(
+            mock.patch.object(
+                entrypoint.internal_services,
+                'seed_internal_services',
+                new_callable=mock.AsyncMock,
+                return_value=[
+                    entrypoint.internal_services.SeededService(
+                        service=service,
+                        account_created=False,
+                        outcome='unchanged',
+                        env={},
+                    )
+                    for service in (
+                        entrypoint.internal_services.INTERNAL_SERVICES
+                    )
+                ],
+            )
+        )
+
+    def test_defaults_to_the_sole_organization(self) -> None:
+        """One organization needs no --organization."""
+        result = self.runner.invoke(
+            entrypoint.main, ['setup-service-accounts']
+        )
+
+        self.assertEqual(result.exit_code, 0)
+        self.mock_seed_services.assert_awaited_once_with(mock.ANY, 'aweber')
+        self.assertIn('existing credential left in place', result.output)
+        self.mock_graph.close.assert_awaited_once()
+
+    def test_explicit_organization_skips_the_lookup(self) -> None:
+        """--organization is used as given."""
+        result = self.runner.invoke(
+            entrypoint.main,
+            ['setup-service-accounts', '--organization', 'other'],
+        )
+
+        self.assertEqual(result.exit_code, 0)
+        self.mock_seed_services.assert_awaited_once_with(mock.ANY, 'other')
+        self.mock_graph.execute.assert_not_awaited()
+
+    def test_multiple_organizations_require_a_choice(self) -> None:
+        """Guessing the tenant would put the accounts in the wrong one."""
+        self.mock_graph.execute.return_value = [
+            {'slug': 'aweber'},
+            {'slug': 'other'},
+        ]
+
+        result = self.runner.invoke(
+            entrypoint.main, ['setup-service-accounts']
+        )
+
+        self.assertEqual(result.exit_code, 1)
+        self.assertIn('Multiple organizations exist', result.output)
+        self.assertIn('aweber, other', result.output)
+        self.assertNotIn('Failed to seed service accounts', result.output)
+        self.mock_seed_services.assert_not_awaited()
+
+    def test_no_organization_points_at_setup(self) -> None:
+        """An un-set-up install is told what to run."""
+        self.mock_graph.execute.return_value = []
+
+        result = self.runner.invoke(
+            entrypoint.main, ['setup-service-accounts']
+        )
+
+        self.assertEqual(result.exit_code, 1)
+        self.assertIn('No organization exists yet', result.output)
+        self.mock_seed_services.assert_not_awaited()
+
+    def test_seed_error_exits_non_zero(self) -> None:
+        """A missing role is reported, not swallowed."""
+        self.mock_seed_services.side_effect = (
+            entrypoint.internal_services.SeedError('role not found')
+        )
+
+        result = self.runner.invoke(
+            entrypoint.main, ['setup-service-accounts']
+        )
+
+        self.assertEqual(result.exit_code, 1)
+        self.assertIn('role not found', result.output)
+        self.mock_graph.close.assert_awaited_once()
+
+    def test_graph_connection_failure(self) -> None:
+        """A connection failure is reported before anything is seeded."""
+        self.mock_graph.open.side_effect = ConnectionError('refused')
+
+        result = self.runner.invoke(
+            entrypoint.main, ['setup-service-accounts']
+        )
+
+        self.assertEqual(result.exit_code, 1)
+        self.assertIn('Failed to connect to PostgreSQL', result.output)
+        self.mock_seed_services.assert_not_awaited()
 
 
 class SetupClickhouseTestCase(unittest.TestCase):

--- a/apps/api/tests/test_entrypoint.py
+++ b/apps/api/tests/test_entrypoint.py
@@ -368,6 +368,19 @@ class SetupTestCase(unittest.TestCase):
         self.assertIn('role not found', result.output)
         self.mock_ch_schema.assert_not_awaited()
 
+    def test_setup_service_account_unexpected_failure(self) -> None:
+        """A non-SeedError reports like every other step, not a traceback."""
+        self.mock_seed_services.side_effect = RuntimeError('connection reset')
+
+        result = self.runner.invoke(
+            entrypoint.main, ['setup'], input='\n\n\n\n'
+        )
+
+        self.assertEqual(result.exit_code, 1)
+        self.assertIn('Failed to seed service accounts', result.output)
+        self.assertIn('connection reset', result.output)
+        self.mock_ch_schema.assert_not_awaited()
+
 
 class SetupServiceAccountsTestCase(unittest.TestCase):
     """Test cases for the ``setup-service-accounts`` command.

--- a/compose.yaml
+++ b/compose.yaml
@@ -27,13 +27,14 @@ services:
       IMBI_EMAIL_SMTP_USE_TLS: "false"
       IMBI_ENVIRONMENT: testing
       POSTGRES_URL: postgresql://postgres:secret@postgres/imbi
-      # imbi-scheduler stays disabled until it has its own service-account
-      # credentials, because it runs every task as that account (ADR 0002).
-      # They cannot be hardcoded here: the account has to exist in the
-      # database, so create one in the UI under Service Accounts and issue it
-      # a client credential, then uncomment these with the values shown.
+      # imbi-scheduler and imbi-gateway each call imbi-api as their own service
+      # account (ADR 0002). Deliberately unset: this all-in-one image mints and
+      # seeds a credential for each on every boot, so both come up working. Set
+      # them to pin the values instead -- `imbi-api setup` then seeds the
+      # accounts to match whatever is here.
       # IMBI_SCHEDULER_SA_CLIENT_ID: ""
       # IMBI_SCHEDULER_SA_CLIENT_SECRET: ""
+      # ACTIONS_IMBI_TOKEN: ""
       S3_ACCESS_KEY: test
       S3_ENDPOINT_URL: http://localstack:4566
       S3_SECRET_KEY: test

--- a/container/entrypoint.sh
+++ b/container/entrypoint.sh
@@ -260,7 +260,7 @@ provision_internal_credentials() {
     # overwrite a secret the operator did set, and `setup-service-accounts`
     # seeds what the environment holds -- so the value they meant to be in
     # use would be replaced by a generated one without anything saying so.
-    if [ -z "${IMBI_SCHEDULER_SA_CLIENT_ID:-}" ] &&
+    if [ -z "${IMBI_SCHEDULER_SA_CLIENT_ID:-}" ] && \
        [ -z "${IMBI_SCHEDULER_SA_CLIENT_SECRET:-}" ]; then
         # A fixed client_id so a restart re-points the same credential
         # instead of accumulating one node per boot.
@@ -268,7 +268,7 @@ provision_internal_credentials() {
         IMBI_SCHEDULER_SA_CLIENT_SECRET="$(random_token)"
         export IMBI_SCHEDULER_SA_CLIENT_SECRET
         minted_scheduler=1
-    elif [ -z "${IMBI_SCHEDULER_SA_CLIENT_ID:-}" ] ||
+    elif [ -z "${IMBI_SCHEDULER_SA_CLIENT_ID:-}" ] || \
          [ -z "${IMBI_SCHEDULER_SA_CLIENT_SECRET:-}" ]; then
         echo "ERROR: set IMBI_SCHEDULER_SA_CLIENT_ID and IMBI_SCHEDULER_SA_CLIENT_SECRET together, or neither" >&2
         return 1

--- a/container/entrypoint.sh
+++ b/container/entrypoint.sh
@@ -107,9 +107,10 @@ case "$IMBI_SERVICE" in
         require_gateway_vars
         # Slack bot is optional in 'all' mode: it auto-enables only when
         # ANTHROPIC_API_KEY and the SLACK_* tokens are present, so its vars
-        # are not required here. The scheduler is optional on the same terms:
-        # it needs its own service-account credentials to run anything, so
-        # without them it would only skip.
+        # are not required here. The scheduler's service-account credentials
+        # are not required either, but for the opposite reason: this mode
+        # seeds them itself when the environment does not supply them (see
+        # `provision_internal_credentials`).
         ;;
     api)
         require_api_vars
@@ -236,8 +237,67 @@ start_caddy() {
     caddy run --config /etc/caddy/Caddyfile &
 }
 
+random_token() {
+    tr -dc 'A-Za-z0-9' < /dev/urandom | head -c "${1:-43}"
+}
+
+random_hex() {
+    tr -dc 'a-f0-9' < /dev/urandom | head -c 32
+}
+
+# 'all' mode only. imbi-scheduler and imbi-gateway authenticate to imbi-api
+# as their own service accounts, so both need a credential before they can
+# do anything: without one every api-target firing is skipped, and every
+# gateway action gets a 401. `setup-service-accounts` seeds whatever the
+# environment supplies, so a deployment that already holds these secrets
+# keeps them. One that does not gets a pair minted here -- in a single
+# container nothing outside it ever needs to know the values, so generating
+# them per boot is cheaper than asking an operator to invent them.
+provision_internal_credentials() {
+    minted_scheduler=0
+    minted_gateway=0
+    if [ -z "${IMBI_SCHEDULER_SA_CLIENT_ID:-}" ]; then
+        # A fixed client_id so a restart re-points the same credential
+        # instead of accumulating one node per boot.
+        export IMBI_SCHEDULER_SA_CLIENT_ID="cc_imbi_scheduler_all_mode"
+        IMBI_SCHEDULER_SA_CLIENT_SECRET="$(random_token)"
+        export IMBI_SCHEDULER_SA_CLIENT_SECRET
+        minted_scheduler=1
+    fi
+    if [ -z "${ACTIONS_IMBI_TOKEN:-}" ]; then
+        ACTIONS_IMBI_TOKEN="ik_$(random_hex)_$(random_token)"
+        export ACTIONS_IMBI_TOKEN
+        minted_gateway=1
+    fi
+    if imbi-api setup-service-accounts; then
+        return 0
+    fi
+    # Seeding failed, so anything minted above authenticates nobody. Drop
+    # it rather than hand a service a credential the database has never
+    # heard of: "not configured" names the real problem, a 401 does not.
+    if [ "$minted_scheduler" = 1 ]; then
+        unset IMBI_SCHEDULER_SA_CLIENT_ID IMBI_SCHEDULER_SA_CLIENT_SECRET
+    fi
+    if [ "$minted_gateway" = 1 ]; then
+        unset ACTIONS_IMBI_TOKEN
+    fi
+    return 1
+}
+
 case "$IMBI_SERVICE" in
     all)
+        # imbi-gateway's default upstream is the service name imbi-api, which
+        # in a single container resolves to nothing; imbi-api is right here.
+        export ACTIONS_IMBI_URL="${ACTIONS_IMBI_URL:-http://localhost:8000}"
+        # Before any service starts: imbi-gateway reads ACTIONS_IMBI_TOKEN
+        # when it handles its first action, and imbi-scheduler its client
+        # credential at every firing.
+        if provision_internal_credentials; then
+            scheduler_configured=1
+        else
+            scheduler_configured=0
+            echo "WARNING: could not seed internal service accounts; run 'imbi-api setup' first" >&2
+        fi
         start_api
         start_assistant
         start_gateway
@@ -253,15 +313,15 @@ case "$IMBI_SERVICE" in
         else
             echo "imbi-slackbot disabled (needs SLACK_APP_TOKEN, SLACK_BOT_TOKEN, ANTHROPIC_API_KEY)"
         fi
-        # Optional on the same terms as the slack bot: without its own
-        # service-account credentials every api-target firing would resolve no
-        # principal and be skipped, so a scheduler that cannot run anything is
-        # not started rather than left logging skips forever.
-        if [ -n "${IMBI_SCHEDULER_SA_CLIENT_ID:-}" ] && \
-           [ -n "${IMBI_SCHEDULER_SA_CLIENT_SECRET:-}" ]; then
+        # `provision_internal_credentials` above seeds or adopts the
+        # scheduler's service-account credential, so the only case left is
+        # one where seeding itself failed. Starting then would leave the
+        # scheduler skipping every api-target firing for want of a
+        # principal, so it stays out.
+        if [ "$scheduler_configured" = 1 ]; then
             start_scheduler
         else
-            echo "imbi-scheduler disabled (needs IMBI_SCHEDULER_SA_CLIENT_ID, IMBI_SCHEDULER_SA_CLIENT_SECRET)"
+            echo "imbi-scheduler disabled (no service-account credential could be seeded)"
         fi
         start_caddy
         ;;

--- a/container/entrypoint.sh
+++ b/container/entrypoint.sh
@@ -241,10 +241,6 @@ random_token() {
     tr -dc 'A-Za-z0-9' < /dev/urandom | head -c "${1:-43}"
 }
 
-random_hex() {
-    tr -dc 'a-f0-9' < /dev/urandom | head -c 32
-}
-
 # 'all' mode only. imbi-scheduler and imbi-gateway authenticate to imbi-api
 # as their own service accounts, so both need a credential before they can
 # do anything: without one every api-target firing is skipped, and every
@@ -274,7 +270,13 @@ provision_internal_credentials() {
         return 1
     fi
     if [ -z "${ACTIONS_IMBI_TOKEN:-}" ]; then
-        ACTIONS_IMBI_TOKEN="ik_$(random_hex)_$(random_token)"
+        # A fixed key_id for the same reason as the client_id above: with a
+        # random one, `_write_api_key` matches nothing on the next boot and
+        # creates another APIKey node, leaving a live unrevoked credential
+        # behind per restart. No underscore past the `ik_` prefix -- the
+        # token is split on the first two, so one here would land inside
+        # the key_id and change where the secret starts.
+        ACTIONS_IMBI_TOKEN="ik_imbigatewayallmode_$(random_token)"
         export ACTIONS_IMBI_TOKEN
         minted_gateway=1
     fi

--- a/container/entrypoint.sh
+++ b/container/entrypoint.sh
@@ -329,10 +329,15 @@ case "$IMBI_SERVICE" in
         # one where seeding itself failed. Starting then would leave the
         # scheduler skipping every api-target firing for want of a
         # principal, so it stays out.
+        #
+        # Seeding is one call for both services, so a bad ACTIONS_IMBI_TOKEN
+        # holds the scheduler back even when its own credential was fine.
+        # Hence the wording: the error above names which one to fix, and
+        # claiming the scheduler's credential failed would be wrong.
         if [ "$scheduler_configured" = 1 ]; then
             start_scheduler
         else
-            echo "imbi-scheduler disabled (no service-account credential could be seeded)"
+            echo "imbi-scheduler disabled (internal service account seeding failed; see the error above)"
         fi
         start_caddy
         ;;

--- a/container/entrypoint.sh
+++ b/container/entrypoint.sh
@@ -256,13 +256,22 @@ random_hex() {
 provision_internal_credentials() {
     minted_scheduler=0
     minted_gateway=0
-    if [ -z "${IMBI_SCHEDULER_SA_CLIENT_ID:-}" ]; then
+    # Both halves or neither. Minting on an empty client id alone would
+    # overwrite a secret the operator did set, and `setup-service-accounts`
+    # seeds what the environment holds -- so the value they meant to be in
+    # use would be replaced by a generated one without anything saying so.
+    if [ -z "${IMBI_SCHEDULER_SA_CLIENT_ID:-}" ] &&
+       [ -z "${IMBI_SCHEDULER_SA_CLIENT_SECRET:-}" ]; then
         # A fixed client_id so a restart re-points the same credential
         # instead of accumulating one node per boot.
         export IMBI_SCHEDULER_SA_CLIENT_ID="cc_imbi_scheduler_all_mode"
         IMBI_SCHEDULER_SA_CLIENT_SECRET="$(random_token)"
         export IMBI_SCHEDULER_SA_CLIENT_SECRET
         minted_scheduler=1
+    elif [ -z "${IMBI_SCHEDULER_SA_CLIENT_ID:-}" ] ||
+         [ -z "${IMBI_SCHEDULER_SA_CLIENT_SECRET:-}" ]; then
+        echo "ERROR: set IMBI_SCHEDULER_SA_CLIENT_ID and IMBI_SCHEDULER_SA_CLIENT_SECRET together, or neither" >&2
+        return 1
     fi
     if [ -z "${ACTIONS_IMBI_TOKEN:-}" ]; then
         ACTIONS_IMBI_TOKEN="ik_$(random_hex)_$(random_token)"

--- a/docs/getting-started/setup.md
+++ b/docs/getting-started/setup.md
@@ -40,27 +40,51 @@ The setup command performs the following:
    roles with appropriate permissions
 3. **Creates the admin user** - Interactively prompts for email, display
    name, and password
-4. **Creates the ClickHouse schema** - Executes the DDL for the analytics
+4. **Creates the internal service accounts** - `imbi-scheduler` and
+   `imbi-gateway`, each with a least-privilege role and a credential
+5. **Creates the ClickHouse schema** - Executes the DDL for the analytics
    tables and materialized views
 
 The setup command is idempotent: it checks whether the system has already
 been seeded before making changes, so it is safe to run multiple times.
 
+### Internal Service Credentials
+
+imbi-scheduler and imbi-gateway call imbi-api as themselves, so each needs a
+credential of its own — the scheduler a client credential (it has no other way
+to run a task; see ADR 0002), the gateway an API key it sends as a bearer
+token. Setup handles both:
+
+- **You supply them.** Set `IMBI_SCHEDULER_SA_CLIENT_ID`,
+  `IMBI_SCHEDULER_SA_CLIENT_SECRET`, and `ACTIONS_IMBI_TOKEN` (an
+  `ik_<id>_<secret>` API key) before running setup, and the accounts are
+  seeded to match. This is the path for Helm and Compose, where the values
+  already live in a values file or `.env`.
+- **Setup supplies them.** Leave them unset and setup generates a credential
+  per service and prints it once, as assignments to paste into your
+  environment. They cannot be read back afterwards.
+
+Re-running setup never rotates a working credential, and never narrows a role
+you have since widened. In `all` mode the container entrypoint provisions both
+credentials itself when the environment does not supply them.
+
 ## Applying Upgrades
 
 `setup` is interactive and covers everything, which is more than an
 existing instance needs when a release only adds ClickHouse tables or new
-permissions. Two commands run those steps on their own, without prompting
+permissions. Three commands run those steps on their own, without prompting
 or touching the admin user:
 
 ```bash
-imbi-api setup-clickhouse    # apply the ClickHouse schema only
-imbi-api setup-permissions   # seed permissions and default roles only
+imbi-api setup-clickhouse        # apply the ClickHouse schema only
+imbi-api setup-permissions       # seed permissions and default roles only
+imbi-api setup-service-accounts  # seed the internal service accounts only
 ```
 
-Both are idempotent and safe to re-run. `setup-permissions` also refreshes
+All three are idempotent and safe to re-run. `setup-permissions` also refreshes
 each default role's permission grants and prunes permissions retired by a
-previous release.
+previous release; run it before `setup-service-accounts`, which grants each
+account a role by name.
 
 ## Post-Setup
 

--- a/docs/getting-started/setup.md
+++ b/docs/getting-started/setup.md
@@ -64,9 +64,17 @@ token. Setup handles both:
   per service and prints it once, as assignments to paste into your
   environment. They cannot be read back afterward.
 
+  That output contains live secrets. Treat it as you would a password: do not
+  pipe it anywhere that ships logs off the host.
+
+The scheduler's two variables go together — set both or neither. Half a pair
+fails rather than being ignored, because seeding a generated credential instead
+would leave the scheduler holding a value that authenticates nobody.
+
 Re-running setup never rotates a working credential, and never narrows a role
 you have since widened. In `all` mode the container entrypoint provisions both
-credentials itself when the environment does not supply them.
+credentials itself when the environment does not supply them — for the
+scheduler, only when both of its variables are absent.
 
 ## Applying Upgrades
 

--- a/docs/getting-started/setup.md
+++ b/docs/getting-started/setup.md
@@ -62,7 +62,7 @@ token. Setup handles both:
   already live in a values file or `.env`.
 - **Setup supplies them.** Leave them unset and setup generates a credential
   per service and prints it once, as assignments to paste into your
-  environment. They cannot be read back afterwards.
+  environment. They cannot be read back afterward.
 
 Re-running setup never rotates a working credential, and never narrows a role
 you have since widened. In `all` mode the container entrypoint provisions both

--- a/docs/scheduler/configuration.md
+++ b/docs/scheduler/configuration.md
@@ -19,12 +19,23 @@ shared with the rest of the platform and keep their platform-wide names.
 Without the service-account credentials the service still starts and still
 schedules, but no `api` target can resolve a principal, so every such firing is
 recorded as `skipped`. The container entrypoint therefore refuses to start in
-`scheduler` mode without them, and leaves the scheduler out of `all` mode until
-they are set.
+`scheduler` mode without them.
 
-The account is not seeded. Create a service account in the UI, grant it the
-`scheduled_task:*` permissions plus whatever the tasks it runs will need, and
-issue it a client credential.
+The account itself is seeded. `imbi-api setup` — or `imbi-api
+setup-service-accounts` on an install that predates it — creates the
+`imbi-scheduler` service account, gives it the seeded `imbi-scheduler` role, and
+either adopts the credential these two variables name or generates one and
+prints it once. Set them before running setup and they are what the account
+authenticates with; leave them unset and setup tells you what to set them to.
+
+In `all` mode the entrypoint provisions the pair itself when the environment does
+not supply it, so a single-container deployment runs the scheduler with no
+credential setup at all.
+
+The seeded role grants `scheduled_task:*` plus every `:read` — enough to manage
+the schedule and to inspect what a task reads, and deliberately not enough to
+write anything else. A task whose `api` target *writes* needs that permission
+added to the `imbi-scheduler` role first; until then it gets a 403.
 
 ## Reaching imbi-api
 

--- a/docs/scheduler/configuration.md
+++ b/docs/scheduler/configuration.md
@@ -28,9 +28,15 @@ either adopts the credential these two variables name or generates one and
 prints it once. Set them before running setup and they are what the account
 authenticates with; leave them unset and setup tells you what to set them to.
 
-In `all` mode the entrypoint provisions the pair itself when the environment does
-not supply it, so a single-container deployment runs the scheduler with no
-credential setup at all.
+Set both or neither. A client id without its secret cannot be verified and a
+secret without its id names nothing to verify it against, so half a pair is
+refused rather than quietly replaced by a generated credential the service does
+not hold.
+
+In `all` mode the entrypoint provisions the pair itself when neither variable is
+set, so a single-container deployment runs the scheduler with no credential setup
+at all. Setting only one there is the same error, and the entrypoint reports it
+and leaves the scheduler out.
 
 The seeded role grants `scheduled_task:*` plus every `:read` — enough to manage
 the schedule and to inspect what a task reads, and deliberately not enough to

--- a/helm/imbi/templates/configmap.yaml
+++ b/helm/imbi/templates/configmap.yaml
@@ -12,6 +12,10 @@ data:
   # service.internalApiUrl when running imbi-mcp or imbi-assistant
   # as separate pods.
   IMBI_INTERNAL_API_URL: {{ .Values.service.internalApiUrl | quote }}
+  # imbi-gateway reads its own upstream setting rather than the one above.
+  # Pointed at the same place: its default (http://imbi-api:8000) is a service
+  # name this chart does not create, so every action would fail to connect.
+  ACTIONS_IMBI_URL: {{ .Values.service.internalApiUrl | quote }}
   {{- if eq .Values.service.mode "scheduler" }}
   {{- if eq .Values.service.internalApiUrl "http://localhost:8000" }}
   {{- fail "service.internalApiUrl must point at imbi-api when service.mode is 'scheduler' (e.g. http://imbi-api.<namespace>.svc.cluster.local:8000) -- the default is an in-pod loopback, which in a standalone scheduler pod resolves to the scheduler itself, so every api-target firing fails while the pod reports healthy" }}

--- a/helm/imbi/templates/configmap.yaml
+++ b/helm/imbi/templates/configmap.yaml
@@ -15,6 +15,11 @@ data:
   # imbi-gateway reads its own upstream setting rather than the one above.
   # Pointed at the same place: its default (http://imbi-api:8000) is a service
   # name this chart does not create, so every action would fail to connect.
+  {{- if eq .Values.service.mode "gateway" }}
+  {{- if eq .Values.service.internalApiUrl "http://localhost:8000" }}
+  {{- fail "service.internalApiUrl must point at imbi-api when service.mode is 'gateway' (e.g. http://imbi-api.<namespace>.svc.cluster.local:8000) -- the default is an in-pod loopback, which in a standalone gateway pod resolves to the gateway itself, so every action it takes fails to connect while the pod reports healthy" }}
+  {{- end }}
+  {{- end }}
   ACTIONS_IMBI_URL: {{ .Values.service.internalApiUrl | quote }}
   {{- if eq .Values.service.mode "scheduler" }}
   {{- if eq .Values.service.internalApiUrl "http://localhost:8000" }}

--- a/helm/imbi/templates/configmap.yaml
+++ b/helm/imbi/templates/configmap.yaml
@@ -12,9 +12,11 @@ data:
   # service.internalApiUrl when running imbi-mcp or imbi-assistant
   # as separate pods.
   IMBI_INTERNAL_API_URL: {{ .Values.service.internalApiUrl | quote }}
-  # imbi-gateway reads its own upstream setting rather than the one above.
-  # Pointed at the same place: its default (http://imbi-api:8000) is a service
-  # name this chart does not create, so every action would fail to connect.
+  # imbi-gateway reads its own upstream setting rather than the one above, so
+  # it is set here rather than left to the gateway's own default of
+  # http://imbi-api:8000 -- a service name this chart does not create. Pointed
+  # at the same value, which is the in-pod loopback unless overridden: right
+  # for "all" and "api" mode, and guarded below for a standalone gateway.
   {{- if eq .Values.service.mode "gateway" }}
   {{- if eq .Values.service.internalApiUrl "http://localhost:8000" }}
   {{- fail "service.internalApiUrl must point at imbi-api when service.mode is 'gateway' (e.g. http://imbi-api.<namespace>.svc.cluster.local:8000) -- the default is an in-pod loopback, which in a standalone gateway pod resolves to the gateway itself, so every action it takes fails to connect while the pod reports healthy" }}

--- a/helm/imbi/templates/deployment.yaml
+++ b/helm/imbi/templates/deployment.yaml
@@ -78,6 +78,19 @@ spec:
                   key: scheduler-sa-client-secret
                   optional: true
             {{- end }}
+            {{- if or .Values.gateway.serviceAccount.token .Values.existingSecret }}
+            {{- /* Optional for the same reason as the scheduler keys above: a
+                   deployment that does not run the gateway has no reason to
+                   define it, and a required missing key blocks the pod. In
+                   'all' mode the entrypoint seeds one itself when this is
+                   absent. */}}
+            - name: ACTIONS_IMBI_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "imbi.secretName" . }}
+                  key: gateway-sa-token
+                  optional: true
+            {{- end }}
             {{- if and .Values.storage.accessKey .Values.storage.secretKey }}
             - name: S3_ACCESS_KEY
               valueFrom:

--- a/helm/imbi/templates/secret.yaml
+++ b/helm/imbi/templates/secret.yaml
@@ -24,6 +24,9 @@ stringData:
   scheduler-sa-client-id: {{ required "scheduler.serviceAccount.clientId is required when clientSecret is set" .Values.scheduler.serviceAccount.clientId | quote }}
   scheduler-sa-client-secret: {{ required "scheduler.serviceAccount.clientSecret is required when clientId is set" .Values.scheduler.serviceAccount.clientSecret | quote }}
   {{- end }}
+  {{- if .Values.gateway.serviceAccount.token }}
+  gateway-sa-token: {{ .Values.gateway.serviceAccount.token | quote }}
+  {{- end }}
   {{- if .Values.storage.accessKey }}
   s3-access-key: {{ .Values.storage.accessKey | quote }}
   s3-secret-key: {{ .Values.storage.secretKey | quote }}

--- a/helm/imbi/values.yaml
+++ b/helm/imbi/values.yaml
@@ -57,9 +57,24 @@ scheduler:
   # The scheduler runs every task as its own service account (ADR 0002 removed
   # the per-task credential store). Without these it starts and schedules, but
   # resolves no principal for an api target, so every such firing is skipped.
+  #
+  # `imbi-api setup` seeds the account to match whatever is set here, so these
+  # are values to invent, not ones to copy back out of Imbi. Left empty, setup
+  # generates a pair and prints it once for you to paste in.
   serviceAccount:
     clientId: ""
     clientSecret: ""
+
+# Gateway configuration
+gateway:
+  # The gateway calls back into imbi-api to patch projects and record releases,
+  # authenticating with this API key (the `ik_<id>_<secret>` form); patch
+  # attribution is this key's identity. Unset, the gateway starts and serves
+  # webhooks but every action it takes gets a 401.
+  #
+  # Seeded by `imbi-api setup` exactly like the scheduler credential above.
+  serviceAccount:
+    token: ""
 
 # Optional: reference an existing secret instead of specifying values above.
 # The secret must contain keys: jwt-secret, encryption-key, clickhouse-url,
@@ -71,9 +86,10 @@ scheduler:
 #   - s3-access-key, s3-secret-key when storage.accessKey is set
 # Those two refs are not optional, so a secret missing a key the deployment
 # asks for will fail the pod. The scheduler's scheduler-sa-client-id and
-# scheduler-sa-client-secret are read whenever existingSecret is set, but are
-# marked optional, so omitting them only leaves the scheduler unable to
-# resolve a principal for api targets.
+# scheduler-sa-client-secret are read whenever existingSecret is set, as is the
+# gateway's gateway-sa-token, but all three are marked optional -- omitting them
+# only leaves the scheduler unable to resolve a principal for api targets and
+# the gateway unable to authenticate its own calls.
 existingSecret: ""
 
 ingress:

--- a/helm/imbi/values.yaml
+++ b/helm/imbi/values.yaml
@@ -13,13 +13,14 @@ replicaCount: 1
 # Use the matching .service.<name>.replicas value to scale that service.
 service:
   mode: all
-  # Internal upstream URL imbi-mcp, imbi-assistant, and imbi-scheduler use
-  # to reach imbi-api. The default works for "all" and "api" modes; override
-  # when running "mcp", "assistant", or "scheduler" as separate pods (e.g.
-  # http://imbi-api.<namespace>.svc.cluster.local:8000). In "scheduler" mode
-  # the chart fails to render if this is left at the loopback default: there
-  # it resolves to the scheduler's own pod, and the resulting pod reports
-  # healthy while every api-target firing fails.
+  # Internal upstream URL imbi-mcp, imbi-assistant, imbi-scheduler, and
+  # imbi-gateway use to reach imbi-api. The default works for "all" and "api"
+  # modes; override when running "mcp", "assistant", "scheduler", or "gateway"
+  # as separate pods (e.g.
+  # http://imbi-api.<namespace>.svc.cluster.local:8000). In "scheduler" and
+  # "gateway" modes the chart fails to render if this is left at the loopback
+  # default: there it resolves to that pod itself, and the pod reports healthy
+  # while every api-target firing (or gateway action) fails.
   internalApiUrl: "http://localhost:8000"
   # imbi-api's *public* URL, whose path component is the prefix it mounts
   # its routes under. imbi-scheduler re-derives that prefix to build the

--- a/helm/imbi/values.yaml
+++ b/helm/imbi/values.yaml
@@ -62,6 +62,12 @@ scheduler:
   # `imbi-api setup` seeds the account to match whatever is set here, so these
   # are values to invent, not ones to copy back out of Imbi. Left empty, setup
   # generates a pair and prints it once for you to paste in.
+  #
+  # Both or neither: one alone is refused rather than ignored, since seeding a
+  # generated credential instead would leave the scheduler holding a value that
+  # authenticates nobody. In "all" mode that also stops the entrypoint from
+  # provisioning, so a half-filled pair here (or a `existingSecret` carrying
+  # only one of the two keys) leaves the scheduler out entirely.
   serviceAccount:
     clientId: ""
     clientSecret: ""

--- a/helm/imbi/values.yaml
+++ b/helm/imbi/values.yaml
@@ -88,9 +88,15 @@ gateway:
 # Those two refs are not optional, so a secret missing a key the deployment
 # asks for will fail the pod. The scheduler's scheduler-sa-client-id and
 # scheduler-sa-client-secret are read whenever existingSecret is set, as is the
-# gateway's gateway-sa-token, but all three are marked optional -- omitting them
-# only leaves the scheduler unable to resolve a principal for api targets and
-# the gateway unable to authenticate its own calls.
+# gateway's gateway-sa-token, and all three are marked optional -- so what a
+# missing one costs depends on the mode:
+#   - service.mode "scheduler": require_scheduler_vars() demands both scheduler
+#     keys, so the container exits at startup and the pod CrashLoopBackOffs.
+#   - service.mode "all": neither is required. The entrypoint seeds a credential
+#     for each service itself when the environment does not supply one.
+#   - any other mode: nothing reads them, and nothing is affected.
+# gateway-sa-token is never required: without it the gateway serves webhooks and
+# every action it takes gets a 401.
 existingSecret: ""
 
 ingress:


### PR DESCRIPTION
## Summary

`imbi-api setup` now seeds the service accounts and credentials that imbi-scheduler and imbi-gateway authenticate to imbi-api with, so a fresh install has a working scheduler and gateway with no manual credential setup. Fixes #188.

## Problem

Both services call imbi-api as themselves, and neither identity was seeded:

- **imbi-scheduler** resolved no principal for any `api`-target firing, so every one was recorded as `skipped`. `require_scheduler_vars` therefore refused to start in `scheduler` mode without `IMBI_SCHEDULER_SA_CLIENT_ID`/`_SECRET`, and `all` mode left the scheduler out entirely — a single-container deployment silently had no scheduler.
- **imbi-gateway** needs a bearer token for its outbound calls (`ActionSettings.imbi_token`). Nothing checked for it, so the gateway started happily and failed at action time. `ACTIONS_IMBI_TOKEN` was not wired into the chart or Compose at all.

## Solution

`setup` gains a step (and `setup-service-accounts` runs it alone, for an install that predates it) creating a `ServiceAccount` per internal service, each with a least-privilege system role and a credential:

| Service | Credential | Role grants |
| --- | --- | --- |
| `imbi-scheduler` | client credential (ADR 0002: its only way to run a task) | `scheduled_task:*` plus every `:read` |
| `imbi-gateway` | API key sent as a bearer | `project:read`, `project:write`, `user:read` |

`project:write` is the guard on every write endpoint the gateway calls, releases and SBOMs included; `user:read` is `/users/by-identity`. A task whose `api` target *writes* needs that permission added to the `imbi-scheduler` role deliberately — it gets a 403 until then.

**Credential delivery.** Supplied by the environment when it is there (`IMBI_SCHEDULER_SA_CLIENT_ID`/`_SECRET`, `ACTIONS_IMBI_TOKEN`), so a Helm values file or an `.env` stays the source of truth for its own secret and a changed value reconciles. Otherwise one is generated and printed once as pasteable assignments, since it cannot be read back.

**Idempotent.** Re-running creates no duplicate account or credential, never rotates a working one, and never resets a role an operator has since widened. A revoked credential does not count as one, so a stale revocation cannot suppress seeding forever.

**`all` mode.** The entrypoint provisions both credentials itself when the environment does not supply them (fixed client id, fresh secret per boot — nothing outside the container needs the value), so the scheduler is no longer excluded by default. If seeding fails, the minted values are dropped and the scheduler stays out, so the message names the real problem instead of a 401.

Out of the issue's open questions: **assistant, mcp, and slackbot are deliberately excluded** — each forwards the *caller's* token, so an account of their own would carry privileges nothing uses. **Rotation stays out of scope** (the per-credential rotate endpoints already cover the manual path).

## Drive-by fix this depends on

`seed_default_roles` appended the GRANTS edges to the role query as a trailing `UNWIND` ending in `RETURN created LIMIT 1`. AGE stops pulling rows at the limit, so **exactly one GRANTS edge was ever written** and every seeded role came up granting nothing. Verified against Postgres/AGE on `main`: 1 edge total; 211 (every role complete) after the fix. The grants are now their own statement ending in an aggregate, which forces the whole `UNWIND` to be consumed. Covered by a regression test.

## Verification

Beyond the unit tests, run against real Postgres 18 + AGE:

- Fresh seed → both accounts created, both credentials verify against their stored Argon2 hashes, `imbi-scheduler` resolves 23 permissions and `imbi-gateway` 3.
- Re-seed → nothing created, nothing rotated, no duplicate nodes; a role widened to `admin` survives.
- Environment-supplied → the named credential is stored and its secret verifies; a second run re-points rather than duplicating.
- Through the real app: the seeded client credential gets a token from the `client_credentials` grant (200), that token reads projects (200) and is denied `/service-accounts` (403), and the seeded gateway API key authenticates as a bearer for project reads and `/users/by-identity`.
- `helm template` renders in `all`/`gateway`/`scheduler` modes with and without the values set, and via `existingSecret`; `helm lint` clean; `shellcheck` clean on the entrypoint.
- Full suite: 5354 passed. ruff, basedpyright, and mypy clean.

Not verified: the scheduler process actually firing a task end to end — that needs the service running. Every step of its identity path is covered above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)