### PR TITLE
Add Open and Closed columns to the PR Activity report

### DIFF
--- a/apps/api/src/imbi/api/endpoints/pull_requests.py
+++ b/apps/api/src/imbi/api/endpoints/pull_requests.py
@@ -81,6 +81,8 @@ class PRActivityRow(pydantic.BaseModel):
     display_name: str | None = None
     avatar_url: str | None = None
     created: int
+    open: int
+    closed: int
     merged: int
 
 
@@ -359,12 +361,18 @@ async def _fetch_pr_activity(
     project_ids: list[str],
     since: datetime.datetime,
 ) -> list[dict[str, typing.Any]]:
-    """Aggregate created/merged PR counts per author since *since*.
+    """Aggregate created/open/closed/merged counts per author.
 
     A PR counts toward ``created`` when created on/after ``since`` and
     toward ``merged`` when merged on/after ``since`` -- the two use
     different anchors, so a PR opened earlier but merged in-window still
     contributes to ``merged``.
+
+    ``open`` and ``closed`` are current-state breakdowns of the PRs
+    created in-window: ``open`` is still open, ``closed`` was closed
+    without merging.  Both anchor on ``created_at`` because the table
+    carries no close timestamp -- only ``merged_at`` -- so a PR closed
+    in-window but opened earlier cannot be attributed to the window.
     """
     if not project_ids:
         return []
@@ -374,6 +382,10 @@ async def _fetch_pr_activity(
     sql = (
         'SELECT author,'
         ' countIf(created_at >= {since:DateTime64(3)}) AS created_count,'
+        " countIf(state = 'open' AND created_at >= {since:DateTime64(3)})"
+        ' AS open_count,'
+        " countIf(state != 'open' AND NOT merged"
+        ' AND created_at >= {since:DateTime64(3)}) AS closed_count,'
         ' countIf(merged AND merged_at >= {since:DateTime64(3)})'
         ' AS merged_count'
         ' FROM pull_requests FINAL'
@@ -399,7 +411,7 @@ async def pull_request_activity(
     ],
     since: str | None = None,
 ) -> PRActivityResponse:
-    """Per-team-member PR activity (created/merged) across the org.
+    """Per-member PR activity (created/open/closed/merged) for the org.
 
     ``since`` is an inclusive lower bound (``YYYY-MM-DD`` or ISO
     timestamp); it defaults to 30 days ago.  Authors are resolved to
@@ -426,6 +438,8 @@ async def pull_request_activity(
                 display_name=user['display_name'] if user else None,
                 avatar_url=user['avatar_url'] if user else None,
                 created=created,
+                open=int(row.get('open_count') or 0),
+                closed=int(row.get('closed_count') or 0),
                 merged=merged,
             )
         )

--- a/apps/api/tests/endpoints/test_pull_requests.py
+++ b/apps/api/tests/endpoints/test_pull_requests.py
@@ -213,16 +213,22 @@ class PullRequestActivityTestCase(_PullRequestsTestBase):
                         {
                             'author': 'alice',
                             'created_count': 5,
+                            'open_count': 1,
+                            'closed_count': 2,
                             'merged_count': 3,
                         },
                         {
                             'author': 'ghost',
                             'created_count': 2,
+                            'open_count': 0,
+                            'closed_count': 1,
                             'merged_count': 1,
                         },
                         {
                             'author': 'idle',
                             'created_count': 0,
+                            'open_count': 0,
+                            'closed_count': 0,
                             'merged_count': 0,
                         },
                     ]
@@ -241,6 +247,8 @@ class PullRequestActivityTestCase(_PullRequestsTestBase):
         self.assertEqual(rows[0]['display_name'], 'Alice')
         self.assertEqual(rows[0]['email'], 'alice@example.com')
         self.assertEqual(rows[0]['merged'], 3)
+        self.assertEqual(rows[0]['open'], 1)
+        self.assertEqual(rows[0]['closed'], 2)
         # Unresolved login: raw login, no user fields.
         self.assertEqual(rows[1]['login'], 'ghost')
         self.assertIsNone(rows[1]['display_name'])

--- a/ui/src/api/endpoints.ts
+++ b/ui/src/api/endpoints.ts
@@ -2985,11 +2985,13 @@ export interface PRActivityResponse {
 
 export interface PRActivityRow {
   avatar_url: null | string
+  closed: number
   created: number
   display_name: null | string
   email: null | string
   login: string
   merged: number
+  open: number
 }
 
 export const getPRActivity = (

--- a/ui/src/components/reports/PRActivityReport.tsx
+++ b/ui/src/components/reports/PRActivityReport.tsx
@@ -9,6 +9,33 @@ import { Sk } from '@/components/ui/skeleton'
 import { UserIdentity } from '@/components/ui/user-identity'
 import { useOrganization } from '@/contexts/OrganizationContext'
 
+interface CountColumn {
+  key: string
+  label: string
+  pick: (row: PRActivityRow) => number
+  tone: CountTone
+}
+
+type CountTone = 'danger' | 'info' | 'warning'
+
+/**
+ * The numeric columns, in PR lifecycle order. `open` and `closed` are
+ * current-state breakdowns of the PRs created in-window; `closed` counts
+ * only PRs closed without merging.
+ */
+const COUNT_COLUMNS: CountColumn[] = [
+  { key: 'created', label: 'Created', pick: (r) => r.created, tone: 'warning' },
+  { key: 'open', label: 'Open', pick: (r) => r.open, tone: 'info' },
+  { key: 'closed', label: 'Closed', pick: (r) => r.closed, tone: 'danger' },
+  { key: 'merged', label: 'Merged ↓', pick: (r) => r.merged, tone: 'warning' },
+]
+
+const TONE_BACKGROUNDS: Record<CountTone, string> = {
+  danger: 'var(--background-color-danger)',
+  info: 'var(--background-color-info)',
+  warning: 'var(--background-color-warning)',
+}
+
 export function PRActivityReport() {
   const orgSlug = useOrgSlug()
   const [since, setSince] = useState(defaultSince)
@@ -59,16 +86,13 @@ function ActivityRowsSkeleton() {
                 <Sk line w={120} />
               </div>
             </td>
-            <td className="px-4 py-2.5">
-              <div className="flex justify-end">
-                <Sk h={16} r={3} w="70%" />
-              </div>
-            </td>
-            <td className="px-[18px] py-2.5">
-              <div className="flex justify-end">
-                <Sk h={16} r={3} w="70%" />
-              </div>
-            </td>
+            {COUNT_COLUMNS.map((col, c) => (
+              <td className={`${countCellX(c)} py-2.5`} key={col.key}>
+                <div className="flex justify-end">
+                  <Sk h={16} r={3} w="70%" />
+                </div>
+              </td>
+            ))}
           </tr>
         ))}
       </tbody>
@@ -77,10 +101,12 @@ function ActivityRowsSkeleton() {
 }
 
 function ActivityTable({ rows }: { rows: PRActivityRow[] }) {
-  const maxCreated = rows.reduce((m, r) => Math.max(m, r.created), 0)
-  const maxMerged = rows.reduce((m, r) => Math.max(m, r.merged), 0)
-  const totalCreated = rows.reduce((s, r) => s + r.created, 0)
-  const totalMerged = rows.reduce((s, r) => s + r.merged, 0)
+  const maxes = COUNT_COLUMNS.map((col) =>
+    rows.reduce((m, r) => Math.max(m, col.pick(r)), 0),
+  )
+  const totals = COUNT_COLUMNS.map((col) =>
+    rows.reduce((s, r) => s + col.pick(r), 0),
+  )
   return (
     <table className="w-full text-sm">
       <thead>
@@ -88,12 +114,14 @@ function ActivityTable({ rows }: { rows: PRActivityRow[] }) {
           <th className="text-overline text-tertiary px-[18px] py-2.5 text-left font-normal tracking-wide uppercase">
             Member
           </th>
-          <th className="text-overline text-tertiary w-48 px-4 py-2.5 text-right font-normal tracking-wide uppercase">
-            Created
-          </th>
-          <th className="text-overline text-tertiary w-48 px-[18px] py-2.5 text-right font-normal tracking-wide uppercase">
-            Merged ↓
-          </th>
+          {COUNT_COLUMNS.map((col, c) => (
+            <th
+              className={`text-overline text-tertiary w-32 ${countCellX(c)} py-2.5 text-right font-normal tracking-wide uppercase`}
+              key={col.key}
+            >
+              {col.label}
+            </th>
+          ))}
         </tr>
       </thead>
       <tbody>
@@ -112,12 +140,15 @@ function ActivityTable({ rows }: { rows: PRActivityRow[] }) {
                 size="small"
               />
             </td>
-            <td className="px-4 py-2.5">
-              <CountCell max={maxCreated} value={row.created} />
-            </td>
-            <td className="px-[18px] py-2.5">
-              <CountCell max={maxMerged} value={row.merged} />
-            </td>
+            {COUNT_COLUMNS.map((col, c) => (
+              <td className={`${countCellX(c)} py-2.5`} key={col.key}>
+                <CountCell
+                  max={maxes[c]}
+                  tone={col.tone}
+                  value={col.pick(row)}
+                />
+              </td>
+            ))}
           </tr>
         ))}
       </tbody>
@@ -126,12 +157,14 @@ function ActivityTable({ rows }: { rows: PRActivityRow[] }) {
           <td className="text-secondary px-[18px] py-3 text-xs font-medium tracking-wide uppercase">
             Total ({rows.length})
           </td>
-          <td className="text-primary px-4 py-3 text-right font-mono text-xs tabular-nums">
-            {totalCreated}
-          </td>
-          <td className="text-primary px-[18px] py-3 text-right font-mono text-xs tabular-nums">
-            {totalMerged}
-          </td>
+          {COUNT_COLUMNS.map((col, c) => (
+            <td
+              className={`text-primary ${countCellX(c)} py-3 text-right font-mono text-xs tabular-nums`}
+              key={col.key}
+            >
+              {totals[c]}
+            </td>
+          ))}
         </tr>
       </tfoot>
     </table>
@@ -186,8 +219,16 @@ function applySince(
   }
 }
 
-/** Number with an amber bar sized to its share of the column max. */
-function CountCell({ max, value }: { max: number; value: number }) {
+/** Number with a tinted bar sized to its share of the column max. */
+function CountCell({
+  max,
+  tone,
+  value,
+}: {
+  max: number
+  tone: CountTone
+  value: number
+}) {
   const pct = max > 0 ? (value / max) * 100 : 0
   return (
     <div className="relative flex h-6 items-center justify-end">
@@ -195,7 +236,7 @@ function CountCell({ max, value }: { max: number; value: number }) {
         <div
           className="absolute inset-y-0 left-0 rounded-sm"
           style={{
-            background: 'var(--background-color-warning)',
+            background: TONE_BACKGROUNDS[tone],
             width: `${pct}%`,
           }}
         />
@@ -215,15 +256,30 @@ function CountCell({ max, value }: { max: number; value: number }) {
   )
 }
 
+/** Horizontal padding for a count column; the last one hugs the edge. */
+function countCellX(index: number): string {
+  return index === COUNT_COLUMNS.length - 1 ? 'px-[18px]' : 'px-4'
+}
+
 /** Default report window: 30 days back from today. */
 function defaultSince(): string {
   return isoDaysAgo(30)
 }
 
 function downloadCsv(rows: PRActivityRow[], appliedSince: string) {
-  const header = ['Member', 'Login', 'Email', 'Created', 'Merged']
+  const header = [
+    'Member',
+    'Login',
+    'Email',
+    ...COUNT_COLUMNS.map((c) => c.label.replace(' ↓', '')),
+  ]
   const lines = rows.map((r) =>
-    [r.display_name ?? r.login, r.login, r.email ?? '', r.created, r.merged]
+    [
+      r.display_name ?? r.login,
+      r.login,
+      r.email ?? '',
+      ...COUNT_COLUMNS.map((c) => c.pick(r)),
+    ]
       .map((v) => `"${String(v).replace(/"/g, '""')}"`)
       .join(','),
   )

--- a/ui/src/pages/ReportsPage.tsx
+++ b/ui/src/pages/ReportsPage.tsx
@@ -50,11 +50,12 @@ const REPORTS: Report[] = [
     subtitle: 'Open pull requests, filterable by team and project type',
   },
   {
-    description: 'PRs created and merged per member',
+    description: 'PR outcomes per member',
     icon: Activity,
     id: 'pr-activity',
     label: 'PR Activity',
-    subtitle: 'PRs created and merged per team member, since a chosen date',
+    subtitle:
+      'PRs created, open, closed, and merged per team member, since a chosen date',
   },
   {
     description: 'Service dependency graph',


### PR DESCRIPTION
## Summary
Add **Open** and **Closed** columns to the PR Activity report, so a member's pull requests that were closed without merging are visible instead of silently disappearing between Created and Merged.

## Problem
The report showed only Created and Merged. A PR that a member opened and then closed without merging counted toward Created and then vanished — nothing accounted for the difference between the two columns. Reading the report, you could not tell whether the gap was work still in flight or work abandoned, which are very different signals.

## Solution
- Add two aggregates to the activity query. **Open** is `state = 'open'`; **Closed** is `state != 'open' AND NOT merged`, so a merged PR is never double-counted as closed.
- Widen `PRActivityRow` on both sides (`pull_requests.py` and the hand-written `endpoints.ts` types) with the two new fields.
- Drive the table header, body, footer totals, loading skeleton, and CSV export off a single `COUNT_COLUMNS` list instead of per-column duplication. This is why the UI diff is larger than two added columns would suggest — the previous code repeated each column's markup, max, and total by hand.
- Tint Open blue (`--background-color-info`) and Closed red (`--background-color-danger`); Created and Merged keep their existing amber, so the columns that were already there look unchanged.
- Update the report's own description and subtitle, which still advertised "created and merged".

### One design decision worth reviewing
Open and Closed anchor on `created_at`, while Merged continues to anchor on `merged_at`. The `pull_requests` ClickHouse table records only `merged_at` — there is no close timestamp — so a PR opened before the window but closed inside it cannot be attributed to the window. Open and Closed therefore read as "of the PRs created in this window, how many are still open / were closed unmerged".

Giving Closed true close-time attribution would require adding a `closed_at` column to the table and backfilling it from the GitHub PR sync. That is a schema change plus a backfill, so it is deliberately not in this PR.

## Impact
- Additive to the API response; no fields removed or renamed, so no existing consumer breaks.
- The CSV export gains two columns, and its header row is now derived from the column labels.
- `ui/src/types/api-generated.ts` still carries the old `PRActivityRow` schema. It is codegen output that needs `npm run codegen:fetch` against a running API, so it is not hand-edited here. Nothing breaks in the meantime — the report reads its types from `endpoints.ts`.
- No migration, no config change, no rollout coordination.

## Testing
- Ran the new aggregate against a live **ClickHouse 25.3** — the cluster's major version, deliberately not the 26.6 the docker test stack runs — using a fixture with one PR of each shape (still open, closed unmerged, merged in-window, merged in-window but opened before it). Result: `created 3, open 1, closed 1, merged 2`, matching the fixture, with no `ILLEGAL_AGGREGATION`. This version check is intentional: a previous fix on this table passed locally on 26.6 and failed on the 25.3 cluster.
- `pytest apps/api/tests/endpoints/test_pull_requests.py` — 11 passed; the activity test now asserts the new counts.
- `pre-commit` (ruff check, ruff format, mypy) clean on the Python files; `tsc --noEmit` clean; `oxlint` reports 0 errors, and warnings on `PRActivityReport.tsx` dropped from 22 to 17.
- Not yet exercised in a browser against real org data.
