### PR TITLE
Add Duplicate action to project configuration detail pane

### DIFF
--- a/ui/src/components/project/ConfigurationTab.tsx
+++ b/ui/src/components/project/ConfigurationTab.tsx
@@ -75,6 +75,7 @@ interface ConfigurationTabProps {
 interface CreateDraft {
   data_type: DataType
   key: string
+  targets?: string[]
   values: Record<string, string>
 }
 
@@ -398,6 +399,7 @@ export function ConfigurationTab({
     setDraft({
       data_type: effectiveSelectedType,
       key: prefix,
+      targets: envSlugs.filter((s) => Boolean(selected.envs[s])),
       values: Object.fromEntries(
         envSlugs.map((s) => [
           s,
@@ -555,7 +557,11 @@ export function ConfigurationTab({
       toast.error('Key is required')
       return
     }
-    const targets = envSlugs.filter((slug) => draft.values[slug]?.trim())
+    // Duplicate drafts carry the source's environments so explicitly
+    // empty values still save; hand-typed drafts derive them from text.
+    const targets = envSlugs.filter(
+      (slug) => draft.targets?.includes(slug) || draft.values[slug]?.trim(),
+    )
     if (targets.length === 0) {
       toast.error('Set a value for at least one environment')
       return

--- a/ui/src/components/project/ConfigurationTab.tsx
+++ b/ui/src/components/project/ConfigurationTab.tsx
@@ -80,6 +80,7 @@ interface CreateDraft {
 
 interface DetailPaneProps {
   draft?: CreateDraft
+  duplicateBlockedReason?: null | string
   environments: Environment[]
   isCreate?: boolean
   onAdd?: () => void
@@ -98,6 +99,14 @@ interface DetailPaneProps {
   typeOverride?: DataType | null
   valueLoadingByEnv?: Record<string, boolean>
   valuesByEnv?: Record<string, Record<string, unknown>>
+}
+
+interface DuplicateGateInput {
+  environments: Environment[]
+  key: AggregatedKey
+  valueErrorByEnv: Record<string, boolean>
+  valueLoadingByEnv: Record<string, boolean>
+  valuesByEnv: Record<string, Record<string, unknown>>
 }
 
 interface EnvRowProps {
@@ -315,6 +324,11 @@ export function ConfigurationTab({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [sortedEnvironments, ...valueLoadingFlags])
 
+  const valueErrorByEnv: Record<string, boolean> = {}
+  sortedEnvironments.forEach((env, idx) => {
+    valueErrorByEnv[env.slug] = Boolean(valueQueries[idx]?.isError)
+  })
+
   const filtered = useMemo(() => {
     const q = filter.trim().toLowerCase()
     if (!q) return aggregated
@@ -346,6 +360,25 @@ export function ConfigurationTab({
     }
   }, [aggregated, mode, selected])
 
+  const selectedTypeOverride: DataType | null =
+    typeOverride && selected && typeOverride.key === selected.key
+      ? typeOverride.type
+      : null
+
+  const effectiveSelectedType: DataType =
+    selectedTypeOverride ??
+    (selected?.secret ? 'secret' : (selected?.data_type ?? 'string'))
+
+  const duplicateBlocked = selected
+    ? duplicateBlockedReason({
+        environments: sortedEnvironments,
+        key: selected,
+        valueErrorByEnv,
+        valueLoadingByEnv,
+        valuesByEnv,
+      })
+    : null
+
   // Enters create mode with an empty draft.
   const startCreate = () => {
     setDraft({
@@ -356,18 +389,19 @@ export function ConfigurationTab({
     setMode('create')
   }
 
-  // Enters create mode with `source`'s data_type and per-environment
-  // values; the name is empty.
-  const startDuplicate = (source: AggregatedKey) => {
+  const startDuplicate = () => {
+    if (!selected) return
+    if (duplicateBlocked) {
+      toast.error(duplicateBlocked)
+      return
+    }
     setDraft({
-      data_type: source.secret ? 'secret' : source.data_type,
+      data_type: effectiveSelectedType,
       key: prefix,
       values: Object.fromEntries(
         envSlugs.map((s) => [
           s,
-          source.envs[s]
-            ? ((valuesByEnv[s]?.[source.key] as string | undefined) ?? '')
-            : '',
+          selected.envs[s] ? (valuesByEnv[s]?.[selected.key] as string) : '',
         ]),
       ),
     })
@@ -670,22 +704,19 @@ export function ConfigurationTab({
             />
           ) : selected ? (
             <DetailPane
+              duplicateBlockedReason={duplicateBlocked}
               environments={sortedEnvironments}
               onAdd={startCreate}
               onCommitType={handleCommitType}
               onCommitValue={handleCommitValue}
               onDelete={() => setConfirmDelete(selected.key)}
-              onDuplicate={() => startDuplicate(selected)}
+              onDuplicate={startDuplicate}
               onToggleReveal={toggleReveal}
               prefix={prefix}
               revealed={revealed}
               savedFlash={savedFlash}
               selected={selected}
-              typeOverride={
-                typeOverride && typeOverride.key === selected.key
-                  ? typeOverride.type
-                  : null
-              }
+              typeOverride={selectedTypeOverride}
               valueLoadingByEnv={valueLoadingByEnv}
               valuesByEnv={valuesByEnv}
             />
@@ -839,6 +870,7 @@ function containsCredentials(value: string): boolean {
 
 function DetailPane({
   draft,
+  duplicateBlockedReason,
   environments,
   isCreate,
   onAdd,
@@ -907,7 +939,16 @@ function DetailPane({
           </span>
         )}
         {!isCreate && onDuplicate && (
-          <Button onClick={onDuplicate} size="sm" variant="outline">
+          <Button
+            disabled={Boolean(duplicateBlockedReason)}
+            onClick={onDuplicate}
+            size="sm"
+            title={
+              duplicateBlockedReason ??
+              "Copy this parameter's type and values into a new key"
+            }
+            variant="outline"
+          >
             <CopyPlus className="size-3" /> Duplicate
           </Button>
         )}
@@ -1035,6 +1076,34 @@ function DetailPane({
       </div>
     </div>
   )
+}
+
+function duplicateBlockedReason({
+  environments,
+  key,
+  valueErrorByEnv,
+  valueLoadingByEnv,
+  valuesByEnv,
+}: DuplicateGateInput): null | string {
+  const targets = environments.filter((env) => key.envs[env.slug])
+  if (targets.length === 0) return 'This parameter has no values to copy'
+  const names = (envs: Environment[]) => envs.map((e) => e.name).join(', ')
+  if (targets.some((env) => valueLoadingByEnv[env.slug])) {
+    return 'Values are still loading'
+  }
+  const failed = targets.filter((env) => valueErrorByEnv[env.slug])
+  if (failed.length > 0) {
+    return `Values failed to load for ${names(failed)}`
+  }
+  const unreadable = targets.filter(
+    (env) => typeof valuesByEnv[env.slug]?.[key.key] !== 'string',
+  )
+  if (unreadable.length > 0) {
+    return key.secret
+      ? `Secret values are not readable for ${names(unreadable)}`
+      : `Values are unavailable for ${names(unreadable)}`
+  }
+  return null
 }
 
 function EmptyState({ onAdd }: { onAdd: () => void }) {

--- a/ui/src/components/project/ConfigurationTab.tsx
+++ b/ui/src/components/project/ConfigurationTab.tsx
@@ -10,6 +10,7 @@ import {
 } from '@tanstack/react-query'
 import {
   Check,
+  CopyPlus,
   Eye,
   EyeOff,
   Lock,
@@ -88,6 +89,7 @@ interface DetailPaneProps {
   onCreate?: () => void
   onDelete?: () => void
   onDraftChange?: (next: CreateDraft) => void
+  onDuplicate?: () => void
   onToggleReveal?: (envSlug: string, key: string) => void
   prefix: string
   revealed?: Record<string, boolean>
@@ -344,16 +346,33 @@ export function ConfigurationTab({
     }
   }, [aggregated, mode, selected])
 
-  // Reset draft entering create mode.
-  useEffect(() => {
-    if (mode === 'create') {
-      setDraft({
-        data_type: 'string',
-        key: prefix,
-        values: Object.fromEntries(envSlugs.map((s) => [s, ''])),
-      })
-    }
-  }, [mode, prefix, envSlugs])
+  // Enters create mode with an empty draft.
+  const startCreate = () => {
+    setDraft({
+      data_type: 'string',
+      key: prefix,
+      values: Object.fromEntries(envSlugs.map((s) => [s, ''])),
+    })
+    setMode('create')
+  }
+
+  // Enters create mode with `source`'s data_type and per-environment
+  // values; the name is empty.
+  const startDuplicate = (source: AggregatedKey) => {
+    setDraft({
+      data_type: source.secret ? 'secret' : source.data_type,
+      key: prefix,
+      values: Object.fromEntries(
+        envSlugs.map((s) => [
+          s,
+          source.envs[s]
+            ? ((valuesByEnv[s]?.[source.key] as string | undefined) ?? '')
+            : '',
+        ]),
+      ),
+    })
+    setMode('create')
+  }
 
   const setMutation = useMutation({
     mutationFn: ({
@@ -652,10 +671,11 @@ export function ConfigurationTab({
           ) : selected ? (
             <DetailPane
               environments={sortedEnvironments}
-              onAdd={() => setMode('create')}
+              onAdd={startCreate}
               onCommitType={handleCommitType}
               onCommitValue={handleCommitValue}
               onDelete={() => setConfirmDelete(selected.key)}
+              onDuplicate={() => startDuplicate(selected)}
               onToggleReveal={toggleReveal}
               prefix={prefix}
               revealed={revealed}
@@ -670,7 +690,7 @@ export function ConfigurationTab({
               valuesByEnv={valuesByEnv}
             />
           ) : (
-            <EmptyState onAdd={() => setMode('create')} />
+            <EmptyState onAdd={startCreate} />
           )}
         </Panel>
       </Group>
@@ -828,6 +848,7 @@ function DetailPane({
   onCreate,
   onDelete,
   onDraftChange,
+  onDuplicate,
   onToggleReveal,
   prefix,
   revealed,
@@ -884,6 +905,11 @@ function DetailPane({
           <span className="text-success inline-flex items-center gap-1 text-xs">
             <Check className="size-3" /> Saved
           </span>
+        )}
+        {!isCreate && onDuplicate && (
+          <Button onClick={onDuplicate} size="sm" variant="outline">
+            <CopyPlus className="size-3" /> Duplicate
+          </Button>
         )}
         {!isCreate && onAdd && (
           <Button onClick={onAdd} size="sm">

--- a/ui/src/components/project/__tests__/ConfigurationTab.test.tsx
+++ b/ui/src/components/project/__tests__/ConfigurationTab.test.tsx
@@ -160,6 +160,54 @@ describe('ConfigurationTab Duplicate action', () => {
     )
   })
 
+  it('preserves an explicitly empty source value when duplicating', async () => {
+    stubValues({
+      production: async () => [value(PASSWORD_KEY, '')],
+      staging: async () => [value(PASSWORD_KEY, 'pw-staging')],
+    })
+    renderTab()
+    const button = await duplicateButton()
+    await waitFor(() => expect(button).toBeEnabled())
+
+    const user = userEvent.setup()
+    await user.click(button)
+    await user.click(await screen.findByRole('button', { name: /save/i }))
+
+    await waitFor(() => expect(setConfigurationValue).toHaveBeenCalledTimes(2))
+    expect(setConfigurationValue).toHaveBeenLastCalledWith(
+      'acme',
+      'proj-1',
+      'imbi/acme/db/',
+      { data_type: 'string', secret: false, value: '' },
+      { environment: 'production', source: 'aws' },
+    )
+  })
+
+  it('duplicates a key whose source values are all empty', async () => {
+    stubValues({
+      production: async () => [value(PASSWORD_KEY, '')],
+      staging: async () => [value(PASSWORD_KEY, '')],
+    })
+    renderTab()
+    const button = await duplicateButton()
+    await waitFor(() => expect(button).toBeEnabled())
+
+    const user = userEvent.setup()
+    await user.click(button)
+    await user.click(await screen.findByRole('button', { name: /save/i }))
+
+    await waitFor(() => expect(setConfigurationValue).toHaveBeenCalledTimes(2))
+    for (const env of ['staging', 'production']) {
+      expect(setConfigurationValue).toHaveBeenCalledWith(
+        'acme',
+        'proj-1',
+        'imbi/acme/db/',
+        { data_type: 'string', secret: false, value: '' },
+        { environment: env, source: 'aws' },
+      )
+    }
+  })
+
   it('uses the pending type override when duplicating', async () => {
     stubValues({
       production: async () => [value(PASSWORD_KEY, 'pw-prod')],

--- a/ui/src/components/project/__tests__/ConfigurationTab.test.tsx
+++ b/ui/src/components/project/__tests__/ConfigurationTab.test.tsx
@@ -174,7 +174,14 @@ describe('ConfigurationTab Duplicate action', () => {
     await user.click(await screen.findByRole('button', { name: /save/i }))
 
     await waitFor(() => expect(setConfigurationValue).toHaveBeenCalledTimes(2))
-    expect(setConfigurationValue).toHaveBeenLastCalledWith(
+    expect(setConfigurationValue).toHaveBeenCalledWith(
+      'acme',
+      'proj-1',
+      'imbi/acme/db/',
+      { data_type: 'string', secret: false, value: 'pw-staging' },
+      { environment: 'staging', source: 'aws' },
+    )
+    expect(setConfigurationValue).toHaveBeenCalledWith(
       'acme',
       'proj-1',
       'imbi/acme/db/',

--- a/ui/src/components/project/__tests__/ConfigurationTab.test.tsx
+++ b/ui/src/components/project/__tests__/ConfigurationTab.test.tsx
@@ -1,0 +1,187 @@
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { ApiError } from '@/api/client'
+import {
+  fetchConfigurationValues,
+  listConfigurationKeys,
+  setConfigurationValue,
+} from '@/api/endpoints'
+import { ConfigurationTab } from '@/components/project/ConfigurationTab'
+import { ThemeProvider } from '@/contexts/ThemeContext'
+import { render, screen, waitFor } from '@/test/utils'
+import type { ConfigKeyValueResponse, Environment } from '@/types'
+
+vi.mock('@/api/endpoints', () => ({
+  deleteConfigurationKey: vi.fn(),
+  fetchConfigurationValues: vi.fn(),
+  getConfigurationPrefix: vi.fn(async () => ({ prefix: 'imbi/acme/' })),
+  listConfigurationKeys: vi.fn(),
+  listProjectPlugins: vi.fn(async () => [
+    { label: 'AWS SSM', plugin_id: 'aws', plugin_type: 'configuration' },
+  ]),
+  setConfigurationValue: vi.fn(() => new Promise(() => {})),
+}))
+
+const PASSWORD_KEY = 'imbi/acme/db/password'
+const USER_KEY = 'imbi/acme/db/user'
+
+const environments = [
+  { name: 'Staging', slug: 'staging', sort_order: 1 },
+  { name: 'Production', slug: 'production', sort_order: 2 },
+] as unknown as Environment[]
+
+const keyList = (secret = false) => [
+  {
+    data_type: secret ? 'secret' : 'string',
+    key: PASSWORD_KEY,
+    last_modified: null,
+    secret,
+  },
+  { data_type: 'string', key: USER_KEY, last_modified: null, secret: false },
+]
+
+const value = (key: string, val: string): ConfigKeyValueResponse => ({
+  data_type: 'string',
+  key,
+  last_modified: null,
+  secret: false,
+  value: val,
+})
+
+// Resolves the values query per environment from `byEnv`; a missing entry
+// leaves the query pending forever.
+function stubValues(
+  byEnv: Record<string, (() => Promise<ConfigKeyValueResponse[]>) | undefined>,
+) {
+  vi.mocked(fetchConfigurationValues).mockImplementation(
+    (_org, _project, _keys, params) => {
+      const handler = byEnv[params?.environment ?? '']
+      if (!handler) return new Promise(() => {})
+      return handler()
+    },
+  )
+}
+
+const renderTab = () =>
+  render(
+    <ThemeProvider>
+      <ConfigurationTab
+        environments={environments}
+        orgSlug="acme"
+        projectId="proj-1"
+      />
+    </ThemeProvider>,
+  )
+
+const duplicateButton = async () =>
+  await screen.findByRole('button', { name: /duplicate/i })
+
+describe('ConfigurationTab Duplicate action', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(setConfigurationValue).mockImplementation(
+      () => new Promise(() => {}) as never,
+    )
+    vi.mocked(listConfigurationKeys).mockImplementation(
+      async () => keyList() as never,
+    )
+  })
+
+  it('disables Duplicate while an environment value query is pending', async () => {
+    stubValues({
+      staging: async () => [value(PASSWORD_KEY, 'pw-staging')],
+    })
+    renderTab()
+    const button = await duplicateButton()
+    await waitFor(() => expect(button).toBeDisabled())
+    expect(button).toHaveAttribute('title', 'Values are still loading')
+  })
+
+  it('disables Duplicate when a value query rejects with 403', async () => {
+    stubValues({
+      production: () => Promise.reject(new ApiError(403, 'Forbidden')),
+      staging: async () => [value(PASSWORD_KEY, 'pw-staging')],
+    })
+    renderTab()
+    const button = await duplicateButton()
+    await waitFor(() =>
+      expect(button).toHaveAttribute(
+        'title',
+        'Values failed to load for Production',
+      ),
+    )
+    expect(button).toBeDisabled()
+  })
+
+  it('disables Duplicate when the values response omits the key for an environment', async () => {
+    stubValues({
+      production: async () => [value(USER_KEY, 'user-prod')],
+      staging: async () => [value(PASSWORD_KEY, 'pw-staging')],
+    })
+    renderTab()
+    const button = await duplicateButton()
+    await waitFor(() =>
+      expect(button).toHaveAttribute(
+        'title',
+        'Values are unavailable for Production',
+      ),
+    )
+    expect(button).toBeDisabled()
+  })
+
+  it('enables Duplicate once every environment value has landed, and writes each environment value on Save', async () => {
+    stubValues({
+      production: async () => [value(PASSWORD_KEY, 'pw-prod')],
+      staging: async () => [value(PASSWORD_KEY, 'pw-staging')],
+    })
+    renderTab()
+    const button = await duplicateButton()
+    await waitFor(() => expect(button).toBeEnabled())
+
+    const user = userEvent.setup()
+    await user.click(button)
+    await user.click(await screen.findByRole('button', { name: /save/i }))
+
+    await waitFor(() => expect(setConfigurationValue).toHaveBeenCalledTimes(2))
+    expect(setConfigurationValue).toHaveBeenCalledWith(
+      'acme',
+      'proj-1',
+      'imbi/acme/db/',
+      { data_type: 'string', secret: false, value: 'pw-staging' },
+      { environment: 'staging', source: 'aws' },
+    )
+    expect(setConfigurationValue).toHaveBeenLastCalledWith(
+      'acme',
+      'proj-1',
+      'imbi/acme/db/',
+      { data_type: 'string', secret: false, value: 'pw-prod' },
+      { environment: 'production', source: 'aws' },
+    )
+  })
+
+  it('uses the pending type override when duplicating', async () => {
+    stubValues({
+      production: async () => [value(PASSWORD_KEY, 'pw-prod')],
+      staging: async () => [value(PASSWORD_KEY, 'pw-staging')],
+    })
+    renderTab()
+    const button = await duplicateButton()
+    await waitFor(() => expect(button).toBeEnabled())
+
+    const user = userEvent.setup()
+    await user.click(screen.getByRole('button', { name: 'Secret' }))
+    await user.click(button)
+    await user.click(await screen.findByRole('button', { name: /save/i }))
+
+    await waitFor(() =>
+      expect(setConfigurationValue).toHaveBeenLastCalledWith(
+        'acme',
+        'proj-1',
+        'imbi/acme/db/',
+        { data_type: 'secret', secret: true, value: 'pw-prod' },
+        { environment: 'production', source: 'aws' },
+      ),
+    )
+  })
+})


### PR DESCRIPTION
- New Duplicate button copies the selected key's type and per-environment values into a fresh create draft
- Replace create-mode reset effect with explicit startCreate and startDuplicate handlers