### PR TITLE
Fix three post-2.22 gaps: scheduler health, scheduler_runs TTL, read-session finalizer

### DIFF
--- a/apps/api/src/imbi/api/endpoints/_document_reads.py
+++ b/apps/api/src/imbi/api/endpoints/_document_reads.py
@@ -269,8 +269,8 @@ SELECT org_slug,
        any(project_id)         AS project_id,
        max(document_version)   AS document_version,
        max(estimated_read_ms)  AS estimated_read_ms,
-       min(session_started_at) AS started_at,
-       max(recorded_at)        AS ended_at,
+       min(seq_started_at)     AS started_at,
+       max(seq_recorded_at)    AS ended_at,
        sum(engaged_ms)         AS engaged_ms,
        max(max_scroll_pct)     AS max_scroll_pct
 FROM (
@@ -283,8 +283,13 @@ FROM (
            argMax(project_id, recorded_at)         AS project_id,
            argMax(document_version, recorded_at)   AS document_version,
            argMax(estimated_read_ms, recorded_at)  AS estimated_read_ms,
-           min(session_started_at)                 AS session_started_at,
-           max(recorded_at)                        AS recorded_at,
+           -- Deliberately *not* aliased back to the source column names:
+           -- `recorded_at` is the ordering argument of every `argMax` in
+           -- this select list, and an alias shadowing it makes each one
+           -- read as `argMax(x, max(recorded_at))` -- nested aggregation,
+           -- which the server rejects outright (ILLEGAL_AGGREGATION).
+           min(session_started_at)                 AS seq_started_at,
+           max(recorded_at)                        AS seq_recorded_at,
            argMax(engaged_ms, recorded_at)         AS engaged_ms,
            argMax(max_scroll_pct, recorded_at)     AS max_scroll_pct
     FROM imbi.document_read_events

--- a/apps/api/src/imbi/api/endpoints/dashboard.py
+++ b/apps/api/src/imbi/api/endpoints/dashboard.py
@@ -258,6 +258,9 @@ async def get_dashboard_status(
                 ),
                 _check_service(http_client, 'Gateway', internal.gateway_url),
                 _check_service(http_client, 'MCP', internal.mcp_url),
+                _check_service(
+                    http_client, 'Scheduler', internal.scheduler_url
+                ),
                 _check_service(http_client, 'Slackbot', internal.slackbot_url),
             ),
         )

--- a/apps/api/src/imbi/api/settings.py
+++ b/apps/api/src/imbi/api/settings.py
@@ -222,10 +222,15 @@ class InternalServices(pydantic_settings.BaseSettings):
     assistant_url: str = ''
     gateway_url: str = ''
     mcp_url: str = ''
+    scheduler_url: str = ''
     slackbot_url: str = ''
 
     @pydantic.field_validator(
-        'assistant_url', 'gateway_url', 'mcp_url', 'slackbot_url'
+        'assistant_url',
+        'gateway_url',
+        'mcp_url',
+        'scheduler_url',
+        'slackbot_url',
     )
     @classmethod
     def _strip_slash(cls, value: str) -> str:

--- a/apps/api/tests/endpoints/test_dashboard.py
+++ b/apps/api/tests/endpoints/test_dashboard.py
@@ -89,7 +89,7 @@ class DashboardStatusEndpointTestCase(support.SharedAppTestCase):
         self.pg_size_patch = mock.patch.object(
             dashboard, '_postgres_size', mock.AsyncMock(return_value=4096)
         )
-        # All four sibling services configured.
+        # All five sibling services configured.
         self.services_patch = mock.patch.object(
             dashboard.settings,
             'get_internal_services',
@@ -97,6 +97,7 @@ class DashboardStatusEndpointTestCase(support.SharedAppTestCase):
                 assistant_url='http://assistant:8002',
                 gateway_url='http://gateway:8003',
                 mcp_url='http://mcp:8001',
+                scheduler_url='http://scheduler:8005',
                 slackbot_url='http://slackbot:8004',
             ),
         )
@@ -131,7 +132,8 @@ class DashboardStatusEndpointTestCase(support.SharedAppTestCase):
 
         services = {s['name']: s for s in body['services']}
         self.assertEqual(
-            {'API', 'Assistant', 'Gateway', 'MCP', 'Slackbot'}, set(services)
+            {'API', 'Assistant', 'Gateway', 'MCP', 'Scheduler', 'Slackbot'},
+            set(services),
         )
         for entry in services.values():
             self.assertEqual('up', entry['status'])
@@ -180,6 +182,8 @@ class DashboardStatusEndpointTestCase(support.SharedAppTestCase):
         services = {s['name']: s for s in response.json()['services']}
         self.assertEqual('down', services['Slackbot']['status'])
         self.assertEqual('not configured', services['Slackbot']['detail'])
+        self.assertEqual('down', services['Scheduler']['status'])
+        self.assertEqual('not configured', services['Scheduler']['detail'])
 
     def test_requires_permission(self) -> None:
         """A non-admin without admin:dashboard:read is forbidden."""

--- a/apps/api/tests/endpoints/test_document_reads_sql.py
+++ b/apps/api/tests/endpoints/test_document_reads_sql.py
@@ -1,0 +1,50 @@
+"""The read-analytics SQL, executed against a live ClickHouse.
+
+Every other test in this suite mocks ClickHouse, which cannot catch a query
+the server refuses to analyze. ``_SESSION_AGGREGATE_SQL`` shipped with an
+inner alias shadowing the ``argMax`` ordering column, so the finalizer raised
+``ILLEGAL_AGGREGATION`` on every call and ``document_read_sessions`` stayed
+empty -- with the failure swallowed by the finalizer's own except/log. These
+run each statement with a session id that matches nothing: both errors are
+raised at analysis time, so an invalid query still fails while a valid one
+writes nothing.
+"""
+
+import unittest
+
+from imbi.api.endpoints import _document_reads
+from imbi.common import clickhouse
+
+
+class ReadAnalyticsSqlTestCase(unittest.IsolatedAsyncioTestCase):
+    """Executes the finalizer and reaper SQL for real."""
+
+    async def asyncSetUp(self) -> None:
+        await clickhouse.initialize()
+        await clickhouse.setup_schema()
+
+    async def asyncTearDown(self) -> None:
+        # The client singleton binds to the loop that created it, and
+        # IsolatedAsyncioTestCase gives each test method its own. Left open,
+        # the next test to touch it fails with "Event loop is closed".
+        await clickhouse.aclose()
+
+    async def test_analytics_sql_is_valid(self) -> None:
+        """The finalizer and reaper queries both analyze and run.
+
+        One test rather than two: see ``asyncTearDown``.
+        """
+        aggregates = await clickhouse.query(
+            _document_reads._SESSION_AGGREGATE_SQL,
+            {'session_ids': ['no-such-session']},
+        )
+        self.assertEqual([], aggregates)
+        stale = await clickhouse.query(
+            _document_reads._STALE_SESSION_SQL,
+            {
+                'idle_seconds': _document_reads.SESSION_IDLE_TIMEOUT_SECONDS,
+                'lookback_hours': _document_reads.SWEEP_LOOKBACK_HOURS,
+                'batch': 1,
+            },
+        )
+        self.assertIsInstance(stale, list)

--- a/apps/api/tests/endpoints/test_document_reads_sql.py
+++ b/apps/api/tests/endpoints/test_document_reads_sql.py
@@ -14,26 +14,31 @@ import unittest
 
 from imbi.api.endpoints import _document_reads
 from imbi.common import clickhouse
+from imbi.common.clickhouse import client
 
 
 class ReadAnalyticsSqlTestCase(unittest.IsolatedAsyncioTestCase):
     """Executes the finalizer and reaper SQL for real."""
 
     async def asyncSetUp(self) -> None:
+        # ``Clickhouse`` is a process-wide singleton and its client binds to
+        # the loop that opened it, while IsolatedAsyncioTestCase gives each
+        # test method its own loop. An earlier test in the same session may
+        # have left the singleton connected, in which case ``initialize()``
+        # is a no-op and the first request here dies on that dead loop. Take
+        # a private instance instead, and hand the old one back afterwards.
+        self._previous = client.Clickhouse._instance
+        client.Clickhouse._instance = None
+        self.addAsyncCleanup(self._restore_singleton)
         await clickhouse.initialize()
         await clickhouse.setup_schema()
 
-    async def asyncTearDown(self) -> None:
-        # The client singleton binds to the loop that created it, and
-        # IsolatedAsyncioTestCase gives each test method its own. Left open,
-        # the next test to touch it fails with "Event loop is closed".
+    async def _restore_singleton(self) -> None:
         await clickhouse.aclose()
+        client.Clickhouse._instance = self._previous
 
     async def test_analytics_sql_is_valid(self) -> None:
-        """The finalizer and reaper queries both analyze and run.
-
-        One test rather than two: see ``asyncTearDown``.
-        """
+        """The finalizer and reaper queries both analyze and run."""
         aggregates = await clickhouse.query(
             _document_reads._SESSION_AGGREGATE_SQL,
             {'session_ids': ['no-such-session']},

--- a/libraries/common/src/imbi/common/clickhouse/schemata.toml
+++ b/libraries/common/src/imbi/common/clickhouse/schemata.toml
@@ -241,8 +241,11 @@ ORDER BY (task_id, run_id)
 -- server, both ways. Keying on `fired_at`, which every row of a run shares,
 -- expires the pair together instead. The cost is that a run stranded in
 -- `running` by a replica that died mid-flight also ages out at 90 days rather
--- than being kept as evidence.
-TTL fired_at + INTERVAL 90 DAY;
+-- than being kept as evidence. `toDateTime` is required rather than cosmetic:
+-- a TTL expression must yield Date or DateTime, and `DateTime64 + INTERVAL`
+-- yields DateTime64, which the server rejects with BAD_TTL_EXPRESSION at
+-- CREATE time. Matches the document analytics tables below.
+TTL toDateTime(fired_at) + INTERVAL 90 DAY;
 """
 enabled = true
 

--- a/ui/src/components/admin/AdminOverview.tsx
+++ b/ui/src/components/admin/AdminOverview.tsx
@@ -15,6 +15,7 @@ import {
   ArrowUpRight,
   BookOpen,
   Box,
+  CalendarClock,
   Database,
   GitFork,
   GitPullRequest,
@@ -55,6 +56,7 @@ const SERVICE_ICONS: Record<string, LucideIcon> = {
   Assistant: Sparkles,
   Gateway: ArrowLeftRight,
   MCP: Plug,
+  Scheduler: CalendarClock,
   Slackbot: Hash,
 }
 


### PR DESCRIPTION
## Summary

Three independent post-2.22 defects, each found by inspecting a running cluster rather than by a failing test.

## Problem

1. **imbi-scheduler is missing from the admin System health card.** 2.22 shipped the scheduler as a sibling service but `/admin/dashboard/status` never probed it, so the Services list showed five of six processes and a down scheduler read as "everything is fine".

2. **`imbi.scheduler_runs` does not exist in the cluster.** `imbi-api setup-clickhouse` fails to create it with `BAD_TTL_EXPRESSION`: a TTL expression must yield `Date` or `DateTime`, and `fired_at + INTERVAL 90 DAY` yields `DateTime64` because `fired_at` is `DateTime64(3, 'UTC')`. Every run-history write has been failing. The bare form is accepted by ClickHouse 26.6 (the docker test stack) and rejected by 25.3.8 Altinity (the cluster), which is why it passed locally and only failed on deploy. `setup_schema()` logs the failed DDL and continues, so the command still printed `✓ ClickHouse schema created successfully`.

3. **`document_read_sessions` is empty** while `document_read_events` fills up normally. The inner subquery of `_SESSION_AGGREGATE_SQL` aliased `max(recorded_at) AS recorded_at`, shadowing the source column that is also the ordering argument of all six `argMax()` calls in the same select list. Each read as `argMax(x, max(recorded_at))`, so the server rejected the statement at analysis time with `ILLEGAL_AGGREGATION` — on every session, from both writers (the final-beacon background task and the 60s reaper). `finalize_sessions` catches, logs, and returns 0, so ingest kept answering 202 and nothing surfaced. Every reported read metric derives from this table, so all of them read as zero.

## Solution

1. Add `scheduler_url` to `InternalServices` (`IMBI_INTERNAL_SCHEDULER_URL`) and probe it alongside the other siblings; the scheduler's `/status` is unprefixed, so the base URL needs no `IMBI_SCHEDULER_API_PREFIX` handling. Map `Scheduler` to a `CalendarClock` icon in the UI — the rows render generically off the endpoint payload.
2. Wrap the TTL column in `toDateTime()`, matching the document analytics tables that already do.
3. Rename the two colliding aliases to `seq_started_at` / `seq_recorded_at`.

## Verification

All against a live ClickHouse, since none of this is reachable through the existing mocks:

- Both TTL forms executed directly: bare accepted on 26.6, `toDateTime()` accepted on both.
- Replayed real heartbeats through the finalizer: before, `DatabaseError ... ILLEGAL_AGGREGATION`; after, the aggregate returns one row per session and `finalize_sessions` writes it (`engaged_ms=57668, max_scroll_pct=100, is_view=1, is_read=1`).
- Reaper path probed separately: `stale_session_ids()` returns an abandoned session, finalizes it, then stops reporting it.
- New `apps/api/tests/endpoints/test_document_reads_sql.py` runs the finalizer and reaper statements against the live server with a session id matching nothing. Every other test in this suite mocks ClickHouse, which cannot catch a query the server refuses to parse; both errors are raised at analysis time, so an invalid query still fails while a valid one writes no rows.
- `pytest` on the touched suites (dashboard, document reads/analytics, common clickhouse, scheduler runs) passes; `ruff check`/`format` clean; UI `tsc --noEmit` clean and `npm run lint` 0 errors.

## Deploy notes

- The scheduler row shows *not configured* until `IMBI_INTERNAL_SCHEDULER_URL` is set. The chart sets no `IMBI_INTERNAL_*_URL` for any sibling today, so this matches how Assistant/Gateway/MCP/Slackbot already behave there; the dev compose file (in the separate dev-env repo) sets it.
- Re-run `imbi-api setup-clickhouse` after deploy and confirm `EXISTS imbi.scheduler_runs`.
- Existing read sessions get finalized on the reaper's next sweep if they are inside the 24h `SWEEP_LOOKBACK_HOURS` window; anything older is lost.

## Not fixed here

`setup_schema()` (`libraries/common/src/imbi/common/clickhouse/client.py:306`) reports success when a schemata query fails, which is what hid problem 2. Worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)