### PR TITLE
ENG-100: Build the artifact before promoting a release

### DIFF
--- a/apps/api/src/imbi/api/app.py
+++ b/apps/api/src/imbi/api/app.py
@@ -28,6 +28,7 @@ def create_app() -> fastapi.FastAPI:
             lifespans.commit_sync_worker_hook,
             lifespans.pr_sync_worker_hook,
             lifespans.deployment_sync_worker_hook,
+            lifespans.release_promote_worker_hook,
             lifespans.maintenance_worker_hook,
             lifespans.identity_refresh_hook,
             lifespans.document_read_sweeper_hook,

--- a/apps/api/src/imbi/api/auth/principals.py
+++ b/apps/api/src/imbi/api/auth/principals.py
@@ -23,6 +23,7 @@ DEPLOYMENT_SYNC = 'deployment-sync'
 MAINTENANCE = 'maintenance'
 OPSLOG_BACKFILL = 'maintenance-opslog-backfill'
 PR_SYNC = 'pr-sync'
+RELEASE_PROMOTE = 'release-promote'
 #: Fallback stamped when a queued job carries no requesting principal.
 SYSTEM = 'system'
 
@@ -33,6 +34,7 @@ PROCESS_PRINCIPALS = frozenset(
         MAINTENANCE,
         OPSLOG_BACKFILL,
         PR_SYNC,
+        RELEASE_PROMOTE,
         SYSTEM,
     }
 )

--- a/apps/api/src/imbi/api/commit_sync/__init__.py
+++ b/apps/api/src/imbi/api/commit_sync/__init__.py
@@ -16,6 +16,7 @@ from imbi.api.commit_sync.service import (
     CommitSyncUnavailable,
     read_status,
     run_sync,
+    run_tag_sync,
 )
 
 __all__ = [
@@ -25,4 +26,5 @@ __all__ = [
     'enqueue_commit_sync',
     'read_status',
     'run_sync',
+    'run_tag_sync',
 ]

--- a/apps/api/src/imbi/api/commit_sync/service.py
+++ b/apps/api/src/imbi/api/commit_sync/service.py
@@ -165,6 +165,40 @@ async def run_sync(
     return counts
 
 
+async def run_tag_sync(
+    db: graph.Graph, org_slug: str, project_id: str, tag: str
+) -> int:
+    """Resolve the commit-sync capability and record the one tag *tag*.
+
+    The bounded counterpart to :func:`run_sync`, for the caller that
+    already knows which tag appeared -- a promote whose release build just
+    created it.  Cost is flat in the repo's age where a full backfill
+    grows with it, so this is what a per-release sync should call.
+
+    Returns rows written (0 or 1).  Raises
+    :class:`CommitSyncUnavailable` when no integration provides the
+    capability and ``NotImplementedError`` when the resolved one syncs
+    only full history; both leave the caller free to fall back to the
+    queued backfill.
+
+    Deliberately writes no last-sync status and runs no release-notes
+    backfill: this is a side effect of a promote, not the project-wide
+    sync the UI polls, and the promote wrote the notes itself.
+    """
+    try:
+        resolved = await resolve_capability(
+            db, project_id, _CAPABILITY_KIND, None
+        )
+    except fastapi.HTTPException as exc:
+        raise CommitSyncUnavailable(str(exc.detail)) from exc
+    ctx = await _build_context(db, org_slug, project_id, resolved)
+    credentials = decrypt_integration_credentials(
+        resolved.encrypted_credentials
+    )
+    handler = typing.cast('CommitSyncCapability', resolved.capability_cls())
+    return await handler.sync_tag(ctx=ctx, credentials=credentials, tag=tag)
+
+
 async def _backfill_release_notes(
     db: graph.Graph, org_slug: str, project_id: str
 ) -> None:

--- a/apps/api/src/imbi/api/endpoints/project_deployments.py
+++ b/apps/api/src/imbi/api/endpoints/project_deployments.py
@@ -109,8 +109,11 @@ class PromoteActionRequest(pydantic.BaseModel):
     """Body for ``POST /deployments`` with ``action='promote'``.
 
     Cuts a new tag at ``from_committish`` (the build being promoted),
-    creates a release on the remote, then dispatches the workflow with
-    the tag as the ref.
+    then dispatches the workflow with the tag as the ref.  The GitHub
+    Release is *not* created here -- it is the ratification of a
+    successful rollout, published later through
+    ``POST /deployments/releases/{tag}/publish`` (see
+    :func:`publish_release`).
     """
 
     action: typing.Literal['promote']
@@ -317,6 +320,29 @@ class ReleaseBlockResponse(pydantic.BaseModel):
     blocked_reason: str | None = None
     blocked_by: str | None = None
     blocked_at: datetime.datetime | None = None
+
+
+class ReleasePublishRequest(pydantic.BaseModel):
+    """Body for ``POST /deployments/releases/{tag}/publish``.
+
+    Every field is optional: the release title and notes come from the
+    ``Release`` node being ratified, so a caller that knows only the tag
+    (the gateway, reacting to a successful deployment) posts an empty
+    body.
+    """
+
+    model_config = pydantic.ConfigDict(extra='forbid')
+
+    prerelease: bool = False
+
+
+class ReleasePublishResponse(pydantic.BaseModel):
+    """Result of ratifying a ``Release`` on the remote."""
+
+    tag: str
+    published: bool
+    release_url: str | None = None
+    warning: str | None = None
 
 
 class ReleaseCutRequest(pydantic.BaseModel):
@@ -1836,7 +1862,7 @@ async def _handle_deploy(
     )
 
 
-async def _cut_tag_and_release(
+async def _cut_tag(
     db: graph.Graph,
     *,
     ctx: PluginContext,
@@ -1846,24 +1872,21 @@ async def _cut_tag_and_release(
     auth: permissions.AuthContext,
     from_committish: str,
     tag: str,
-    release_name: str | None,
-    release_notes_markdown: str,
-    prerelease: bool,
+    tag_message: str,
     warnings: list[str],
     project_id: str,
     log_context: str = '',
-) -> typing.Any:
-    """Cut a git tag + create a release at ``from_committish``.
+) -> None:
+    """Cut a git tag at ``from_committish`` on the remote.
 
-    The shared core behind both ``promote`` (which then deploys) and the
-    library ``releases/cut`` action (which does not).  Failures degrade
-    to a warning appended to ``warnings`` rather than raising -- a flaky
-    GitHub API shouldn't bury the audit trail.  Returns the
-    plugin-returned ReleaseInfo on success (or ``None`` when the plugin
-    has no ``create_release``).  ``log_context`` is an opaque label
-    (e.g. the target env, or ``'release-cut'``) used only in log lines.
+    The first half of cutting a release.  A plugin with no ``create_tag``
+    is a 400 -- the action is simply unavailable -- but a remote failure
+    degrades to a warning appended to ``warnings`` rather than raising,
+    so a flaky GitHub API doesn't bury the audit trail.  A 422
+    "already exists" is the idempotent re-run and is not a warning.
+    ``log_context`` is an opaque label (e.g. the target env, or
+    ``'release-cut'``) used only in log lines.
     """
-    tag_message = release_name or tag
 
     async def _create_tag(c: PluginContext) -> typing.Any:
         return await call_with_timeout(
@@ -1903,6 +1926,32 @@ async def _cut_tag_and_release(
                 tag,
             )
             warnings.append(_promote_warning('create_tag', exc))
+
+
+async def _create_remote_release(
+    db: graph.Graph,
+    *,
+    ctx: PluginContext,
+    resolved: ResolvedCapability,
+    handler: DeploymentCapability,
+    credentials: dict[str, str],
+    auth: permissions.AuthContext,
+    tag: str,
+    release_name: str | None,
+    release_notes_markdown: str,
+    prerelease: bool,
+    warnings: list[str],
+    project_id: str,
+    log_context: str = '',
+) -> typing.Any:
+    """Create the release on the remote for an already-cut ``tag``.
+
+    The second half of cutting a release, split out so a promote can
+    defer it until the rollout succeeds (see :func:`publish_release`).
+    Returns the plugin-returned ``ReleaseInfo`` on success, or ``None``
+    when the plugin has no ``create_release``, the release already
+    exists, or the call failed (in which case a warning is appended).
+    """
 
     async def _create_release(c: PluginContext) -> typing.Any:
         return await call_with_timeout(
@@ -1944,7 +1993,62 @@ async def _cut_tag_and_release(
         return None
 
 
-async def _promote_cut_release(
+async def _cut_tag_and_release(
+    db: graph.Graph,
+    *,
+    ctx: PluginContext,
+    resolved: ResolvedCapability,
+    handler: DeploymentCapability,
+    credentials: dict[str, str],
+    auth: permissions.AuthContext,
+    from_committish: str,
+    tag: str,
+    release_name: str | None,
+    release_notes_markdown: str,
+    prerelease: bool,
+    warnings: list[str],
+    project_id: str,
+    log_context: str = '',
+) -> typing.Any:
+    """Cut a git tag *and* create its release at ``from_committish``.
+
+    Backs the library ``releases/cut`` action, where there is no
+    deployment to gate the release on so both halves run in one step.
+    ``promote`` deliberately does *not* use this: it cuts the tag now
+    (:func:`_cut_tag`) and defers the release to :func:`publish_release`.
+    """
+    await _cut_tag(
+        db,
+        ctx=ctx,
+        resolved=resolved,
+        handler=handler,
+        credentials=credentials,
+        auth=auth,
+        from_committish=from_committish,
+        tag=tag,
+        tag_message=release_name or tag,
+        warnings=warnings,
+        project_id=project_id,
+        log_context=log_context,
+    )
+    return await _create_remote_release(
+        db,
+        ctx=ctx,
+        resolved=resolved,
+        handler=handler,
+        credentials=credentials,
+        auth=auth,
+        tag=tag,
+        release_name=release_name,
+        release_notes_markdown=release_notes_markdown,
+        prerelease=prerelease,
+        warnings=warnings,
+        project_id=project_id,
+        log_context=log_context,
+    )
+
+
+async def _promote_cut_tag(
     db: graph.Graph,
     *,
     ctx: PluginContext,
@@ -1955,14 +2059,16 @@ async def _promote_cut_release(
     body: PromoteActionRequest,
     warnings: list[str],
     project_id: str,
-) -> typing.Any:
-    """Cut a tag + create a release for a promote (then the caller deploys).
+) -> None:
+    """Cut the promote's tag; the release is published after the rollout.
 
-    Thin wrapper over :func:`_cut_tag_and_release` so ``_handle_promote``
-    is unchanged; the repo's ``on: release: [published]`` workflow handles
-    the deploy.
+    Promote creates the git tag and stops there.  The GitHub Release is
+    the *ratification* of a release that actually shipped, so it is
+    published from the ``deployment_status`` webhook once the deploy
+    reports success -- and a failed rollout leaves a blocked release
+    rather than a ratified one.
     """
-    return await _cut_tag_and_release(
+    await _cut_tag(
         db,
         ctx=ctx,
         resolved=resolved,
@@ -1971,9 +2077,7 @@ async def _promote_cut_release(
         auth=auth,
         from_committish=body.from_committish,
         tag=body.tag,
-        release_name=body.release_name,
-        release_notes_markdown=body.release_notes_markdown,
-        prerelease=body.prerelease,
+        tag_message=body.release_name or body.tag,
         warnings=warnings,
         project_id=project_id,
         log_context=body.to_environment,
@@ -2029,10 +2133,10 @@ async def _handle_promote(
     #   ``create_release``; call ``trigger_deployment`` so the repo's
     #   ``on: deployment`` workflow fires.  This is the "promote to prod
     #   from a stage release tag" path.
-    # * Git short/full SHA                       -> cut a tag at the SHA,
-    #   create a GitHub Release; the repo's ``on: release`` workflow
-    #   handles the deploy server-side.  This is the "first promote off
-    #   a build commit" path.
+    # * Git short/full SHA                       -> cut a tag at the SHA
+    #   and dispatch against it.  This is the "first promote off a build
+    #   commit" path.  No GitHub Release is created here; publishing it
+    #   is deferred until the rollout succeeds.
     # * A ref that fails a configured tag format  -> 400.  We refuse to
     #   silently cut a tag that violates the org/project-type policy; a
     #   typo at the API boundary should fail loudly.
@@ -2063,10 +2167,11 @@ async def _handle_promote(
 
     warnings: list[str] = []
     run = DeploymentRun(run_id='', status='queued')
-    release_info = None
+    # The GitHub Release is published by ``publish_release`` once the
+    # rollout reports success, so a promote never returns a release URL.
     release_url: str | None = None
 
-    release_info = await _promote_cut_release(
+    await _promote_cut_tag(
         db,
         ctx=ctx,
         resolved=resolved,
@@ -2076,9 +2181,6 @@ async def _handle_promote(
         body=body,
         warnings=warnings,
         project_id=project_id,
-    )
-    release_url = (release_info.html_url if release_info else None) or (
-        release_info.url if release_info else None
     )
 
     promote_inputs: dict[str, str] | None
@@ -3194,6 +3296,187 @@ async def cut_release(
         release_url=release_url,
         committish=committish,
         recorded=True,
+        warning='; '.join(warnings) if warnings else None,
+    )
+
+
+async def _release_for_tag(
+    db: graph.Graph,
+    *,
+    org_slug: str,
+    project_id: str,
+    tag: str,
+) -> dict[str, typing.Any] | None:
+    """Return the ``Release`` node for ``tag``, or ``None``.
+
+    Scoped through the project's owning organization so a tag from
+    another org can never be ratified against this one.  A tag carried
+    by more than one ``Release`` (a retag) is ambiguous about *which*
+    notes to publish, so the newest by ``created_at`` wins and the
+    collision is logged.
+    """
+    query: typing.LiteralString = """
+    MATCH (p:Project {{id: {project_id}}})
+          -[:OWNED_BY]->(:Team)
+          -[:BELONGS_TO]->(:Organization {{slug: {org_slug}}})
+    MATCH (p)-[:HAS_RELEASE]->(r:Release {{tag: {tag}}})
+    RETURN r{{.id, .tag, .committish, .title, .description,
+              .created_at}} AS release
+    """
+    rows = await db.execute(
+        query,
+        {'project_id': project_id, 'org_slug': org_slug, 'tag': tag},
+        ['release'],
+    )
+    if not rows:
+        return None
+    nodes = [
+        typing.cast(
+            'dict[str, typing.Any]', graph.parse_agtype(row['release'])
+        )
+        for row in rows
+    ]
+    if len(nodes) > 1:
+        LOGGER.warning(
+            'Multiple Release nodes for project=%s tag=%s; publishing the '
+            'most recently created one',
+            project_id,
+            tag,
+        )
+        nodes.sort(key=lambda node: str(node.get('created_at') or ''))
+    return nodes[-1]
+
+
+@project_deployments_router.post('/releases/{tag}/publish')
+async def publish_release(
+    org_slug: str,
+    project_id: str,
+    tag: str,
+    background: fastapi.BackgroundTasks,
+    db: graph.Pool,
+    auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(
+            permissions.require_permission('project:deployment:write'),
+        ),
+    ],
+    body: ReleasePublishRequest | None = None,
+    source: str | None = None,
+) -> ReleasePublishResponse:
+    """Ratify an existing ``Release`` by creating it on the remote.
+
+    ``promote`` cuts the tag and records the ``Release`` node -- the
+    *intent* to ship.  This publishes the GitHub Release for it, which
+    is the *ratification*: the gateway calls it from the
+    ``deployment_status`` webhook once the rollout reports success, so a
+    failed rollout leaves a blocked release rather than a ratified one.
+
+    Title and notes come from the ``Release`` node, so the ratification
+    can't drift from what Imbi recorded at promote time.  Idempotent: a
+    release the remote already has is not an error, and the node's
+    ``github_release`` link is refreshed either way.  Blocked releases
+    are refused with a 409.
+    """
+    release = await _release_for_tag(
+        db, org_slug=org_slug, project_id=project_id, tag=tag
+    )
+    if release is None:
+        raise fastapi.HTTPException(
+            status_code=404,
+            detail=f'No release found for tag {tag!r}',
+        )
+    # A block and a success webhook can race; the block wins.  Match on
+    # the tag alone -- the committish gate belongs to the deploy paths,
+    # and a sibling release cut from the same commit must not veto this
+    # one's ratification.
+    await _assert_not_blocked(db, project_id, tag=tag)
+
+    resolved, ctx, credentials = await _resolve_and_context(
+        db,
+        org_slug,
+        project_id,
+        auth,
+        source=source,
+        # The caller is normally the gateway's service principal, which
+        # has no per-user identity connection; fall back to the
+        # Integration's own credentials rather than 503ing.
+        best_effort_identity=True,
+    )
+    handler = _handler(resolved)
+
+    warnings: list[str] = []
+    release_info = await _create_remote_release(
+        db,
+        ctx=ctx,
+        resolved=resolved,
+        handler=handler,
+        credentials=credentials,
+        auth=auth,
+        tag=tag,
+        release_name=str(release.get('title') or tag),
+        release_notes_markdown=str(release.get('description') or ''),
+        prerelease=(body or ReleasePublishRequest()).prerelease,
+        warnings=warnings,
+        project_id=project_id,
+        log_context='publish',
+    )
+    release_url = (release_info.html_url if release_info else None) or (
+        release_info.url if release_info else None
+    )
+    if release_url is None and not warnings:
+        # The plugin returned nothing -- either it has no
+        # ``create_release`` or the remote already had one.  Ask for the
+        # existing release so the node still gets its link.
+        remote = await _get_release(
+            handler, ctx, _resolve_credentials(ctx, credentials), tag
+        )
+        release_url = remote.html_url if remote else None
+
+    await persist_link_writeback(db, ctx)
+
+    committish = str(release.get('committish') or '')
+    # Guard on the committish: it is the node's identity, and upserting
+    # against an empty one would spawn a second, unmatchable Release.
+    if release_url and committish:
+        await _upsert_release_node(
+            db,
+            project_id=project_id,
+            tag=tag,
+            committish=committish,
+            title=str(release.get('title') or tag),
+            # Empty preserves whatever the node already holds; this call
+            # is only here to write the ``github_release`` link.
+            notes_markdown='',
+            release_url=release_url,
+            created_by=auth.principal_name,
+        )
+
+    published = not warnings
+    LOGGER.info(
+        'Release publish: project=%s tag=%s published=%s plugin=%s actor=%s',
+        project_id,
+        tag,
+        published,
+        resolved.plugin_slug,
+        ctx.actor_user_id,
+    )
+    background.add_task(
+        _record_deployment_audit,
+        project_id=project_id,
+        project_slug=ctx.project_slug,
+        environment_slug='',
+        recorded_by=auth.principal_name,
+        action='publish',
+        tag=tag,
+        committish=committish,
+        plugin_slug=resolved.plugin_slug,
+        run_url=None,
+        release_url=release_url,
+    )
+    return ReleasePublishResponse(
+        tag=tag,
+        published=published,
+        release_url=release_url,
         warning='; '.join(warnings) if warnings else None,
     )
 

--- a/apps/api/src/imbi/api/endpoints/project_deployments.py
+++ b/apps/api/src/imbi/api/endpoints/project_deployments.py
@@ -2146,12 +2146,18 @@ async def _promote_cut_tag(
     )
 
 
-#: Inputs ``release.yml`` declares.  Imbi fills every one of them: the
-#: shared ``release-tag.yaml`` treats an empty ``commit`` as "release the
-#: tip of the default branch", so omitting it would silently tag something
-#: other than the build being promoted -- a green release of the wrong
-#: tree.  ``create_deployment`` is the D6 seam from ENG-101: the workflow
-#: stops creating the Deployment once Imbi does.
+#: Inputs ``release.yml`` declares.  The shared ``release-tag.yaml``
+#: treats an empty ``commit`` as "release the tip of the default branch",
+#: so omitting it would silently tag something other than the build being
+#: promoted -- a green release of the wrong tree.  ``create_deployment``
+#: is the D6 seam from ENG-101: the workflow stops creating the
+#: Deployment once Imbi does.
+#:
+#: Only the first three are universal.  ``environment`` and
+#: ``create_deployment`` are declared by the workflow a *deployable*
+#: project dispatches; the releasable (library / image) variant drops
+#: both, so :func:`_dispatch_release_build` gates them on the project
+#: type's ``deployable`` flag.
 _RELEASE_WORKFLOW_DESCRIPTION_INPUT = 'description'
 _RELEASE_WORKFLOW_NOTES_INPUT = 'release_notes'
 _RELEASE_WORKFLOW_COMMIT_INPUT = 'commit'
@@ -2254,10 +2260,16 @@ async def _dispatch_release_build(
         # Never omitted: release-tag.yaml reads an empty ``commit`` as
         # "release the tip of the default branch".
         _RELEASE_WORKFLOW_COMMIT_INPUT: committish,
-        _RELEASE_WORKFLOW_CREATE_DEPLOYMENT_INPUT: 'false',
     }
-    if to_environment:
-        inputs[_RELEASE_WORKFLOW_ENVIRONMENT_INPUT] = to_environment
+    # The deployment inputs exist only in the workflow a deployable
+    # project dispatches.  A releasable project's workflow declares
+    # neither -- publishing *is* its release, so it has no deployment
+    # seam to close -- and workflow_dispatch rejects the whole call with
+    # a 422 when it is handed an input the workflow does not declare.
+    if await _project_is_deployable(db, project_id):
+        inputs[_RELEASE_WORKFLOW_CREATE_DEPLOYMENT_INPUT] = 'false'
+        if to_environment:
+            inputs[_RELEASE_WORKFLOW_ENVIRONMENT_INPUT] = to_environment
 
     async def _dispatch(c: PluginContext) -> plugin_base.ArtifactRun:
         return await call_with_timeout(

--- a/apps/api/src/imbi/api/endpoints/project_deployments.py
+++ b/apps/api/src/imbi/api/endpoints/project_deployments.py
@@ -26,6 +26,7 @@ import nanoid
 import pydantic
 
 from imbi.api.auth import permissions, principals
+from imbi.api.commit_sync import queue as commit_sync_queue
 from imbi.api.deployment_sync import queue as deployment_sync_queue
 from imbi.api.deployment_sync import service as deployment_sync_service
 from imbi.api.endpoints._helpers import (
@@ -48,9 +49,12 @@ from imbi.api.identity.host_integration import (
 from imbi.api.llm.dependencies import InjectAnthropicClient
 from imbi.api.plugins import call_with_timeout
 from imbi.api.plugins.resolution import ResolvedCapability, resolve_capability
+from imbi.api.release_promote import queue as release_promote_queue
+from imbi.api.release_promote import service as release_promote_service
 from imbi.api.scoring import OptionalValkeyClient
 from imbi.common import clickhouse, graph, versioning
 from imbi.common import models as common_models
+from imbi.common.plugins import base as plugin_base
 from imbi.common.plugins import decrypt_integration_credentials
 from imbi.common.plugins.base import (
     Commit,
@@ -147,6 +151,21 @@ class DeploymentTriggerResponse(pydantic.BaseModel):
     # workflow isn't wired up yet).  The promote itself still records a
     # DeploymentEvent; the UI surfaces this as an amber inline note.
     warning: str | None = None
+    #: Set only on the dispatch-driven promote path (the project has a
+    #: Release workflow configured).  ``'building'`` means the response
+    #: went out while the release build was still running and the
+    #: Deployment does not exist yet -- the UI polls
+    #: ``GET /deployments/promote-status`` from here rather than treating
+    #: ``run`` as a live rollout.  ``None`` marks the legacy path, where
+    #: the Deployment was created inline and ``run`` is already real.
+    phase: typing.Literal['building'] | None = None
+    #: The dispatched workflow run, when there is one.
+    artifact_run_id: str | None = None
+    artifact_run_url: str | None = None
+    #: ``False`` when the build was dispatched but no watcher could be
+    #: enqueued (Valkey down).  The build still runs; Imbi just won't
+    #: finish the promote on its own, so the UI must say so.
+    watched: bool = True
 
 
 class DraftReleaseNotesRequest(pydantic.BaseModel):
@@ -367,6 +386,17 @@ class ReleaseCutResponse(pydantic.BaseModel):
     committish: str
     recorded: bool = False
     warning: str | None = None
+    #: Set when the project has a Release workflow configured, in which
+    #: case the tag and the remote Release do not exist yet -- the
+    #: dispatched build creates them.  ``release_url`` is therefore
+    #: ``None`` here, and the UI polls
+    #: ``GET /deployments/promote-status`` instead of linking straight to
+    #: a release.  ``None`` marks the inline path, where both already
+    #: exist by the time this returns.
+    phase: typing.Literal['building'] | None = None
+    artifact_run_id: str | None = None
+    artifact_run_url: str | None = None
+    watched: bool = True
 
 
 # ---------------------------------------------------------------------------
@@ -1531,6 +1561,7 @@ async def trigger_deployment(
     body: DeploymentRequestBody,
     background: fastapi.BackgroundTasks,
     db: graph.Pool,
+    valkey_client: OptionalValkeyClient,
     auth: typing.Annotated[
         permissions.AuthContext,
         fastapi.Depends(
@@ -1560,6 +1591,7 @@ async def trigger_deployment(
             body,
             background=background,
             source=source,
+            valkey_client=valkey_client,
         )
     return await _handle_deploy(
         db,
@@ -1658,6 +1690,31 @@ async def get_deployment_sync_status(
     """Return the project's last deployment-resync state."""
     del org_slug
     return await deployment_sync_service.read_status(db, project_id)
+
+
+@project_deployments_router.get('/promote-status')
+async def get_promote_status(
+    org_slug: str,
+    project_id: str,
+    db: graph.Pool,
+    _auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(
+            permissions.require_permission('project:deployment:read'),
+        ),
+    ],
+) -> release_promote_service.PromoteStatus:
+    """Return the project's in-flight (or last) promote state.
+
+    The dispatch-driven promote returns as soon as the Release workflow is
+    dispatched, so this is how the UI follows the rest: ``building`` while
+    the artifact builds, ``deploying`` once Imbi has created the
+    Deployment, then ``success``.  ``build_failed`` means the release is
+    blocked; ``failed`` means the build outcome is unknown or Imbi could
+    not finish, and the tag is still shippable.
+    """
+    del org_slug
+    return await release_promote_service.read_status(db, project_id)
 
 
 @project_deployments_router.get('/runs/{run_id}')
@@ -2084,6 +2141,247 @@ async def _promote_cut_tag(
     )
 
 
+#: Inputs ``release.yml`` declares.  Imbi fills every one of them: the
+#: shared ``release-tag.yaml`` treats an empty ``commit`` as "release the
+#: tip of the default branch", so omitting it would silently tag something
+#: other than the build being promoted -- a green release of the wrong
+#: tree.  ``create_deployment`` is the D6 seam from ENG-101: the workflow
+#: stops creating the Deployment once Imbi does.
+_RELEASE_WORKFLOW_DESCRIPTION_INPUT = 'description'
+_RELEASE_WORKFLOW_NOTES_INPUT = 'release_notes'
+_RELEASE_WORKFLOW_COMMIT_INPUT = 'commit'
+_RELEASE_WORKFLOW_ENVIRONMENT_INPUT = 'environment'
+_RELEASE_WORKFLOW_CREATE_DEPLOYMENT_INPUT = 'create_deployment'
+
+
+async def _default_branch(
+    handler: DeploymentCapability,
+    ctx: PluginContext,
+    credentials: dict[str, str],
+) -> str | None:
+    """The repo's default branch, for use as a dispatch ref.
+
+    ``workflow_dispatch`` resolves the workflow file on the ref it is
+    given, and a freshly-promoted tag does not exist yet -- the workflow
+    is what creates it.  So the dispatch runs from the default branch and
+    the workflow checks out the version itself.
+    """
+    refs = await _best_effort(
+        handler.list_refs(ctx, credentials, kind='default'),
+        f'list_refs kind=default for project {ctx.project_id}',
+    )
+    for ref in refs or []:
+        if ref.name:
+            return ref.name
+    return None
+
+
+class _DispatchedBuild(typing.NamedTuple):
+    """What :func:`_dispatch_release_build` leaves behind."""
+
+    release_id: str
+    artifact: plugin_base.ArtifactRun
+    #: ``True`` when a watcher was queued.  ``False`` means the build runs
+    #: but nothing will finish the promote.
+    watched: bool
+    warning: str | None
+
+
+async def _dispatch_release_build(
+    db: graph.Graph,
+    org_slug: str,
+    project_id: str,
+    auth: permissions.AuthContext,
+    *,
+    resolved: ResolvedCapability,
+    ctx: PluginContext,
+    credentials: dict[str, str],
+    handler: DeploymentCapability,
+    valkey_client: typing.Any,
+    tag: str,
+    committish: str,
+    title: str,
+    notes_markdown: str,
+    to_environment: str = '',
+    from_environment: str = '',
+    deploy: bool,
+) -> _DispatchedBuild:
+    """Record the release, dispatch its build, and queue the watcher.
+
+    Shared by the promote and the release-cut paths -- they differ only in
+    whether a deployment follows, which the watcher reads off
+    ``deploy``.
+
+    The ``Release`` node is written *before* the dispatch on purpose: a
+    build that fails needs something to block, and the node keyed on
+    ``(tag, committish)`` is that something.  So a node can exist for a
+    tag the remote never carries; the block and its reason are what
+    distinguish that from a shipped release.
+    """
+    release_id = await _upsert_release_node(
+        db,
+        project_id=project_id,
+        tag=tag,
+        committish=committish,
+        title=title,
+        notes_markdown=notes_markdown,
+        release_url=None,
+        created_by=auth.principal_name,
+    )
+    ref = await _default_branch(handler, ctx, credentials)
+    if ref is None:
+        raise fastapi.HTTPException(
+            status_code=502,
+            detail=(
+                "Could not resolve the repository's default branch, which "
+                'is the ref the Release workflow must be dispatched from.'
+            ),
+        )
+    inputs = {
+        _RELEASE_WORKFLOW_DESCRIPTION_INPUT: title,
+        _RELEASE_WORKFLOW_NOTES_INPUT: notes_markdown,
+        # Never omitted: release-tag.yaml reads an empty ``commit`` as
+        # "release the tip of the default branch".
+        _RELEASE_WORKFLOW_COMMIT_INPUT: committish,
+        _RELEASE_WORKFLOW_CREATE_DEPLOYMENT_INPUT: 'false',
+    }
+    if to_environment:
+        inputs[_RELEASE_WORKFLOW_ENVIRONMENT_INPUT] = to_environment
+
+    async def _dispatch(c: PluginContext) -> plugin_base.ArtifactRun:
+        return await call_with_timeout(
+            handler.create_deployment_artifact(
+                c,
+                _resolve_credentials(c, credentials),
+                ref=ref,
+                version=tag,
+                inputs=inputs,
+            )
+        )
+
+    try:
+        artifact = await call_with_identity_retry(
+            db, ctx, resolved, auth, fn=_dispatch, attached=True
+        )
+    except NotImplementedError as exc:
+        raise fastapi.HTTPException(
+            status_code=400,
+            detail=(
+                f'Plugin {resolved.plugin_slug!r} cannot dispatch a release '
+                'workflow; clear the Release workflow option to fall back '
+                'to cutting the tag directly.'
+            ),
+        ) from exc
+    await persist_link_writeback(db, ctx)
+
+    job = release_promote_service.WatchJob(
+        org_slug=org_slug,
+        project_id=project_id,
+        release_id=release_id,
+        tag=tag,
+        committish=committish,
+        to_environment=to_environment,
+        from_environment=from_environment,
+        run_id=artifact.run_id or '',
+        run_url=artifact.run_url or '',
+        requested_by=auth.principal_name,
+        deploy=deploy,
+    )
+    watched = bool(artifact.run_id) and (
+        await release_promote_queue.enqueue_release_promote(valkey_client, job)
+    )
+    warning: str | None = None
+    if not artifact.run_id:
+        warning = (
+            'The release workflow was dispatched but the remote did not '
+            'report a run id, so Imbi cannot watch the build. Finish the '
+            'release from the workflow run once it is green.'
+        )
+    elif not watched:
+        warning = (
+            'The release build is running, but Imbi could not queue a '
+            'watcher for it and will not finish the release automatically.'
+        )
+    await release_promote_service.set_status(
+        db,
+        project_id,
+        status='building' if watched else 'failed',
+        tag=tag,
+        committish=committish,
+        environment=to_environment,
+        from_environment=from_environment,
+        artifact_run_id=artifact.run_id or '',
+        artifact_run_url=artifact.run_url or '',
+        requested_by=auth.principal_name,
+        error=warning or '',
+    )
+    LOGGER.info(
+        'Release workflow dispatched: project=%s %s->%s tag=%s commit=%s '
+        'plugin=%s actor=%s run_id=%s deploy=%s watched=%s',
+        project_id,
+        from_environment or '-',
+        to_environment or '-',
+        tag,
+        committish,
+        resolved.plugin_slug,
+        ctx.actor_user_id,
+        artifact.run_id,
+        deploy,
+        watched,
+    )
+    return _DispatchedBuild(release_id, artifact, watched, warning)
+
+
+async def _promote_via_dispatch(
+    db: graph.Graph,
+    org_slug: str,
+    project_id: str,
+    auth: permissions.AuthContext,
+    body: PromoteActionRequest,
+    *,
+    resolved: ResolvedCapability,
+    ctx: PluginContext,
+    credentials: dict[str, str],
+    handler: DeploymentCapability,
+    valkey_client: typing.Any,
+) -> DeploymentTriggerResponse:
+    """Dispatch the project's Release workflow instead of cutting the tag.
+
+    The workflow creates the annotated tag and the remote Release, so Imbi
+    does neither here; the deployment follows once the build is green.
+    """
+    built = await _dispatch_release_build(
+        db,
+        org_slug,
+        project_id,
+        auth,
+        resolved=resolved,
+        ctx=ctx,
+        credentials=credentials,
+        handler=handler,
+        valkey_client=valkey_client,
+        tag=body.tag,
+        committish=versioning.short_committish(body.from_committish),
+        title=body.release_name or body.tag,
+        notes_markdown=body.release_notes_markdown,
+        to_environment=body.to_environment,
+        from_environment=body.from_environment,
+        deploy=await _project_is_deployable(db, project_id),
+    )
+    return DeploymentTriggerResponse(
+        run=DeploymentRun(run_id='', status='queued'),
+        plugin_id=resolved.integration_id,
+        plugin_slug=resolved.plugin_slug,
+        recorded=True,
+        tag=body.tag,
+        phase='building',
+        artifact_run_id=built.artifact.run_id,
+        artifact_run_url=built.artifact.run_url,
+        watched=built.watched,
+        warning=built.warning,
+    )
+
+
 async def _handle_promote(
     db: graph.Graph,
     org_slug: str,
@@ -2093,6 +2391,7 @@ async def _handle_promote(
     *,
     background: fastapi.BackgroundTasks,
     source: str | None,
+    valkey_client: typing.Any = None,
 ) -> DeploymentTriggerResponse:
     env_flags = await _load_env_flags(
         db,
@@ -2164,6 +2463,29 @@ async def _handle_promote(
         environment=body.to_environment,
     )
     handler = _handler(resolved)
+
+    # A project with a Release workflow configured takes the
+    # dispatch-and-watch path: the workflow builds the artifact, cuts the
+    # annotated tag and creates the remote Release, and only then does
+    # Imbi deploy.  Nothing below this point runs for those projects.
+    #
+    # With the option blank, keep cutting the tag inline and ratifying the
+    # Release from the deployment_status webhook (ENG-101).  That is the
+    # right behaviour for a project whose artifacts are built outside
+    # Imbi -- there is no build to wait on.
+    if str(resolved.capability_options.get('artifact_workflow') or '').strip():
+        return await _promote_via_dispatch(
+            db,
+            org_slug,
+            project_id,
+            auth,
+            body,
+            resolved=resolved,
+            ctx=ctx,
+            credentials=credentials,
+            handler=handler,
+            valkey_client=valkey_client,
+        )
 
     warnings: list[str] = []
     run = DeploymentRun(run_id='', status='queued')
@@ -2419,6 +2741,333 @@ async def _upsert_release_node(
         if rid:
             return str(rid)
     return new_id
+
+
+# ---------------------------------------------------------------------------
+# Dispatch-driven promote: completion path
+#
+# ``_handle_promote`` dispatches the project's Release workflow and returns.
+# The functions below are what ``imbi.api.release_promote.service`` calls once
+# that build reaches a terminal state -- they live here so every graph write
+# and plugin call for the promote flow stays in one module, the same way
+# ``deployment_sync.service`` defers to ``resync_for_project``.
+#
+# All of them run under the watcher's process principal, which has no per-user
+# identity connection, so they resolve context with
+# ``best_effort_identity=True`` and act with the Integration's own service
+# credential.  The promoting user is carried separately, as ``requested_by``,
+# and reaches the ``DeploymentEvent`` and the ``operations_log`` row -- a
+# promote is something a person did, and losing that would leave the activity
+# history crediting a worker.
+# ---------------------------------------------------------------------------
+
+
+def _watcher_auth() -> permissions.AuthContext:
+    """The synthetic principal the promote watcher acts under."""
+    return principals.system_auth(
+        principals.RELEASE_PROMOTE, 'Imbi Release Promote'
+    )
+
+
+async def _project_is_deployable(db: graph.Graph, project_id: str) -> bool:
+    """True when any of the project's types is ``deployable``.
+
+    A project can carry more than one ``ProjectType``, so this aggregates
+    rather than reading one: ``deployable`` XOR ``releasable`` holds per
+    type, not per project.  A project with no type at all answers
+    ``False`` -- there is nothing to deploy into.
+    """
+    query: typing.LiteralString = """
+    MATCH (p:Project {{id: {project_id}}})
+    OPTIONAL MATCH (p)-[:TYPE]->(pt:ProjectType)
+    RETURN collect(COALESCE(pt.deployable, false)) AS flags
+    """
+    rows = await db.execute(query, {'project_id': project_id}, ['flags'])
+    if not rows:
+        return False
+    flags = typing.cast(
+        'list[object]', graph.parse_agtype(rows[0].get('flags')) or []
+    )
+    return any(bool(flag) for flag in flags)
+
+
+async def poll_artifact_run(
+    db: graph.Graph,
+    *,
+    org_slug: str,
+    project_id: str,
+    run_id: str,
+) -> plugin_base.ArtifactRun:
+    """Report the current state of a dispatched release build.
+
+    Wraps ``get_artifact_run_status``, which resolves a *workflow run*
+    id.  Deliberately not :func:`get_deployment_run` -- that one resolves
+    a GitHub *Deployment* id through a different endpoint, and handing it
+    a workflow run id would 404.
+    """
+    resolved, ctx, credentials = await _resolve_and_context(
+        db,
+        org_slug,
+        project_id,
+        _watcher_auth(),
+        source=None,
+        best_effort_identity=True,
+    )
+    handler = _handler(resolved)
+    return await call_with_timeout(
+        handler.get_artifact_run_status(
+            ctx, _resolve_credentials(ctx, credentials), run_id=run_id
+        )
+    )
+
+
+async def fail_promote_build(
+    db: graph.Graph,
+    *,
+    org_slug: str,
+    project_id: str,
+    tag: str,
+    reason: str,
+    requested_by: str = '',
+) -> None:
+    """Block ``tag`` after its release build failed.
+
+    Scoped to the tag (see :func:`_set_release_block`): the build failed
+    for this version, and the ordinary fix is to promote a bumped version
+    off the same commit, which a commit-wide block would refuse.
+    """
+    blocked = await _set_release_block(
+        db,
+        org_slug=org_slug,
+        project_id=project_id,
+        tag=tag,
+        blocked_at=datetime.datetime.now(datetime.UTC).isoformat(),
+        blocked_by=requested_by or principals.RELEASE_PROMOTE,
+        reason=reason[:500],
+        scope='tag',
+    )
+    if not blocked:
+        # The promote creates the node before dispatching, so this means
+        # someone deleted it mid-build.  Nothing to block; the warning is
+        # the whole remedy.
+        LOGGER.warning(
+            'release-promote could not block tag %s on project %s: no '
+            'Release node found',
+            tag,
+            project_id,
+        )
+        return
+    LOGGER.info(
+        'release-promote blocked tag %s on project %s: %s',
+        tag,
+        project_id,
+        reason,
+    )
+
+
+async def _set_release_artifact_run(
+    db: graph.Graph,
+    *,
+    project_id: str,
+    release_id: str,
+    run_id: str,
+    run_url: str | None,
+) -> None:
+    """Record which workflow run built a release.
+
+    Kept off :func:`_upsert_release_node` on purpose: that function is
+    also the resync's writer, and resync observes deployments rather than
+    builds, so it has no run id to contribute and should not have to pass
+    a placeholder.
+    """
+    query: typing.LiteralString = """
+    MATCH (:Project {{id: {project_id}}})
+          -[:HAS_RELEASE]->(r:Release {{id: {release_id}}})
+    SET r.workflow_run_id = {run_id},
+        r.workflow_run_url = {run_url},
+        r.updated_at = {now}
+    RETURN r.id AS rid
+    """
+    await db.execute(
+        query,
+        {
+            'project_id': project_id,
+            'release_id': release_id,
+            'run_id': run_id,
+            'run_url': run_url,
+            'now': datetime.datetime.now(datetime.UTC).isoformat(),
+        },
+        ['rid'],
+    )
+
+
+async def complete_promote_build(
+    db: graph.Graph,
+    *,
+    org_slug: str,
+    project_id: str,
+    release_id: str,
+    tag: str,
+    committish: str,
+    to_environment: str,
+    from_environment: str = '',
+    requested_by: str = '',
+    run_id: str = '',
+    run_url: str | None = None,
+    deploy: bool = True,
+    valkey_client: typing.Any = None,
+) -> None:
+    """Finish a promote whose release build succeeded.
+
+    The build created the annotated tag and the remote Release, so this
+    reconciles Imbi with what now exists and then ships it:
+
+    1. Resolve what the tag actually points at, and warn on disagreement.
+    2. Refresh the ``Release`` node with the remote release link and the
+       run that built it.
+    3. Enqueue a commit/tag resync -- an API-created tag fires no ``push``
+       event, so ``github#sync_tags`` never runs and the tag is missing
+       from the ClickHouse ``tags`` table (and therefore from
+       release-history and the Releases tab) until something asks for one.
+    4. For a deployable project, create the Deployment and record the
+       event.  A releasable-only project stops after step 3: there is
+       nothing to deploy into.
+    """
+    resolved, ctx, credentials = await _resolve_and_context(
+        db,
+        org_slug,
+        project_id,
+        _watcher_auth(),
+        source=None,
+        environment=to_environment or None,
+        best_effort_identity=True,
+    )
+    handler = _handler(resolved)
+    creds = _resolve_credentials(ctx, credentials)
+
+    tagged = await _best_effort(
+        handler.resolve_committish(ctx, creds, committish=tag),
+        f'resolve tag {tag} for project {project_id}',
+    )
+    if tagged is not None:
+        actual = versioning.short_committish(tagged.sha)
+        if actual != versioning.short_committish(committish):
+            # Imbi created the Release node keyed on the commit it asked
+            # to tag.  A mismatch means the workflow tagged something
+            # else -- the likeliest cause is a dispatch that omitted the
+            # ``commit`` input, which makes release-tag.yaml tag the tip
+            # of the default branch instead.  Don't rewrite the node's
+            # identity underneath its DEPLOYED_TO edges; say so loudly.
+            LOGGER.error(
+                'release-promote: tag %s on project %s points at %s, not '
+                'the promoted commit %s; the Release node keeps the '
+                'promoted identity',
+                tag,
+                project_id,
+                actual,
+                committish,
+            )
+
+    remote = await _get_release(handler, ctx, creds, tag)
+    release_url = remote.html_url if remote else None
+    if release_url:
+        await _upsert_release_node(
+            db,
+            project_id=project_id,
+            tag=tag,
+            committish=committish,
+            title=tag,
+            # Empty preserves the notes the promote already wrote; this
+            # call exists to attach the remote release link.
+            notes_markdown='',
+            release_url=release_url,
+            created_by=principals.RELEASE_PROMOTE,
+        )
+    if run_id:
+        await _set_release_artifact_run(
+            db,
+            project_id=project_id,
+            release_id=release_id,
+            run_id=run_id,
+            run_url=run_url,
+        )
+    await persist_link_writeback(db, ctx)
+
+    # ENG-100 F6: the tag exists on the remote but produced no push
+    # event, so nothing has fed it to ClickHouse.  Best-effort -- a
+    # missing resync delays the Releases tab, it does not fail the
+    # promote.
+    if not await commit_sync_queue.enqueue_commit_sync(
+        valkey_client, org_slug, project_id, principals.RELEASE_PROMOTE
+    ):
+        LOGGER.info(
+            'release-promote could not enqueue a tag resync for project %s; '
+            'tag %s stays absent from ClickHouse until the next sync',
+            project_id,
+            tag,
+        )
+
+    if not deploy:
+        LOGGER.info(
+            'release-promote finished build-only release %s for project %s',
+            tag,
+            project_id,
+        )
+        return
+
+    inputs: dict[str, str] | None = None
+    if ctx.environment_config:
+        inputs = {
+            key: value if isinstance(value, str) else json.dumps(value)
+            for key, value in ctx.environment_config.items()
+        }
+    run = await call_with_timeout(
+        handler.trigger_deployment(ctx, creds, ref_or_sha=tag, inputs=inputs)
+    )
+    LOGGER.info(
+        'release-promote deployment triggered: project=%s env=%s tag=%s '
+        'plugin=%s run_id=%s',
+        project_id,
+        to_environment,
+        tag,
+        resolved.plugin_slug,
+        run.run_id,
+    )
+    appended = await append_deployment_event(
+        db,
+        org_slug=org_slug,
+        project_id=project_id,
+        release_id=release_id,
+        env_slug=to_environment,
+        status='in_progress',
+        note=f'via {resolved.plugin_slug}',
+        external_run_id=str(run.run_id) if run.run_id else None,
+        external_run_url=run.run_url,
+        # The person who pressed promote, not the worker that got here.
+        performed_by=requested_by or None,
+    )
+    if isinstance(appended, str):
+        LOGGER.warning(
+            'release-promote could not record the deployment event for '
+            'project %s release %s: %s',
+            project_id,
+            release_id,
+            appended,
+        )
+    await _record_deployment_audit(
+        project_id=project_id,
+        project_slug=ctx.project_slug,
+        environment_slug=to_environment,
+        recorded_by=requested_by or principals.RELEASE_PROMOTE,
+        action='promote',
+        tag=tag,
+        committish=committish,
+        plugin_slug=resolved.plugin_slug,
+        run_url=run.run_url,
+        external_run_id=str(run.run_id) if run.run_id else None,
+        release_url=release_url,
+        from_environment=from_environment or None,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -3194,6 +3843,7 @@ async def cut_release(
     body: ReleaseCutRequest,
     background: fastapi.BackgroundTasks,
     db: graph.Pool,
+    valkey_client: OptionalValkeyClient,
     auth: typing.Annotated[
         permissions.AuthContext,
         fastapi.Depends(
@@ -3234,6 +3884,39 @@ async def cut_release(
         db, org_slug, project_id, auth, source=source
     )
     handler = _handler(resolved)
+
+    # With a Release workflow configured, the build owns the tag and the
+    # remote Release, exactly as on the promote path -- the only
+    # difference is that nothing is deployed afterwards.  See
+    # ``_handle_promote`` for why the option gates this.
+    if str(resolved.capability_options.get('artifact_workflow') or '').strip():
+        built = await _dispatch_release_build(
+            db,
+            org_slug,
+            project_id,
+            auth,
+            resolved=resolved,
+            ctx=ctx,
+            credentials=credentials,
+            handler=handler,
+            valkey_client=valkey_client,
+            tag=body.tag,
+            committish=versioning.short_committish(body.committish),
+            title=body.release_name or body.tag,
+            notes_markdown=body.release_notes_markdown,
+            deploy=False,
+        )
+        return ReleaseCutResponse(
+            tag=body.tag,
+            release_url=None,
+            committish=versioning.short_committish(body.committish),
+            recorded=True,
+            phase='building',
+            artifact_run_id=built.artifact.run_id,
+            artifact_run_url=built.artifact.run_url,
+            watched=built.watched,
+            warning=built.warning,
+        )
 
     warnings: list[str] = []
     release_info = await _cut_tag_and_release(
@@ -3513,13 +4196,24 @@ async def _set_release_block(
     blocked_at: str | None,
     blocked_by: str | None,
     reason: str | None,
+    scope: typing.Literal['tag'] | None = None,
 ) -> bool:
     """Write the ``blocked_*`` properties on a tagged ``Release``.
 
-    Passing ``None`` for all three clears the block (AGE stores a
-    ``null`` assignment as property removal).  Returns ``False`` when no
-    ``Release`` node for ``tag`` exists under the org, letting the caller
-    decide between creating one and returning a 404.
+    Passing ``None`` for ``blocked_at`` / ``blocked_by`` / ``reason``
+    clears the block (AGE stores a ``null`` assignment as property
+    removal).  Returns ``False`` when no ``Release`` node for ``tag``
+    exists under the org, letting the caller decide between creating one
+    and returning a 404.
+
+    ``scope='tag'`` narrows the block to this exact version, so
+    :func:`_blocked_release` stops matching it on the shared committish.
+    A failed *release build* is a property of the version, not of the
+    commit -- the usual fix is to promote a new version off the same tree,
+    which a commit-wide block would refuse.  A manual block leaves
+    ``scope`` ``None`` and keeps the broad, commit-wide semantics: an
+    operator blocking a rolled-back release means "stop shipping this
+    code", which is exactly the commit.
     """
     query: typing.LiteralString = """
     MATCH (p:Project {{id: {project_id}}})
@@ -3529,6 +4223,7 @@ async def _set_release_block(
     SET r.blocked_at = {blocked_at},
         r.blocked_by = {blocked_by},
         r.blocked_reason = {reason},
+        r.blocked_scope = {scope},
         r.updated_at = {now}
     RETURN r.id AS rid
     """
@@ -3541,6 +4236,7 @@ async def _set_release_block(
             'blocked_at': blocked_at,
             'blocked_by': blocked_by,
             'reason': reason,
+            'scope': scope,
             'now': datetime.datetime.now(datetime.UTC).isoformat(),
         },
         ['rid'],
@@ -3563,12 +4259,20 @@ async def _blocked_release(
     nothing blocked matches.  Empty strings stand in for the absent
     identity -- neither ever matches a stored value, and AGE has no
     NULL equality.
+
+    A release blocked with ``blocked_scope = 'tag'`` matches on its tag
+    only.  Those are build failures, recorded by the promote watcher
+    against one version; matching them on the committish too would wedge
+    the whole commit and refuse the ordinary fix of promoting a bumped
+    version off the same tree.  Manual blocks carry no scope and keep
+    matching both identities.
     """
     query: typing.LiteralString = """
     MATCH (:Project {{id: {project_id}}})-[:HAS_RELEASE]->(r:Release)
     WHERE r.blocked_at IS NOT NULL
       AND (COALESCE(r.tag, '') = {tag}
-           OR COALESCE(r.committish, '') = {committish})
+           OR (COALESCE(r.committish, '') = {committish}
+               AND COALESCE(r.blocked_scope, '') <> 'tag'))
     RETURN r{{.tag, .committish, .blocked_reason}} AS release
     """
     rows = await db.execute(

--- a/apps/api/src/imbi/api/endpoints/project_deployments.py
+++ b/apps/api/src/imbi/api/endpoints/project_deployments.py
@@ -27,6 +27,7 @@ import pydantic
 
 from imbi.api.auth import permissions, principals
 from imbi.api.commit_sync import queue as commit_sync_queue
+from imbi.api.commit_sync import service as commit_sync_service
 from imbi.api.deployment_sync import queue as deployment_sync_queue
 from imbi.api.deployment_sync import service as deployment_sync_service
 from imbi.api.endpoints._helpers import (
@@ -2962,6 +2963,51 @@ async def _set_release_artifact_run(
     )
 
 
+async def _sync_promoted_tag(
+    db: graph.Graph,
+    *,
+    org_slug: str,
+    project_id: str,
+    tag: str,
+    valkey_client: typing.Any,
+) -> None:
+    """Feed the tag the release build created to ClickHouse.
+
+    ENG-100 F6: an API-created tag fires no ``push`` event, so
+    ``github#sync_tags`` never runs and the tag is missing from the
+    ``tags`` table -- and therefore from release history and the Releases
+    tab -- until something asks for it.
+
+    Records that one tag directly, because the caller knows which tag
+    appeared: three remote calls, where the queued backfill re-peels every
+    tag the repo already carries.  Falls back to that backfill when the
+    bounded path can't run (no commit-sync capability, or one that syncs
+    only full history) -- and, either way, degrades quietly: a tag that
+    lands late delays the Releases tab, it does not fail the promote.
+    """
+    written = await _best_effort(
+        commit_sync_service.run_tag_sync(db, org_slug, project_id, tag),
+        f'sync tag {tag} for project {project_id}',
+    )
+    if written is not None:
+        LOGGER.info(
+            'release-promote recorded %d tag row(s) for project %s tag %s',
+            written,
+            project_id,
+            tag,
+        )
+        return
+    if not await commit_sync_queue.enqueue_commit_sync(
+        valkey_client, org_slug, project_id, principals.RELEASE_PROMOTE
+    ):
+        LOGGER.info(
+            'release-promote could not enqueue a tag resync for project %s; '
+            'tag %s stays absent from ClickHouse until the next sync',
+            project_id,
+            tag,
+        )
+
+
 async def complete_promote_build(
     db: graph.Graph,
     *,
@@ -2986,10 +3032,10 @@ async def complete_promote_build(
     1. Resolve what the tag actually points at, and warn on disagreement.
     2. Refresh the ``Release`` node with the remote release link and the
        run that built it.
-    3. Enqueue a commit/tag resync -- an API-created tag fires no ``push``
-       event, so ``github#sync_tags`` never runs and the tag is missing
-       from the ClickHouse ``tags`` table (and therefore from
-       release-history and the Releases tab) until something asks for one.
+    3. Record the new tag in ClickHouse -- an API-created tag fires no
+       ``push`` event, so ``github#sync_tags`` never runs and the tag is
+       missing from the ``tags`` table (and therefore from release-history
+       and the Releases tab) until something asks for it.
     4. For a deployable project, create the Deployment and record the
        event.  A releasable-only project stops after step 3: there is
        nothing to deploy into.
@@ -3060,19 +3106,13 @@ async def complete_promote_build(
         )
     await persist_link_writeback(db, ctx)
 
-    # ENG-100 F6: the tag exists on the remote but produced no push
-    # event, so nothing has fed it to ClickHouse.  Best-effort -- a
-    # missing resync delays the Releases tab, it does not fail the
-    # promote.
-    if not await commit_sync_queue.enqueue_commit_sync(
-        valkey_client, org_slug, project_id, principals.RELEASE_PROMOTE
-    ):
-        LOGGER.info(
-            'release-promote could not enqueue a tag resync for project %s; '
-            'tag %s stays absent from ClickHouse until the next sync',
-            project_id,
-            tag,
-        )
+    await _sync_promoted_tag(
+        db,
+        org_slug=org_slug,
+        project_id=project_id,
+        tag=tag,
+        valkey_client=valkey_client,
+    )
 
     if not deploy:
         LOGGER.info(

--- a/apps/api/src/imbi/api/endpoints/project_deployments.py
+++ b/apps/api/src/imbi/api/endpoints/project_deployments.py
@@ -2222,7 +2222,22 @@ async def _dispatch_release_build(
     ``(tag, committish)`` is that something.  So a node can exist for a
     tag the remote never carries; the block and its reason are what
     distinguish that from a shipped release.
+
+    That reasoning only covers failures *after* the dispatch, though, so
+    everything that can fail before it runs first.  A 502 here used to
+    leave a node behind that no dispatch, no block, and no promote status
+    explained -- and one that still matched the ``(tag, committish)``
+    gates in :func:`_blocked_release`.
     """
+    ref = await _default_branch(handler, ctx, credentials)
+    if ref is None:
+        raise fastapi.HTTPException(
+            status_code=502,
+            detail=(
+                "Could not resolve the repository's default branch, which "
+                'is the ref the Release workflow must be dispatched from.'
+            ),
+        )
     release_id = await _upsert_release_node(
         db,
         project_id=project_id,
@@ -2233,15 +2248,6 @@ async def _dispatch_release_build(
         release_url=None,
         created_by=auth.principal_name,
     )
-    ref = await _default_branch(handler, ctx, credentials)
-    if ref is None:
-        raise fastapi.HTTPException(
-            status_code=502,
-            detail=(
-                "Could not resolve the repository's default branch, which "
-                'is the ref the Release workflow must be dispatched from.'
-            ),
-        )
     inputs = {
         _RELEASE_WORKFLOW_DESCRIPTION_INPUT: title,
         _RELEASE_WORKFLOW_NOTES_INPUT: notes_markdown,

--- a/apps/api/src/imbi/api/endpoints/project_deployments.py
+++ b/apps/api/src/imbi/api/endpoints/project_deployments.py
@@ -1708,10 +1708,15 @@ async def get_promote_status(
 
     The dispatch-driven promote returns as soon as the Release workflow is
     dispatched, so this is how the UI follows the rest: ``building`` while
-    the artifact builds, ``deploying`` once Imbi has created the
-    Deployment, then ``success``.  ``build_failed`` means the release is
-    blocked; ``failed`` means the build outcome is unknown or Imbi could
-    not finish, and the tag is still shippable.
+    the artifact builds, ``deploying`` while the Deployment Imbi created
+    rolls out, then ``success`` once that rollout reports success.
+
+    Three ways it can end short of that, differing in what the operator
+    has to do next: ``build_failed`` blocks the release (fix the build and
+    promote a bumped version, or unblock to retry); ``deploy_failed``
+    leaves the tag shippable (redeploy it once the cause is fixed);
+    ``failed`` means Imbi lost track of the build or the rollout, so the
+    outcome is unknown and the tag is likewise left shippable.
     """
     del org_slug
     return await release_promote_service.read_status(db, project_id)
@@ -2821,6 +2826,44 @@ async def poll_artifact_run(
     )
 
 
+async def poll_promote_rollout(
+    db: graph.Graph,
+    *,
+    org_slug: str,
+    project_id: str,
+    run_id: str,
+) -> DeploymentRun:
+    """Report the current state of a promote's rollout.
+
+    The counterpart to :func:`poll_artifact_run` for the second half of a
+    dispatch-driven promote: once the build is green and
+    :func:`complete_promote_build` has created the Deployment, this is
+    what tells the watcher whether the rollout actually shipped.
+
+    Resolves a *Deployment* id, so it goes through
+    ``get_deployment_status`` -- the same split
+    :func:`poll_artifact_run` documents, in the other direction.
+    Distinct from :func:`get_deployment_run` because that one runs under
+    the caller's identity and raises ``HTTPException``; the watcher has
+    no per-user identity, so it resolves the Integration's own service
+    credential instead.
+    """
+    resolved, ctx, credentials = await _resolve_and_context(
+        db,
+        org_slug,
+        project_id,
+        _watcher_auth(),
+        source=None,
+        best_effort_identity=True,
+    )
+    handler = _handler(resolved)
+    return await call_with_timeout(
+        handler.get_deployment_status(
+            ctx, _resolve_credentials(ctx, credentials), run_id=run_id
+        )
+    )
+
+
 async def fail_promote_build(
     db: graph.Graph,
     *,
@@ -2916,7 +2959,7 @@ async def complete_promote_build(
     run_url: str | None = None,
     deploy: bool = True,
     valkey_client: typing.Any = None,
-) -> None:
+) -> DeploymentRun | None:
     """Finish a promote whose release build succeeded.
 
     The build created the annotated tag and the remote Release, so this
@@ -2932,6 +2975,12 @@ async def complete_promote_build(
     4. For a deployable project, create the Deployment and record the
        event.  A releasable-only project stops after step 3: there is
        nothing to deploy into.
+
+    Returns the Deployment it created so the caller can watch the
+    rollout, or ``None`` for a releasable-only project.  Creating the
+    Deployment is *not* the end of the promote -- the rollout it starts
+    is what the user is waiting on -- so this deliberately hands the run
+    back rather than reporting success on its own behalf.
     """
     resolved, ctx, credentials = await _resolve_and_context(
         db,
@@ -3013,7 +3062,7 @@ async def complete_promote_build(
             tag,
             project_id,
         )
-        return
+        return None
 
     inputs: dict[str, str] | None = None
     if ctx.environment_config:
@@ -3068,6 +3117,7 @@ async def complete_promote_build(
         release_url=release_url,
         from_environment=from_environment or None,
     )
+    return run
 
 
 # ---------------------------------------------------------------------------

--- a/apps/api/src/imbi/api/lifespans.py
+++ b/apps/api/src/imbi/api/lifespans.py
@@ -20,6 +20,7 @@ from imbi.api.identity import sweeper as identity_sweeper
 from imbi.api.maintenance import worker as maintenance_worker
 from imbi.api.plugins import lifecycle as plugin_lifecycle
 from imbi.api.pr_sync import queue as pr_sync_queue
+from imbi.api.release_promote import queue as release_promote_queue
 from imbi.api.scoring import queue as score_queue
 from imbi.api.storage.client import StorageClient
 from imbi.common import clickhouse, graph, valkey
@@ -269,6 +270,43 @@ async def deployment_sync_worker_hook() -> abc.AsyncGenerator[None]:
         except Exception:  # noqa: BLE001
             LOGGER.warning(
                 'Deployment-sync worker task exited with error', exc_info=True
+            )
+
+
+@contextlib.asynccontextmanager
+async def release_promote_worker_hook() -> abc.AsyncGenerator[None]:
+    """Run the consumer that watches dispatched release builds."""
+    try:
+        client = valkey.get_client()
+    except RuntimeError:
+        LOGGER.warning(
+            'Valkey unavailable; release-promote worker not started'
+        )
+        yield None
+        return
+    if _graph is None:
+        LOGGER.warning('Graph not ready; release-promote worker not started')
+        yield None
+        return
+    stop = asyncio.Event()
+    LOGGER.info('Release-promote worker starting')
+    consumer_task = asyncio.create_task(
+        release_promote_queue.consume_release_promote(
+            client, _graph, stop=stop
+        )
+    )
+    try:
+        yield None
+    finally:
+        stop.set()
+        consumer_task.cancel()
+        try:
+            await consumer_task
+        except asyncio.CancelledError:
+            pass
+        except Exception:  # noqa: BLE001
+            LOGGER.warning(
+                'Release-promote worker task exited with error', exc_info=True
             )
 
 

--- a/apps/api/src/imbi/api/release_promote/__init__.py
+++ b/apps/api/src/imbi/api/release_promote/__init__.py
@@ -1,0 +1,12 @@
+"""Watch a dispatched release build, then release and deploy.
+
+The dispatch-driven promote flow.  ``_handle_promote`` dispatches the
+project's *Release workflow* (the ``artifact_workflow`` capability
+option) and returns immediately; the work of waiting for that build and
+acting on its outcome lives here, because a release build takes minutes
+and cannot block a request handler.
+
+:mod:`imbi.api.release_promote.queue` is the Valkey-stream consumer;
+:mod:`imbi.api.release_promote.service` holds the poll loop and the
+status the UI reads back.
+"""

--- a/apps/api/src/imbi/api/release_promote/queue.py
+++ b/apps/api/src/imbi/api/release_promote/queue.py
@@ -115,7 +115,14 @@ def _parse_job(fields: dict[str, str]) -> WatchJob | None:
     try:
         return WatchJob.model_validate_json(raw)
     except (pydantic.ValidationError, json.JSONDecodeError):
-        LOGGER.exception('release-promote job payload is unusable: %r', raw)
+        # Deliberately not the payload itself: a ``WatchJob`` carries
+        # ``requested_by``, which is the promoting user's identity, and
+        # this fires on every malformed message.  The exception already
+        # says which field failed; the length is enough to tell a
+        # truncated write from a schema mismatch.
+        LOGGER.exception(
+            'release-promote job payload is unusable (%d bytes)', len(raw)
+        )
         return None
 
 
@@ -293,7 +300,17 @@ async def _run_job(
     except Exception:
         # Leave it pending for a reclaim; ``_maybe_dead_letter`` retires
         # it once the delivery count is exhausted.
-        LOGGER.exception('release-promote job failed for %s', fields)
+        #
+        # Identify the job by project and tag rather than dumping
+        # ``fields``: its ``job`` entry is a serialized ``WatchJob``,
+        # which carries the promoting user's identity in
+        # ``requested_by``.  Those two are enough to find the run.
+        job = _parse_job(fields)
+        LOGGER.exception(
+            'release-promote job failed for project=%s tag=%s',
+            job.project_id if job else '<unparseable>',
+            job.tag if job else '<unparseable>',
+        )
         return
     finally:
         renewer.cancel()

--- a/apps/api/src/imbi/api/release_promote/queue.py
+++ b/apps/api/src/imbi/api/release_promote/queue.py
@@ -1,0 +1,384 @@
+"""Release-promote watch queue (Valkey Streams).
+
+Sibling of :mod:`imbi.api.deployment_sync.queue`, with three deliberate
+differences forced by how long a release build runs:
+
+* **No per-project debounce.**  The resync debounce is right for
+  coalescable work; silently dropping a promote watch would orphan a
+  build nobody is waiting on.  Jobs are made idempotent instead --
+  re-running one re-polls the same run id and converges on the same
+  outcome.
+* **Entries are processed concurrently**, not serially.  A watch job
+  lives for the length of a release build (minutes, up to
+  ``service.TIMEOUT_SECONDS``).  Handling entries one at a time -- what
+  the resync consumer does, correctly, for second-long jobs -- would make
+  one project's build block every other project's promote behind it, and
+  the ones behind could time out having never been polled.
+* **Claim renewal is mandatory, not defensive.**  A job routinely
+  outlives ``CLAIM_IDLE_MS`` by an order of magnitude, so without
+  renewal another worker reclaims it mid-flight and double-drives the
+  same promote -- two Deployments for one tag.
+
+Dead-lettering after ``MAX_DELIVERIES`` and the global rate-limit pause
+carry over from the sibling unchanged.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import logging
+import os
+import socket
+import time
+import typing
+from collections import abc
+
+import pydantic
+from valkey import asyncio as valkey
+
+from imbi.api.release_promote.service import WatchJob, run_watch, set_status
+from imbi.common import graph
+from imbi.common.plugins.errors import PluginRateLimited
+
+STREAM = 'imbi:release-promote'
+GROUP = 'release-promote-workers'
+CONSUMER_PREFIX = 'worker'
+DLQ = 'imbi:release-promote:dlq'
+MAX_DELIVERIES = 3
+CLAIM_IDLE_MS = 120_000
+#: How often an in-flight job renews its claim.  Must stay well under
+#: ``CLAIM_IDLE_MS``; see the module docstring.
+CLAIM_RENEW_SECONDS = 30
+PAUSE_KEY = 'imbi:release-promote:paused-until'
+PAUSE_POLL_CAP_SECONDS = 30
+PAUSE_KEY_BUFFER_SECONDS = 5
+#: Concurrent watch jobs one worker process will drive.  Bounds the graph
+#: and remote-API load a burst of promotes can generate; excess entries
+#: stay unread in the stream until a slot frees.
+MAX_CONCURRENT = 8
+#: Gap between main-loop iterations when the stream read didn't block.
+IDLE_SLEEP_SECONDS = 0.5
+
+LOGGER = logging.getLogger(__name__)
+
+
+async def enqueue_release_promote(
+    client: valkey.Valkey | None,
+    job: WatchJob,
+) -> bool:
+    """XADD a promote-watch job.  Returns True if enqueued.
+
+    Tolerates *client* being ``None`` (returns False) so the promote
+    endpoint can tell the user the build is running but unwatched, rather
+    than 500, when Valkey is down.
+    """
+    if client is None:
+        return False
+    try:
+        await client.xadd(STREAM, {'job': job.model_dump_json()})
+    except Exception:
+        LOGGER.exception(
+            'enqueue_release_promote failed for project %s tag %s',
+            job.project_id,
+            job.tag,
+        )
+        return False
+    return True
+
+
+async def ensure_group(client: valkey.Valkey) -> None:
+    try:
+        await client.xgroup_create(STREAM, GROUP, id='$', mkstream=True)
+    except Exception as err:
+        if 'BUSYGROUP' not in str(err):
+            LOGGER.exception('xgroup_create failed')
+            raise
+
+
+def _decode_fields(
+    raw: abc.Mapping[bytes | str, bytes | str],
+) -> dict[str, str]:
+    return {
+        (k.decode() if isinstance(k, bytes) else k): (
+            v.decode() if isinstance(v, bytes) else v
+        )
+        for k, v in raw.items()
+    }
+
+
+def _parse_job(fields: dict[str, str]) -> WatchJob | None:
+    raw = fields.get('job')
+    if not raw:
+        return None
+    try:
+        return WatchJob.model_validate_json(raw)
+    except (pydantic.ValidationError, json.JSONDecodeError):
+        LOGGER.exception('release-promote job payload is unusable: %r', raw)
+        return None
+
+
+async def _process_message(
+    db: graph.Graph,
+    fields: dict[str, str],
+    valkey_client: valkey.Valkey | None,
+) -> None:
+    job = _parse_job(fields)
+    if job is None:
+        # Nothing to retry toward: a payload we can't parse will never
+        # become parseable.  Ack it (the caller does) and move on.
+        return
+    await run_watch(db, job, valkey_client=valkey_client)
+
+
+async def _paused_remaining(client: valkey.Valkey) -> float:
+    """Seconds left on the global rate-limit pause, ``0.0`` when clear."""
+    try:
+        raw = await client.get(PAUSE_KEY)
+    except Exception:  # noqa: BLE001
+        return 0.0
+    if raw is None:
+        return 0.0
+    try:
+        until = float(raw.decode() if isinstance(raw, bytes) else raw)
+    except ValueError:
+        return 0.0
+    return max(0.0, until - time.time())
+
+
+async def _pause_until(client: valkey.Valkey, retry_at: float) -> None:
+    """Record the resume time so every worker backs off until *retry_at*."""
+    ttl = max(1, int(retry_at - time.time()) + PAUSE_KEY_BUFFER_SECONDS)
+    try:
+        await client.set(PAUSE_KEY, str(retry_at), ex=ttl)
+    except Exception:
+        LOGGER.exception('failed to set release-promote pause marker')
+
+
+async def _claim_stale(
+    client: valkey.Valkey,
+    consumer: str,
+    count: int,
+) -> list[tuple[bytes, abc.Mapping[bytes | str, bytes | str]]]:
+    try:
+        result = await client.xautoclaim(
+            STREAM,
+            GROUP,
+            consumer,
+            min_idle_time=CLAIM_IDLE_MS,
+            start_id='0-0',
+            count=count,
+        )
+    except Exception as err:  # noqa: BLE001
+        LOGGER.debug('xautoclaim failed: %s', err)
+        return []
+    if isinstance(result, (list, tuple)) and len(result) >= 2:  # type: ignore[arg-type]
+        msgs: object = result[1]  # type: ignore[index]
+        if isinstance(msgs, list):
+            return msgs  # type: ignore[return-value]
+    return []
+
+
+async def _renew_claim(
+    client: valkey.Valkey,
+    consumer: str,
+    msg_id: bytes,
+) -> None:
+    """Reset *msg_id*'s idle clock while its job is still running.
+
+    ``JUSTID`` renews without re-reading the entry or bumping the
+    delivery counter, so renewal never pushes a healthy job toward the
+    dead-letter threshold.  Cancelled by :func:`_run_job` on completion.
+    """
+    while True:
+        await asyncio.sleep(CLAIM_RENEW_SECONDS)
+        try:
+            await client.xclaim(
+                STREAM,
+                GROUP,
+                consumer,
+                min_idle_time=0,
+                message_ids=[msg_id],
+                justid=True,
+            )
+        except Exception as err:  # noqa: BLE001
+            LOGGER.debug('claim renewal failed for %s: %s', msg_id, err)
+
+
+async def _maybe_dead_letter(
+    client: valkey.Valkey,
+    db: graph.Graph,
+    msg_id: bytes,
+    fields: dict[str, str],
+) -> bool:
+    try:
+        info = await client.xpending_range(
+            STREAM, GROUP, min=msg_id, max=msg_id, count=1
+        )
+    except Exception:  # noqa: BLE001
+        return False
+    if not info:
+        return False
+    entry: object = info[0]  # type: ignore[index]
+    delivered: int | None = None
+    if isinstance(entry, dict):
+        raw_delivered = entry.get('times_delivered')  # type: ignore[union-attr]
+        if raw_delivered is not None:
+            delivered = int(raw_delivered)  # type: ignore[arg-type]
+    elif isinstance(entry, (list, tuple)) and len(entry) >= 4:  # type: ignore[arg-type]
+        raw_delivered = entry[3]  # type: ignore[index]
+        if raw_delivered is not None:
+            delivered = int(raw_delivered)  # type: ignore[arg-type]
+    if delivered is not None and delivered >= MAX_DELIVERIES:
+        await client.xadd(DLQ, fields)
+        await client.xack(STREAM, GROUP, msg_id)
+        LOGGER.warning(
+            'dead-lettered release-promote msg %s after %s deliveries',
+            msg_id,
+            delivered,
+        )
+        # The promote will never be watched now, so say so on the project
+        # rather than leaving the panel spinning on ``building`` forever.
+        job = _parse_job(fields)
+        if job is not None:
+            await _mark_abandoned(db, job)
+        return True
+    return False
+
+
+async def _mark_abandoned(db: graph.Graph, job: WatchJob) -> None:
+    """Flag a dead-lettered watch so the UI stops showing ``building``."""
+    await set_status(
+        db,
+        job.project_id,
+        status='failed',
+        tag=job.tag,
+        committish=job.committish,
+        environment=job.to_environment,
+        from_environment=job.from_environment,
+        artifact_run_id=job.run_id,
+        artifact_run_url=job.run_url,
+        requested_by=job.requested_by,
+        error=(
+            'Imbi gave up watching this release build after repeated '
+            'failures. Check the workflow run on the remote; the tag was '
+            'not blocked, so it can still be deployed once green.'
+        ),
+    )
+
+
+async def _run_job(
+    client: valkey.Valkey,
+    db: graph.Graph,
+    msg_id: bytes,
+    fields: dict[str, str],
+    consumer: str,
+    valkey_client: valkey.Valkey | None,
+) -> None:
+    """Drive one watch job to completion, then ack it."""
+    renewer = asyncio.ensure_future(_renew_claim(client, consumer, msg_id))
+    try:
+        await _process_message(db, fields, valkey_client)
+    except PluginRateLimited as exc:
+        # Don't ack: leave the job pending so a reclaim re-drives it once
+        # the limit clears, and pause every worker until then.
+        await _pause_until(client, exc.retry_at)
+        LOGGER.warning(
+            'release-promote paused ~%.0fs (remote rate limit); job left '
+            'queued',
+            max(0.0, exc.retry_at - time.time()),
+        )
+        return
+    except Exception:
+        # Leave it pending for a reclaim; ``_maybe_dead_letter`` retires
+        # it once the delivery count is exhausted.
+        LOGGER.exception('release-promote job failed for %s', fields)
+        return
+    finally:
+        renewer.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await renewer
+    with contextlib.suppress(Exception):
+        await client.xack(STREAM, GROUP, msg_id)
+
+
+async def consume_release_promote(
+    client: valkey.Valkey,
+    db: graph.Graph,
+    consumer: str | None = None,
+    stop: asyncio.Event | None = None,
+) -> None:
+    """Run the release-promote consumer loop until *stop* is set.
+
+    Reads only as many entries as there are free concurrency slots and
+    drives each as its own task, so a long build never blocks another
+    project's promote.
+    """
+    consumer = (
+        consumer or f'{CONSUMER_PREFIX}-{socket.gethostname()}-{os.getpid()}'
+    )
+    await ensure_group(client)
+    LOGGER.info(
+        'Release-promote consumer loop running (consumer=%s)', consumer
+    )
+    in_flight: dict[bytes, asyncio.Task[None]] = {}
+
+    def _spawn(
+        msg_id: bytes, raw_fields: abc.Mapping[bytes | str, bytes | str]
+    ) -> None:
+        if msg_id in in_flight:
+            return
+        fields = _decode_fields(raw_fields)
+        task = asyncio.ensure_future(
+            _run_job(client, db, msg_id, fields, consumer or '', client)
+        )
+        in_flight[msg_id] = task
+        task.add_done_callback(lambda _t: in_flight.pop(msg_id, None))
+
+    try:
+        while stop is None or not stop.is_set():
+            paused = await _paused_remaining(client)
+            if paused > 0:
+                await asyncio.sleep(min(paused, PAUSE_POLL_CAP_SECONDS))
+                continue
+            free = MAX_CONCURRENT - len(in_flight)
+            if free <= 0:
+                await asyncio.sleep(IDLE_SLEEP_SECONDS)
+                continue
+            stale = await _claim_stale(client, consumer, free)
+            for msg_id, raw_fields in stale:
+                if await _maybe_dead_letter(
+                    client, db, msg_id, _decode_fields(raw_fields)
+                ):
+                    continue
+                _spawn(msg_id, raw_fields)
+            free = MAX_CONCURRENT - len(in_flight)
+            if free <= 0:
+                await asyncio.sleep(IDLE_SLEEP_SECONDS)
+                continue
+            try:
+                response = await client.xreadgroup(
+                    GROUP,
+                    consumer,
+                    {STREAM: '>'},
+                    count=free,
+                    block=2000,
+                )
+            except Exception:
+                LOGGER.exception('xreadgroup failed')
+                await asyncio.sleep(1)
+                continue
+            if not response:
+                continue
+            for _stream, entries in typing.cast(
+                'list[tuple[object, list[typing.Any]]]', response
+            ):
+                for msg_id, raw_fields in entries:
+                    _spawn(msg_id, raw_fields)
+    finally:
+        for task in list(in_flight.values()):
+            task.cancel()
+        for task in list(in_flight.values()):
+            with contextlib.suppress(asyncio.CancelledError, Exception):
+                await task

--- a/apps/api/src/imbi/api/release_promote/service.py
+++ b/apps/api/src/imbi/api/release_promote/service.py
@@ -1,0 +1,452 @@
+"""Poll a dispatched release build and act on its outcome.
+
+The promote endpoint dispatches the project's Release workflow and hands
+off here.  This module owns the wait: it polls the workflow run until it
+reaches a terminal state, then either finishes the promote (resync tags,
+refresh the ``Release`` node, create the Deployment) or blocks the
+release.
+
+Progress is persisted as ``promote_*`` properties on the ``Project``
+node, mirroring :mod:`imbi.api.deployment_sync.service` -- the UI polls
+it through ``GET /deployments/promote-status`` rather than holding a
+connection open for the length of a build.
+
+Unlike the resync worker, the enqueueing user *is* used for attribution:
+a promote is something a person did, so ``requested_by`` reaches the
+``DeploymentEvent`` and the ``operations_log`` row.  It is not used for
+credentials -- a background worker has no per-user identity connection,
+so plugin calls resolve the Integration's own service credential
+(``best_effort_identity=True``).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import collections.abc
+import datetime
+import logging
+import typing
+
+import pydantic
+
+from imbi.api.auth import permissions, principals
+from imbi.common import graph
+
+LOGGER = logging.getLogger(__name__)
+
+_MAX_ERROR_LEN = 500
+_STATUS_WRITE_RETRIES = 3
+_STATUS_RETRY_BACKOFF = 0.05
+
+#: First gap between polls.  A release build is minutes long, so there is
+#: nothing to gain from a tighter loop -- and the run is frequently still
+#: ``queued`` for the first few of these.
+POLL_INITIAL_SECONDS = 10.0
+#: Ceiling the interval backs off to.
+POLL_MAX_SECONDS = 30.0
+#: Multiplier applied to the interval after each non-terminal poll.
+POLL_BACKOFF = 1.5
+#: How long to wait before giving up on a run.  This is not "how long a
+#: build takes": ``release.yml`` declares
+#: ``concurrency: release-${{ github.repository }}`` with
+#: ``cancel-in-progress: false``, so a dispatch can sit queued behind
+#: another release for the whole of one before its own first job starts.
+TIMEOUT_SECONDS = 45 * 60
+
+#: States a workflow run stops moving in.
+TERMINAL_STATUSES = frozenset({'success', 'failure', 'cancelled'})
+
+PromoteState = typing.Literal[
+    'idle',
+    'building',
+    'deploying',
+    'success',
+    'build_failed',
+    'failed',
+]
+
+#: ``principal_name`` stamped on work this worker performs itself.  The
+#: promoting user is carried separately for attribution.
+REQUESTED_BY = principals.RELEASE_PROMOTE
+
+
+class PromoteStatus(pydantic.BaseModel):
+    """In-flight (or last) promote state for a project."""
+
+    status: PromoteState = 'idle'
+    tag: str | None = None
+    committish: str | None = None
+    environment: str | None = None
+    from_environment: str | None = None
+    artifact_run_id: str | None = None
+    artifact_run_url: str | None = None
+    error: str | None = None
+    requested_by: str | None = None
+    updated_at: datetime.datetime | None = None
+
+
+def system_auth() -> permissions.AuthContext:
+    """Synthetic principal the watcher's plugin calls run under."""
+    return principals.system_auth(REQUESTED_BY, 'Imbi Release Promote')
+
+
+def now_iso() -> str:
+    """Current UTC time in the ISO-8601 form stored on the Project node."""
+    return datetime.datetime.now(datetime.UTC).isoformat()
+
+
+def _is_write_conflict(exc: Exception) -> bool:
+    """True if *exc* is AGE's concurrent-update conflict (TM_Updated)."""
+    return 'failed to be updated' in str(exc)
+
+
+async def set_status(
+    db: graph.Graph,
+    project_id: str,
+    *,
+    status: PromoteState,
+    tag: str = '',
+    committish: str = '',
+    environment: str = '',
+    from_environment: str = '',
+    artifact_run_id: str = '',
+    artifact_run_url: str = '',
+    requested_by: str = '',
+    error: str = '',
+    retry: bool = True,
+) -> None:
+    """Persist promote state on the ``Project`` node (best-effort).
+
+    *retry* re-attempts on AGE's transient concurrent-update conflict so
+    the worker's authoritative transitions still land when a webhook
+    touches the project mid-write, exactly as
+    :func:`imbi.api.deployment_sync.service.set_status` does.
+
+    There is deliberately no ``only_if_before`` guard here: unlike a
+    resync, a promote is not coalescable, so every transition in a single
+    promote's lifecycle is strictly ordered by the one worker driving it.
+    """
+    query: typing.LiteralString = """
+    MATCH (p:Project {{id: {project_id}}})
+    SET p.promote_status = {status},
+        p.promote_at = {at},
+        p.promote_by = {by},
+        p.promote_tag = {tag},
+        p.promote_committish = {committish},
+        p.promote_environment = {environment},
+        p.promote_from_environment = {from_environment},
+        p.promote_run_id = {run_id},
+        p.promote_run_url = {run_url},
+        p.promote_error = {error}
+    RETURN p.id AS id
+    """
+    params = {
+        'project_id': project_id,
+        'status': status,
+        'at': now_iso(),
+        'by': requested_by,
+        'tag': tag,
+        'committish': committish,
+        'environment': environment,
+        'from_environment': from_environment,
+        'run_id': artifact_run_id,
+        'run_url': artifact_run_url,
+        'error': error[:_MAX_ERROR_LEN],
+    }
+    attempts = _STATUS_WRITE_RETRIES if retry else 1
+    for attempt in range(attempts):
+        try:
+            await db.execute(query, params, ['id'])
+            return
+        except Exception as exc:  # noqa: BLE001
+            conflict = _is_write_conflict(exc)
+            if retry and conflict and attempt + 1 < attempts:
+                await asyncio.sleep(_STATUS_RETRY_BACKOFF * (attempt + 1))
+                continue
+            if conflict:
+                LOGGER.debug(
+                    'release-promote status write for %s lost a concurrent '
+                    'update (status=%s); leaving the newer state in place',
+                    project_id,
+                    status,
+                )
+            else:
+                LOGGER.warning(
+                    'Failed to persist promote status for project %s',
+                    project_id,
+                    exc_info=True,
+                )
+            return
+
+
+def _opt_str(value: object) -> str | None:
+    text = str(value) if value is not None else ''
+    return text or None
+
+
+def _opt_dt(value: object) -> datetime.datetime | None:
+    text = _opt_str(value)
+    if text is None:
+        return None
+    try:
+        return datetime.datetime.fromisoformat(text)
+    except ValueError:
+        return None
+
+
+async def read_status(db: graph.Graph, project_id: str) -> PromoteStatus:
+    """Read promote state from the ``Project`` node (``idle`` default)."""
+    query: typing.LiteralString = """
+    MATCH (p:Project {{id: {project_id}}})
+    RETURN p.promote_status AS status,
+           p.promote_at AS at,
+           p.promote_by AS requested_by,
+           p.promote_tag AS tag,
+           p.promote_committish AS committish,
+           p.promote_environment AS environment,
+           p.promote_from_environment AS from_environment,
+           p.promote_run_id AS run_id,
+           p.promote_run_url AS run_url,
+           p.promote_error AS error
+    """
+    keys = [
+        'status',
+        'at',
+        'requested_by',
+        'tag',
+        'committish',
+        'environment',
+        'from_environment',
+        'run_id',
+        'run_url',
+        'error',
+    ]
+    records = await db.execute(query, {'project_id': project_id}, keys)
+    if not records:
+        return PromoteStatus()
+    row = {key: graph.parse_agtype(records[0].get(key)) for key in keys}
+    status = _opt_str(row['status']) or 'idle'
+    if status not in typing.get_args(PromoteState):
+        # A value written by a newer/older build than this one is data we
+        # can't interpret; report idle rather than failing the read and
+        # blanking the whole panel.
+        LOGGER.warning(
+            'Unrecognized promote status %r on project %s; reporting idle',
+            status,
+            project_id,
+        )
+        status = 'idle'
+    return PromoteStatus(
+        status=typing.cast('PromoteState', status),
+        tag=_opt_str(row['tag']),
+        committish=_opt_str(row['committish']),
+        environment=_opt_str(row['environment']),
+        from_environment=_opt_str(row['from_environment']),
+        artifact_run_id=_opt_str(row['run_id']),
+        artifact_run_url=_opt_str(row['run_url']),
+        error=_opt_str(row['error']),
+        requested_by=_opt_str(row['requested_by']),
+        updated_at=_opt_dt(row['at']),
+    )
+
+
+class WatchJob(pydantic.BaseModel):
+    """One promote awaiting its release build.
+
+    Carries everything the completion path needs so the worker never has
+    to re-derive it from a panel the user has since navigated away from.
+    ``release_id`` names the ``Release`` node the promote created
+    up-front, so a failed build has something to block.
+    """
+
+    org_slug: str
+    project_id: str
+    release_id: str
+    tag: str
+    committish: str
+    to_environment: str
+    from_environment: str = ''
+    run_id: str = ''
+    run_url: str = ''
+    requested_by: str = ''
+    #: ``false`` for releasable-only projects: build and release, no deploy.
+    deploy: bool = True
+
+
+async def run_watch(
+    db: graph.Graph,
+    job: WatchJob,
+    *,
+    valkey_client: object = None,
+    timeout_seconds: float = TIMEOUT_SECONDS,
+    sleep: collections.abc.Callable[
+        [float], collections.abc.Awaitable[None]
+    ]
+    | None = None,
+) -> PromoteState:
+    """Poll ``job``'s release build to a terminal state and act on it.
+
+    Returns the state persisted on the way out.  *sleep* is injectable so
+    tests can drive the loop without real time passing; *valkey_client*
+    is passed through to the tag resync the success path enqueues.
+
+    A run id we never learned (``run_id=''`` -- the bodiless-204 dispatch
+    on appliances without the ``2026-03-10`` API version) cannot be
+    watched.  That is not a build failure, so the release is *not*
+    blocked: the state goes ``failed`` with an explanation and the tag is
+    left shippable, because the build may well have succeeded.
+    """
+    from imbi.api.endpoints import project_deployments
+
+    napper = sleep or asyncio.sleep
+
+    async def mark(
+        state: PromoteState, *, error: str = '', run_url: str | None = None
+    ) -> None:
+        """Persist *state*, carrying the job's identity on every write."""
+        await set_status(
+            db,
+            job.project_id,
+            status=state,
+            tag=job.tag,
+            committish=job.committish,
+            environment=job.to_environment,
+            from_environment=job.from_environment,
+            artifact_run_id=job.run_id,
+            artifact_run_url=run_url if run_url is not None else job.run_url,
+            requested_by=job.requested_by,
+            error=error,
+        )
+
+    if not job.run_id:
+        LOGGER.warning(
+            'release-promote for project %s tag %s has no run id; cannot '
+            'watch the build',
+            job.project_id,
+            job.tag,
+        )
+        await mark(
+            'failed',
+            error=(
+                'The release workflow was dispatched but the remote did not '
+                'report which run it started, so Imbi cannot confirm the '
+                'build. Check the run on the remote, then deploy the tag '
+                'directly once it is green.'
+            ),
+        )
+        return 'failed'
+
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout_seconds
+    interval = POLL_INITIAL_SECONDS
+    status = 'unknown'
+    run_url = job.run_url
+
+    while True:
+        run = await project_deployments.poll_artifact_run(
+            db,
+            org_slug=job.org_slug,
+            project_id=job.project_id,
+            run_id=job.run_id,
+        )
+        status = run.status
+        run_url = run.run_url or run_url
+        if status in TERMINAL_STATUSES:
+            break
+        if loop.time() >= deadline:
+            LOGGER.warning(
+                'release-promote for project %s tag %s timed out after %.0fs '
+                'with the run still %s',
+                job.project_id,
+                job.tag,
+                timeout_seconds,
+                status,
+            )
+            minutes = int(timeout_seconds // 60)
+            await project_deployments.fail_promote_build(
+                db,
+                org_slug=job.org_slug,
+                project_id=job.project_id,
+                tag=job.tag,
+                reason=(
+                    f'Release build did not finish within {minutes} minutes '
+                    f'(last seen {status})'
+                ),
+                requested_by=job.requested_by,
+            )
+            await mark(
+                'build_failed',
+                error=(
+                    f'Release build did not finish within {minutes} minutes. '
+                    f'The release is blocked; unblock it to retry.'
+                ),
+                run_url=run_url or '',
+            )
+            return 'build_failed'
+        await mark('building', run_url=run_url or '')
+        await napper(interval)
+        interval = min(interval * POLL_BACKOFF, POLL_MAX_SECONDS)
+
+    if status != 'success':
+        LOGGER.info(
+            'release-promote build for project %s tag %s reported %s',
+            job.project_id,
+            job.tag,
+            status,
+        )
+        await project_deployments.fail_promote_build(
+            db,
+            org_slug=job.org_slug,
+            project_id=job.project_id,
+            tag=job.tag,
+            reason=f'Release build reported {status}',
+            requested_by=job.requested_by,
+        )
+        await mark(
+            'build_failed',
+            error=(
+                f'The release build {status}. The release is blocked; fix '
+                f'the build and promote a new version, or unblock this one '
+                f'to retry it.'
+            ),
+            run_url=run_url or '',
+        )
+        return 'build_failed'
+
+    await mark('deploying' if job.deploy else 'success', run_url=run_url or '')
+    try:
+        await project_deployments.complete_promote_build(
+            db,
+            org_slug=job.org_slug,
+            project_id=job.project_id,
+            release_id=job.release_id,
+            tag=job.tag,
+            committish=job.committish,
+            to_environment=job.to_environment,
+            from_environment=job.from_environment,
+            requested_by=job.requested_by,
+            run_id=job.run_id,
+            run_url=run_url,
+            deploy=job.deploy,
+            valkey_client=valkey_client,
+        )
+    except Exception as exc:
+        LOGGER.exception(
+            'release-promote completion failed for project %s tag %s',
+            job.project_id,
+            job.tag,
+        )
+        # The build succeeded and the tag exists, so the release is not
+        # blocked -- only Imbi's follow-through failed.  Surface it and
+        # leave the tag shippable so a redeploy can finish the job.
+        await mark(
+            'failed',
+            error=(
+                f'Release built, but Imbi could not finish the promote: {exc}'
+            ),
+            run_url=run_url or '',
+        )
+        return 'failed'
+
+    await mark('success', run_url=run_url or '')
+    return 'success'

--- a/apps/api/src/imbi/api/release_promote/service.py
+++ b/apps/api/src/imbi/api/release_promote/service.py
@@ -1,10 +1,16 @@
 """Poll a dispatched release build and act on its outcome.
 
 The promote endpoint dispatches the project's Release workflow and hands
-off here.  This module owns the wait: it polls the workflow run until it
-reaches a terminal state, then either finishes the promote (resync tags,
-refresh the ``Release`` node, create the Deployment) or blocks the
-release.
+off here.  This module owns the wait, in two phases: it polls the build
+until it reaches a terminal state, then either blocks the release or
+finishes the promote (resync tags, refresh the ``Release`` node, create
+the Deployment) -- and then polls that Deployment's rollout to its own
+terminal state.
+
+Both phases matter to the caller.  Creating the Deployment takes about a
+second; the rollout it starts takes minutes, and *that* is what "did my
+promote ship?" means.  Reporting ``success`` at the handover would tell
+the UI the promote was done while the rollout had not yet started.
 
 Progress is persisted as ``promote_*`` properties on the ``Project``
 node, mirroring :mod:`imbi.api.deployment_sync.service` -- the UI polls
@@ -53,7 +59,19 @@ POLL_BACKOFF = 1.5
 #: another release for the whole of one before its own first job starts.
 TIMEOUT_SECONDS = 45 * 60
 
-#: States a workflow run stops moving in.
+#: First gap between rollout polls.  Tighter than the build's: by this
+#: point the user has already waited out a build, and a rollout is the
+#: part they are watching for.
+DEPLOY_POLL_INITIAL_SECONDS = 6.0
+#: Ceiling the rollout interval backs off to.
+DEPLOY_POLL_MAX_SECONDS = 30.0
+#: How long to wait before giving up on a rollout.  Shorter than the
+#: build timeout: a Deployment is not serialized behind other releases,
+#: so a rollout that has not finished by now is stuck, not queued.
+DEPLOY_TIMEOUT_SECONDS = 30 * 60
+
+#: States a workflow run stops moving in.  ``DeploymentRun`` and
+#: ``ArtifactRun`` share these, so both poll loops test against it.
 TERMINAL_STATUSES = frozenset({'success', 'failure', 'cancelled'})
 
 PromoteState = typing.Literal[
@@ -62,6 +80,7 @@ PromoteState = typing.Literal[
     'deploying',
     'success',
     'build_failed',
+    'deploy_failed',
     'failed',
 ]
 
@@ -279,16 +298,17 @@ async def run_watch(
     *,
     valkey_client: object = None,
     timeout_seconds: float = TIMEOUT_SECONDS,
-    sleep: collections.abc.Callable[
-        [float], collections.abc.Awaitable[None]
-    ]
+    deploy_timeout_seconds: float = DEPLOY_TIMEOUT_SECONDS,
+    sleep: collections.abc.Callable[[float], collections.abc.Awaitable[None]]
     | None = None,
 ) -> PromoteState:
-    """Poll ``job``'s release build to a terminal state and act on it.
+    """Poll ``job``'s release build and rollout, and act on the outcome.
 
     Returns the state persisted on the way out.  *sleep* is injectable so
     tests can drive the loop without real time passing; *valkey_client*
     is passed through to the tag resync the success path enqueues.
+    *timeout_seconds* bounds the build, *deploy_timeout_seconds* the
+    rollout that follows it.
 
     A run id we never learned (``run_id=''`` -- the bodiless-204 dispatch
     on appliances without the ``2026-03-10`` API version) cannot be
@@ -415,7 +435,7 @@ async def run_watch(
 
     await mark('deploying' if job.deploy else 'success', run_url=run_url or '')
     try:
-        await project_deployments.complete_promote_build(
+        deployment = await project_deployments.complete_promote_build(
             db,
             org_slug=job.org_slug,
             project_id=job.project_id,
@@ -448,5 +468,132 @@ async def run_watch(
         )
         return 'failed'
 
-    await mark('success', run_url=run_url or '')
+    if deployment is None or not deployment.run_id:
+        # Releasable-only (no Deployment to watch), or a plugin that
+        # created one without telling us which.  Neither is a failure,
+        # and neither leaves anything to poll.
+        if job.deploy and deployment is not None:
+            LOGGER.warning(
+                'release-promote for project %s tag %s created a deployment '
+                'with no run id; cannot watch the rollout',
+                job.project_id,
+                job.tag,
+            )
+        await mark('success', run_url=run_url or '')
+        return 'success'
+
+    try:
+        return await _watch_rollout(
+            db,
+            job,
+            run_id=deployment.run_id,
+            initial_status=deployment.status,
+            build_run_url=run_url or '',
+            mark=mark,
+            napper=napper,
+            timeout_seconds=deploy_timeout_seconds,
+        )
+    except Exception as exc:
+        LOGGER.exception(
+            'release-promote rollout watch failed for project %s tag %s',
+            job.project_id,
+            job.tag,
+        )
+        # Same reasoning as the completion failure above: the tag and the
+        # Deployment both exist, so leave the release shippable.  Without
+        # this the status would stay ``deploying`` forever and the UI
+        # would poll a promote that nothing is driving.
+        await mark(
+            'failed',
+            error=(f'Deployment started, but Imbi lost track of it: {exc}'),
+            run_url=run_url or '',
+        )
+        return 'failed'
+
+
+async def _watch_rollout(
+    db: graph.Graph,
+    job: WatchJob,
+    *,
+    run_id: str,
+    initial_status: str,
+    build_run_url: str,
+    mark: collections.abc.Callable[..., collections.abc.Awaitable[None]],
+    napper: collections.abc.Callable[[float], collections.abc.Awaitable[None]],
+    timeout_seconds: float,
+) -> PromoteState:
+    """Poll the promote's Deployment until the rollout settles.
+
+    A failed rollout does *not* block the release: the build was green
+    and the tag is real, so the ordinary fix is to redeploy the same tag
+    once the cause is fixed, which a block would refuse.  That is the
+    difference between ``deploy_failed`` here and ``build_failed`` in the
+    build phase.
+
+    *build_run_url* is carried onto every write so the status keeps
+    pointing at the run that built the artifact.  The Deployment's own
+    URL is deliberately not swapped in: ``artifact_run_id`` names the
+    build run, and pairing it with a rollout URL would describe two
+    different runs as one.
+    """
+    from imbi.api.endpoints import project_deployments
+
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout_seconds
+    interval = DEPLOY_POLL_INITIAL_SECONDS
+    status = initial_status
+    target = job.to_environment or 'its environment'
+
+    while status not in TERMINAL_STATUSES:
+        if loop.time() >= deadline:
+            minutes = int(timeout_seconds // 60)
+            LOGGER.warning(
+                'release-promote rollout for project %s tag %s timed out '
+                'after %.0fs with the deployment still %s',
+                job.project_id,
+                job.tag,
+                timeout_seconds,
+                status,
+            )
+            await mark(
+                'deploy_failed',
+                error=(
+                    f'The deployment to {target} did not finish within '
+                    f'{minutes} minutes (last seen {status}). The release is '
+                    f'not blocked -- redeploy {job.tag} once the cause is '
+                    f'fixed.'
+                ),
+                run_url=build_run_url,
+            )
+            return 'deploy_failed'
+        await mark('deploying', run_url=build_run_url)
+        await napper(interval)
+        interval = min(interval * POLL_BACKOFF, DEPLOY_POLL_MAX_SECONDS)
+        run = await project_deployments.poll_promote_rollout(
+            db,
+            org_slug=job.org_slug,
+            project_id=job.project_id,
+            run_id=run_id,
+        )
+        status = run.status
+
+    if status != 'success':
+        LOGGER.info(
+            'release-promote rollout for project %s tag %s reported %s',
+            job.project_id,
+            job.tag,
+            status,
+        )
+        await mark(
+            'deploy_failed',
+            error=(
+                f'The deployment of {job.tag} to {target} {status}. The '
+                f'release is not blocked -- redeploy it once the cause is '
+                f'fixed.'
+            ),
+            run_url=build_run_url,
+        )
+        return 'deploy_failed'
+
+    await mark('success', run_url=build_run_url)
     return 'success'

--- a/apps/api/tests/endpoints/test_project_deployments.py
+++ b/apps/api/tests/endpoints/test_project_deployments.py
@@ -2119,6 +2119,89 @@ class BuildFailureBlockScopeTestCase(unittest.IsolatedAsyncioTestCase):
         )
 
 
+class PromotedTagSyncTestCase(unittest.IsolatedAsyncioTestCase):
+    """The tag a release build created is fed to ClickHouse.
+
+    An API-created tag fires no ``push`` event, so nothing else records
+    it.  The completion path syncs that one tag and only falls back to the
+    queued full backfill when the bounded call cannot run.
+    """
+
+    def setUp(self) -> None:
+        for target, replacement in (
+            ('_resolve_and_context', mock.AsyncMock()),
+            (
+                '_handler',
+                mock.Mock(
+                    return_value=mock.Mock(
+                        resolve_committish=mock.AsyncMock(return_value=None)
+                    )
+                ),
+            ),
+            ('_resolve_credentials', mock.Mock(return_value={})),
+            ('_get_release', mock.AsyncMock(return_value=None)),
+            ('persist_link_writeback', mock.AsyncMock()),
+        ):
+            patcher = mock.patch(f'{_MODULE}.{target}', replacement)
+            self.addCleanup(patcher.stop)
+            patcher.start()
+        project_deployments._resolve_and_context.return_value = (
+            mock.Mock(plugin_slug='github'),
+            mock.Mock(environment_config=None),
+            {},
+        )
+        self.sync_tag = self._patch(
+            'commit_sync_service.run_tag_sync', return_value=1
+        )
+        self.enqueue = self._patch(
+            'commit_sync_queue.enqueue_commit_sync', return_value=True
+        )
+
+    def _patch(self, target: str, **kwargs: typing.Any) -> mock.AsyncMock:
+        patcher = mock.patch(f'{_MODULE}.{target}', mock.AsyncMock(**kwargs))
+        self.addCleanup(patcher.stop)
+        return patcher.start()
+
+    async def _complete(self) -> None:
+        await project_deployments.complete_promote_build(
+            mock.AsyncMock(),
+            org_slug='octo',
+            project_id='p1',
+            release_id='rel1',
+            tag='0.1.5',
+            committish='e6a13a0',
+            to_environment='',
+            deploy=False,
+        )
+
+    async def test_records_the_one_tag_without_a_backfill(self) -> None:
+        await self._complete()
+        self.sync_tag.assert_awaited_once_with(mock.ANY, 'octo', 'p1', '0.1.5')
+        self.enqueue.assert_not_awaited()
+
+    async def test_falls_back_when_the_plugin_lacks_the_bounded_sync(
+        self,
+    ) -> None:
+        self.sync_tag.side_effect = NotImplementedError
+        await self._complete()
+        self.enqueue.assert_awaited_once()
+        self.assertEqual('0.1.5', self.sync_tag.await_args.args[3])
+
+    async def test_falls_back_when_the_bounded_sync_fails(self) -> None:
+        self.sync_tag.side_effect = RuntimeError('clickhouse is down')
+        await self._complete()
+        self.enqueue.assert_awaited_once()
+
+    async def test_a_tag_that_does_not_resolve_is_not_a_fallback(
+        self,
+    ) -> None:
+        """Zero rows means the tag is absent remotely; a backfill can't
+        find it either, so re-walking every tag buys nothing."""
+        self.sync_tag.return_value = 0
+        await self._complete()
+        self.enqueue.assert_not_awaited()
+
+
 class ProjectIsDeployableTestCase(unittest.IsolatedAsyncioTestCase):
     """``deployable`` is per project *type*, and a project can have several."""
 

--- a/apps/api/tests/endpoints/test_project_deployments.py
+++ b/apps/api/tests/endpoints/test_project_deployments.py
@@ -8,6 +8,7 @@ import unittest
 from unittest import mock
 
 import fastapi
+import httpx
 from fastapi import testclient
 
 from apps.api.tests import support
@@ -37,6 +38,7 @@ from imbi.common.plugins.base import (
     RefInfo,
     ReleaseInfo,
     RemoteDeployment,
+    RemoteRelease,
 )
 from imbi.common.plugins.registry import RegistryEntry
 
@@ -651,10 +653,32 @@ class ProjectDeploymentsTestCase(support.SharedAppTestCase):
         # last_tag bumped major: 6.3.0 → 7.0.0
         self.assertEqual(data['version'], 'v7.0.0')
 
-    def test_promote_sha_ref_cuts_tag_and_release(self) -> None:
-        # Promote target is a git SHA -- the handler cuts a tag, creates
-        # a release, AND dispatches trigger_deployment so the run is
-        # tracked in the deployment event.
+    def test_promote_sha_ref_cuts_tag_only(self) -> None:
+        # Promote target is a git SHA -- the handler cuts a tag AND
+        # dispatches trigger_deployment so the run is tracked in the
+        # deployment event.  The GitHub Release is *not* created: it
+        # ratifies a successful rollout, so it waits for the
+        # deployment_status webhook to drive ``releases/{tag}/publish``.
+        created: dict[str, bool] = {'release': False}
+
+        class _WatchRelease(_FakeDeploymentPlugin):
+            async def create_release(  # type: ignore[override]
+                self,
+                ctx,
+                credentials,
+                tag,
+                name,
+                body_markdown,
+                prerelease=False,
+            ):
+                created['release'] = True
+                return await super().create_release(
+                    ctx, credentials, tag, name, body_markdown, prerelease
+                )
+
+        self.mocks['resolve_capability'].return_value = _make_resolved(
+            _WatchRelease
+        )
         self.mocks['append_deployment_event'].return_value = mock.Mock()
         with testclient.TestClient(self.test_app) as client:
             response = client.post(
@@ -673,9 +697,8 @@ class ProjectDeploymentsTestCase(support.SharedAppTestCase):
         self.assertEqual(response.status_code, 202)
         data = response.json()
         self.assertEqual(data['tag'], '1a9c610abcdef')
-        self.assertEqual(
-            data['release_url'], 'https://gh/releases/1a9c610abcdef'
-        )
+        self.assertIsNone(data['release_url'])
+        self.assertFalse(created['release'])
         self.assertTrue(data['recorded'])
         self.assertIsNone(data['warning'])
         call = self.mocks['append_deployment_event'].call_args
@@ -684,11 +707,11 @@ class ProjectDeploymentsTestCase(support.SharedAppTestCase):
         self.assertEqual(call.kwargs['external_run_id'], '42')
         self.assertEqual(call.kwargs['external_run_url'], 'https://gh/runs/42')
 
-    def test_promote_semver_tag_dispatches_and_recreates_release(self) -> None:
+    def test_promote_semver_tag_dispatches_without_publishing(self) -> None:
         # Promote target is a semver tag -- the handler attempts create_tag
-        # and create_release (idempotently) AND dispatches trigger_deployment.
-        # A real GitHub 422 "already exists" for the tag/release is silently
-        # ignored; the fake plugin succeeds so we get a release URL.
+        # (idempotently; a real GitHub 422 "already exists" is silently
+        # ignored) AND dispatches trigger_deployment.  No release URL comes
+        # back because no GitHub Release is created at promote time.
         self.mocks['append_deployment_event'].return_value = mock.Mock()
         with testclient.TestClient(self.test_app) as client:
             response = client.post(
@@ -704,8 +727,7 @@ class ProjectDeploymentsTestCase(support.SharedAppTestCase):
         self.assertEqual(response.status_code, 202)
         data = response.json()
         self.assertEqual(data['tag'], 'v6.4.0')
-        # The fake plugin returned a release URL.
-        self.assertEqual(data['release_url'], 'https://gh/releases/v6.4.0')
+        self.assertIsNone(data['release_url'])
         self.assertIsNone(data['warning'])
         # The dispatched run surfaced on the event.
         call = self.mocks['append_deployment_event'].call_args
@@ -2486,6 +2508,217 @@ class ReleasesTabEndpointsTestCase(ProjectDeploymentsTestCase):
         data = response.json()
         self.assertIsNotNone(data['warning'])
         self.assertIn('create_release', data['warning'])
+
+
+class ReleasePublishTestCase(ProjectDeploymentsTestCase):
+    """Ratifying a Release: ``POST /deployments/releases/{tag}/publish``."""
+
+    _BASE = '/organizations/myorg/projects/proj1/deployments'
+    _PUBLISH = f'{_BASE}/releases/v6.4.0/publish'
+
+    def _patch_execute(
+        self,
+        *,
+        found: bool = True,
+        blocked: bool = False,
+    ) -> dict[str, list[dict[str, typing.Any]]]:
+        """Route the endpoint's graph reads by query text.
+
+        Returns a dict the test can inspect for the parameters of the
+        ``Release``-node link upsert (empty when it never ran).
+        """
+        node = self._release_node() if found else None
+        seen: dict[str, list[dict[str, typing.Any]]] = {'upsert': []}
+
+        def _execute(
+            query: str, params: dict[str, typing.Any], columns: typing.Any
+        ) -> list[dict[str, typing.Any]]:
+            del columns
+            if 'r.blocked_at IS NOT NULL' in query:
+                return (
+                    [
+                        {
+                            'release': json.dumps(
+                                {
+                                    'tag': 'v6.4.0',
+                                    'blocked_reason': 'Regression',
+                                }
+                            )
+                        }
+                    ]
+                    if blocked
+                    else []
+                )
+            if 'RETURN r{{.id, .tag' in query:
+                return [] if node is None else [{'release': json.dumps(node)}]
+            if 'SET r.description' in query:
+                seen['upsert'].append(params)
+                return [{'rid': 'rel-1'}]
+            return []
+
+        self.mock_db.execute = mock.AsyncMock(side_effect=_execute)
+        return seen
+
+    @staticmethod
+    def _release_node(**overrides: typing.Any) -> dict[str, typing.Any]:
+        return {
+            'id': 'rel-1',
+            'tag': 'v6.4.0',
+            'committish': '1a9c610',
+            'title': 'Release 6.4.0',
+            'description': '## Highlights\n- foo',
+            'created_at': '2026-01-01T00:00:00+00:00',
+            **overrides,
+        }
+
+    def test_publish_creates_the_remote_release(self) -> None:
+        seen = self._patch_execute()
+        with testclient.TestClient(self.test_app) as client:
+            response = client.post(self._PUBLISH)
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(data['tag'], 'v6.4.0')
+        self.assertTrue(data['published'])
+        self.assertEqual(data['release_url'], 'https://gh/releases/v6.4.0')
+        self.assertIsNone(data['warning'])
+        # The github_release link was written back onto the node.
+        self.assertEqual(len(seen['upsert']), 1)
+        self.assertIn('https://gh/releases/v6.4.0', seen['upsert'][0]['links'])
+        # ...without clobbering the notes already recorded there.
+        self.assertEqual(seen['upsert'][0]['description'], '')
+
+    def test_publish_uses_the_nodes_title_and_notes(self) -> None:
+        # The ratification must not drift from what Imbi recorded at
+        # promote time, so title/body come from the Release node rather
+        # than from the caller.
+        captured: dict[str, typing.Any] = {}
+
+        class _Capturing(_FakeDeploymentPlugin):
+            async def create_release(  # type: ignore[override]
+                self,
+                ctx,
+                credentials,
+                tag,
+                name,
+                body_markdown,
+                prerelease=False,
+            ):
+                captured.update(
+                    tag=tag,
+                    name=name,
+                    body_markdown=body_markdown,
+                    prerelease=prerelease,
+                )
+                return await super().create_release(
+                    ctx, credentials, tag, name, body_markdown, prerelease
+                )
+
+        self.mocks['resolve_capability'].return_value = _make_resolved(
+            _Capturing
+        )
+        self._patch_execute()
+        with testclient.TestClient(self.test_app) as client:
+            response = client.post(self._PUBLISH, json={'prerelease': True})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(captured['tag'], 'v6.4.0')
+        self.assertEqual(captured['name'], 'Release 6.4.0')
+        self.assertEqual(captured['body_markdown'], '## Highlights\n- foo')
+        self.assertTrue(captured['prerelease'])
+
+    def test_publish_unknown_tag_is_404(self) -> None:
+        self._patch_execute(found=False)
+        with testclient.TestClient(self.test_app) as client:
+            response = client.post(self._PUBLISH)
+        self.assertEqual(response.status_code, 404)
+        self.assertIn('No release found', response.json()['detail'])
+
+    def test_publish_of_a_blocked_release_is_409(self) -> None:
+        self._patch_execute(blocked=True)
+        with testclient.TestClient(self.test_app) as client:
+            response = client.post(self._PUBLISH)
+        self.assertEqual(response.status_code, 409)
+        self.assertIn('is blocked', response.json()['detail'])
+
+    def test_publish_degrades_a_plugin_failure_to_a_warning(self) -> None:
+        class _Boom(_FakeDeploymentPlugin):
+            async def create_release(  # type: ignore[override]
+                self,
+                ctx,
+                credentials,
+                tag,
+                name,
+                body_markdown,
+                prerelease=False,
+            ):
+                raise RuntimeError('boom')
+
+        self.mocks['resolve_capability'].return_value = _make_resolved(_Boom)
+        seen = self._patch_execute()
+        with testclient.TestClient(self.test_app) as client:
+            response = client.post(self._PUBLISH)
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertFalse(data['published'])
+        self.assertIsNone(data['release_url'])
+        self.assertIn('create_release', data['warning'])
+        # Nothing was written back -- there is no URL to record.
+        self.assertEqual(seen['upsert'], [])
+
+    def test_publish_is_idempotent_for_an_existing_remote_release(
+        self,
+    ) -> None:
+        # A 422 "already exists" is the second delivery of the same
+        # deployment_status webhook, not a failure: the endpoint reports
+        # published and recovers the URL via ``get_release``.
+        class _AlreadyThere(_FakeDeploymentPlugin):
+            async def create_release(  # type: ignore[override]
+                self,
+                ctx,
+                credentials,
+                tag,
+                name,
+                body_markdown,
+                prerelease=False,
+            ):
+                raise httpx.HTTPStatusError(
+                    'already exists',
+                    request=httpx.Request('POST', 'https://api.gh/releases'),
+                    response=httpx.Response(
+                        422, json={'message': 'Reference already exists'}
+                    ),
+                )
+
+            async def get_release(  # type: ignore[override]
+                self, ctx, credentials, tag
+            ):
+                return RemoteRelease(
+                    tag=tag, html_url=f'https://gh/releases/{tag}'
+                )
+
+        self.mocks['resolve_capability'].return_value = _make_resolved(
+            _AlreadyThere
+        )
+        seen = self._patch_execute()
+        with testclient.TestClient(self.test_app) as client:
+            response = client.post(self._PUBLISH)
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertTrue(data['published'])
+        self.assertEqual(data['release_url'], 'https://gh/releases/v6.4.0')
+        self.assertIsNone(data['warning'])
+        self.assertEqual(len(seen['upsert']), 1)
+
+    def test_publish_writes_an_operations_log_audit(self) -> None:
+        self._patch_execute()
+        with testclient.TestClient(self.test_app) as client:
+            response = client.post(self._PUBLISH)
+        self.assertEqual(response.status_code, 200)
+        insert = self.mocks['clickhouse'].return_value.insert
+        insert.assert_awaited()
+        columns = insert.await_args.args[2]
+        row = dict(zip(columns, insert.await_args.args[1][0], strict=True))
+        self.assertEqual(row['version'], 'v6.4.0')
+        self.assertEqual(json.loads(row['description'])['action'], 'publish')
 
 
 class ReleaseBlockTestCase(ProjectDeploymentsTestCase):

--- a/apps/api/tests/endpoints/test_project_deployments.py
+++ b/apps/api/tests/endpoints/test_project_deployments.py
@@ -26,6 +26,7 @@ from imbi.common import graph
 from imbi.common.llm import AnthropicClient, CompletionResult
 from imbi.common.models import SEMVER_TAG_FORMAT, TagFormat
 from imbi.common.plugins.base import (
+    ArtifactRun,
     Capability,
     Commit,
     CompareResult,
@@ -115,6 +116,34 @@ class _FakeDeploymentPlugin(DeploymentCapability):
         return getattr(self, '_recent', [])
 
 
+class _DispatchingDeploymentPlugin(_FakeDeploymentPlugin):
+    """Implements the artifact-dispatch half of the capability.
+
+    Records every dispatch on the class so a test driving the endpoint
+    through ``TestClient`` can assert what reached the remote.
+    """
+
+    dispatches: typing.ClassVar[list[dict[str, typing.Any]]] = []
+    run_id: typing.ClassVar[str | None] = '4242'
+
+    async def create_deployment_artifact(  # type: ignore[override]
+        self, ctx, credentials, ref, version, inputs=None
+    ):
+        type(self).dispatches.append(
+            {'ref': ref, 'version': version, 'inputs': dict(inputs or {})}
+        )
+        return ArtifactRun(
+            run_id=type(self).run_id,
+            run_url='https://ghe/run/4242' if type(self).run_id else None,
+            status='queued',
+        )
+
+    async def get_artifact_run_status(  # type: ignore[override]
+        self, ctx, credentials, run_id
+    ):
+        return ArtifactRun(run_id=run_id, status='in_progress')
+
+
 class _FakeNoSyncDeploymentPlugin(_FakeDeploymentPlugin):
     """Deployment plugin that opts *out* of resync."""
 
@@ -198,6 +227,7 @@ def _make_resolved(
     name: str = 'GitHub Deployment',
     sync: bool = True,
     options: dict[str, typing.Any] | None = None,
+    capability_options: dict[str, typing.Any] | None = None,
     env_payloads: dict[str, dict[str, typing.Any]] | None = None,
 ) -> ResolvedCapability:
     entry = _entry(handler, slug=slug, name=name, sync=sync)
@@ -210,7 +240,7 @@ def _make_resolved(
         capability_cls=entry.manifest.get_capability('deployment').handler,
         integration={'id': 'p-1', 'slug': f'{slug}-prod', 'plugin': slug},
         integration_options=options or {},
-        capability_options={},
+        capability_options=capability_options or {},
         encrypted_credentials={},
         env_payloads=env_payloads,
     )
@@ -1850,6 +1880,251 @@ class DeployedOperationLogTestCase(unittest.TestCase):
     def test_commit_sha_defaults_to_none(self) -> None:
         description = self._build(version='1.29.0')
         self.assertIsNone(description['commit_sha'])
+
+
+class DispatchDrivenPromoteTestCase(ProjectDeploymentsTestCase):
+    """Promote dispatches the Release workflow when one is configured.
+
+    The workflow owns the tag and the remote Release, so the endpoint
+    creates neither -- it records the ``Release`` node, dispatches, and
+    hands off to the watcher.
+    """
+
+    _BASE = '/organizations/myorg/projects/proj1/deployments'
+    _PROMOTE: typing.ClassVar[dict[str, typing.Any]] = {
+        'action': 'promote',
+        'from_environment': 'testing',
+        'to_environment': 'staging',
+        'from_committish': 'e6a13a0d6cf93cd5af4eef2a0ca13035aea64192',
+        'tag': '0.1.5',
+        'release_name': 'Release 0.1.5',
+        'release_notes_markdown': '## What changed',
+    }
+
+    def _enable_dispatch(self, *, workflow: str = 'release.yml') -> None:
+        """Opt this test into the dispatch path.
+
+        Deliberately *not* in ``setUp``: this class inherits every test on
+        ``ProjectDeploymentsTestCase``, and configuring a Release workflow
+        for all of them would silently reroute the inherited promote tests
+        onto the dispatch branch.
+        """
+        _DispatchingDeploymentPlugin.dispatches.clear()
+        _DispatchingDeploymentPlugin.run_id = '4242'
+        self.mocks['resolve_capability'].return_value = _make_resolved(
+            _DispatchingDeploymentPlugin,
+            options={'owner': 'octo', 'repo': 'demo'},
+            capability_options=(
+                {'artifact_workflow': workflow} if workflow else {}
+            ),
+        )
+        self.upsert = self._start(
+            mock.patch(f'{_MODULE}._upsert_release_node', return_value='rel1')
+        )
+        self.deployable = self._start(
+            mock.patch(f'{_MODULE}._project_is_deployable', return_value=True)
+        )
+        self.enqueue = self._start(
+            mock.patch(
+                f'{_MODULE}.release_promote_queue.enqueue_release_promote',
+                return_value=True,
+            )
+        )
+        self.set_status = self._start(
+            mock.patch(
+                f'{_MODULE}.release_promote_service.set_status',
+                return_value=None,
+            )
+        )
+        self.create_tag = self._start(
+            mock.patch(f'{_MODULE}._promote_cut_tag', return_value=None)
+        )
+
+    def _promote(self, **overrides: typing.Any) -> httpx.Response:
+        body = {**self._PROMOTE, **overrides}
+        with testclient.TestClient(self.test_app) as client:
+            return client.post(self._BASE, json=body)
+
+    def test_dispatches_instead_of_cutting_the_tag(self) -> None:
+        self._enable_dispatch()
+        response = self._promote()
+        self.assertEqual(response.status_code, 202)
+        data = response.json()
+        self.assertEqual('building', data['phase'])
+        self.assertEqual('4242', data['artifact_run_id'])
+        self.assertEqual('0.1.5', data['tag'])
+        self.assertTrue(data['watched'])
+        self.assertIsNone(data['warning'])
+        self.assertEqual(1, len(_DispatchingDeploymentPlugin.dispatches))
+        # The endpoint must not cut the tag itself any more.
+        self.create_tag.assert_not_called()
+
+    def test_always_sends_the_commit_input(self) -> None:
+        """release-tag.yaml tags the tip of main when ``commit`` is empty.
+
+        Omitting it would silently release a different tree than the one
+        being promoted, and the run would still go green -- so this is a
+        correctness guard, not a nicety.
+        """
+        self._enable_dispatch()
+        self._promote()
+        inputs = _DispatchingDeploymentPlugin.dispatches[0]['inputs']
+        self.assertEqual('e6a13a0', inputs['commit'])
+        self.assertTrue(inputs['commit'])
+
+    def test_dispatch_input_mapping(self) -> None:
+        self._enable_dispatch()
+        self._promote()
+        dispatch = _DispatchingDeploymentPlugin.dispatches[0]
+        # Dispatched from the default branch: workflow_dispatch resolves
+        # the workflow file on the ref, and the tag does not exist yet.
+        self.assertEqual('main', dispatch['ref'])
+        self.assertEqual('0.1.5', dispatch['version'])
+        inputs = dispatch['inputs']
+        self.assertEqual('Release 0.1.5', inputs['description'])
+        self.assertEqual('## What changed', inputs['release_notes'])
+        self.assertEqual('staging', inputs['environment'])
+        # The D6 seam: Imbi owns Deployment creation now.
+        self.assertEqual('false', inputs['create_deployment'])
+
+    def test_description_falls_back_to_the_tag(self) -> None:
+        """``description`` is required by release.yml, so never send empty."""
+        self._enable_dispatch()
+        self._promote(release_name=None)
+        inputs = _DispatchingDeploymentPlugin.dispatches[0]['inputs']
+        self.assertEqual('0.1.5', inputs['description'])
+
+    def test_records_the_release_node_before_dispatching(self) -> None:
+        """A failed build needs a node to block."""
+        self._enable_dispatch()
+        self._promote()
+        self.upsert.assert_awaited_once()
+        kwargs = self.upsert.await_args.kwargs
+        self.assertEqual('0.1.5', kwargs['tag'])
+        self.assertEqual('e6a13a0', kwargs['committish'])
+        # No release URL yet -- the build has not created one.
+        self.assertIsNone(kwargs['release_url'])
+
+    def test_enqueues_a_watch_job_carrying_the_promoter(self) -> None:
+        self._enable_dispatch()
+        self._promote()
+        self.enqueue.assert_awaited_once()
+        job = self.enqueue.await_args.args[1]
+        self.assertEqual('0.1.5', job.tag)
+        self.assertEqual('e6a13a0', job.committish)
+        self.assertEqual('staging', job.to_environment)
+        self.assertEqual('testing', job.from_environment)
+        self.assertEqual('4242', job.run_id)
+        self.assertEqual('rel1', job.release_id)
+        self.assertTrue(job.deploy)
+        self.assertEqual('admin@example.com', job.requested_by)
+
+    def test_releasable_only_project_queues_a_build_only_job(self) -> None:
+        self._enable_dispatch()
+        self.deployable.return_value = False
+        self._promote()
+        self.assertFalse(self.enqueue.await_args.args[1].deploy)
+
+    def test_unqueueable_watch_warns_and_is_not_watched(self) -> None:
+        self._enable_dispatch()
+        self.enqueue.return_value = False
+        data = self._promote().json()
+        self.assertFalse(data['watched'])
+        self.assertIn('could not queue a watcher', data['warning'])
+
+    def test_missing_run_id_warns_and_skips_the_watch(self) -> None:
+        self._enable_dispatch()
+        _DispatchingDeploymentPlugin.run_id = None
+        data = self._promote().json()
+        self.assertFalse(data['watched'])
+        self.assertIn('did not report a run id', data['warning'])
+        self.enqueue.assert_not_awaited()
+
+    def test_blocked_release_is_refused_before_dispatching(self) -> None:
+        self._enable_dispatch()
+        self.mock_db.execute = mock.AsyncMock(
+            return_value=[
+                {
+                    'release': json.dumps(
+                        {
+                            'tag': '0.1.5',
+                            'committish': 'e6a13a0',
+                            'blocked_reason': 'Bad build',
+                        }
+                    )
+                }
+            ]
+        )
+        response = self._promote()
+        self.assertEqual(response.status_code, 409)
+        self.assertEqual([], _DispatchingDeploymentPlugin.dispatches)
+
+    def test_legacy_path_when_no_release_workflow_configured(self) -> None:
+        """A blank Release workflow keeps cutting the tag inline."""
+        self._enable_dispatch(workflow='')
+        response = self._promote()
+        self.assertEqual(response.status_code, 202)
+        self.assertIsNone(response.json()['phase'])
+        self.assertEqual([], _DispatchingDeploymentPlugin.dispatches)
+        self.create_tag.assert_awaited_once()
+
+
+class BuildFailureBlockScopeTestCase(unittest.IsolatedAsyncioTestCase):
+    """A failed build blocks the version, not the commit."""
+
+    async def test_fail_promote_build_scopes_the_block_to_the_tag(
+        self,
+    ) -> None:
+        db = mock.AsyncMock()
+        db.execute = mock.AsyncMock(return_value=[{'rid': 'r1'}])
+        await project_deployments.fail_promote_build(
+            db,
+            org_slug='octo',
+            project_id='p1',
+            tag='0.1.5',
+            reason='Release build reported failure',
+            requested_by='daves@aweber.com',
+        )
+        params = db.execute.await_args.args[1]
+        self.assertEqual('tag', params['scope'])
+        self.assertEqual('0.1.5', params['tag'])
+        self.assertEqual('daves@aweber.com', params['blocked_by'])
+        self.assertIn('failure', params['reason'])
+
+    async def test_missing_release_node_is_survivable(self) -> None:
+        db = mock.AsyncMock()
+        db.execute = mock.AsyncMock(return_value=[])
+        # Deleted mid-build: warn, don't raise into the watcher.
+        await project_deployments.fail_promote_build(
+            db, org_slug='octo', project_id='p1', tag='0.1.5', reason='boom'
+        )
+
+
+class ProjectIsDeployableTestCase(unittest.IsolatedAsyncioTestCase):
+    """``deployable`` is per project *type*, and a project can have several."""
+
+    async def _ask(self, flags: typing.Any) -> bool:
+        db = mock.AsyncMock()
+        db.execute = mock.AsyncMock(
+            return_value=[{'flags': json.dumps(flags)}]
+        )
+        return await project_deployments._project_is_deployable(db, 'p1')
+
+    async def test_true_when_any_type_is_deployable(self) -> None:
+        self.assertTrue(await self._ask([False, True]))
+
+    async def test_false_when_no_type_is_deployable(self) -> None:
+        self.assertFalse(await self._ask([False, False]))
+
+    async def test_false_when_the_project_has_no_type(self) -> None:
+        self.assertFalse(await self._ask([]))
+
+    async def test_false_when_the_project_is_missing(self) -> None:
+        db = mock.AsyncMock()
+        db.execute = mock.AsyncMock(return_value=[])
+        self.assertFalse(
+            await project_deployments._project_is_deployable(db, 'nope')
+        )
 
 
 def _relocating_resolved() -> ResolvedCapability:

--- a/apps/api/tests/endpoints/test_project_deployments.py
+++ b/apps/api/tests/endpoints/test_project_deployments.py
@@ -1987,6 +1987,25 @@ class DispatchDrivenPromoteTestCase(ProjectDeploymentsTestCase):
         # The D6 seam: Imbi owns Deployment creation now.
         self.assertEqual('false', inputs['create_deployment'])
 
+    def test_deployment_inputs_omitted_for_a_releasable_project(self) -> None:
+        """A releasable project's workflow declares neither input.
+
+        Publishing *is* the release for a library, so its variant of
+        release.yml drops ``environment`` and ``create_deployment``
+        entirely -- and workflow_dispatch 422s the whole call when it is
+        handed an input the workflow does not declare, so sending them
+        anyway fails the release outright.
+        """
+        self._enable_dispatch()
+        self.deployable.return_value = False
+        self._promote()
+        inputs = _DispatchingDeploymentPlugin.dispatches[0]['inputs']
+        self.assertNotIn('create_deployment', inputs)
+        self.assertNotIn('environment', inputs)
+        # The universal inputs are unaffected.
+        self.assertEqual('Release 0.1.5', inputs['description'])
+        self.assertEqual('e6a13a0', inputs['commit'])
+
     def test_description_falls_back_to_the_tag(self) -> None:
         """``description`` is required by release.yml, so never send empty."""
         self._enable_dispatch()

--- a/apps/api/tests/test_commit_sync_service.py
+++ b/apps/api/tests/test_commit_sync_service.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import typing
 import unittest
 from unittest import mock
 
@@ -17,6 +18,19 @@ class _FakeCommitSync(CommitSyncCapability):
 
     async def sync_all_history(self, *, ctx, credentials):  # type: ignore[no-untyped-def]
         return (5, 1)
+
+
+class _TagCommitSync(CommitSyncCapability):
+    """Implements the bounded per-tag sync and records what it got."""
+
+    calls: typing.ClassVar[list[str]] = []
+
+    async def sync_all_history(self, *, ctx, credentials):  # type: ignore[no-untyped-def]
+        raise AssertionError('the bounded path must not backfill everything')
+
+    async def sync_tag(self, *, ctx, credentials, tag):  # type: ignore[no-untyped-def]
+        self.calls.append(tag)
+        return 1
 
 
 class _UnavailableCommitSync(CommitSyncCapability):
@@ -62,6 +76,54 @@ class RunSyncTests(unittest.IsolatedAsyncioTestCase):
         ):
             with self.assertRaises(service.CommitSyncUnavailable):
                 await service.run_sync(db, 'octo', 'p1')
+
+
+class RunTagSyncTests(unittest.IsolatedAsyncioTestCase):
+    def setUp(self) -> None:
+        _TagCommitSync.calls.clear()
+
+    def _patch(self, handler_cls: type) -> typing.Any:
+        return (
+            mock.patch.object(
+                service,
+                'resolve_capability',
+                mock.AsyncMock(return_value=_resolved(handler_cls)),
+            ),
+            mock.patch.object(
+                service,
+                '_build_context',
+                mock.AsyncMock(return_value=mock.Mock()),
+            ),
+        )
+
+    async def test_invokes_handler_sync_tag(self) -> None:
+        db = mock.AsyncMock()
+        resolve, context = self._patch(_TagCommitSync)
+        with resolve, context:
+            written = await service.run_tag_sync(db, 'octo', 'p1', '1.2.3')
+        self.assertEqual(1, written)
+        self.assertEqual(['1.2.3'], _TagCommitSync.calls)
+
+    async def test_unimplemented_propagates(self) -> None:
+        """The default raises so the caller can fall back to a backfill."""
+        db = mock.AsyncMock()
+        resolve, context = self._patch(_FakeCommitSync)
+        with resolve, context, self.assertRaises(NotImplementedError):
+            await service.run_tag_sync(db, 'octo', 'p1', '1.2.3')
+
+    async def test_unresolved_raises_unavailable(self) -> None:
+        db = mock.AsyncMock()
+        with mock.patch.object(
+            service,
+            'resolve_capability',
+            mock.AsyncMock(
+                side_effect=fastapi.HTTPException(
+                    status_code=404, detail='no capability'
+                )
+            ),
+        ):
+            with self.assertRaises(service.CommitSyncUnavailable):
+                await service.run_tag_sync(db, 'octo', 'p1', '1.2.3')
 
 
 class CheckAvailableTests(unittest.IsolatedAsyncioTestCase):

--- a/apps/api/tests/test_release_promote_service.py
+++ b/apps/api/tests/test_release_promote_service.py
@@ -1,0 +1,215 @@
+"""Tests for the release-promote watcher (poll loop, status, outcomes)."""
+
+from __future__ import annotations
+
+import typing
+import unittest
+from unittest import mock
+
+from imbi.api.release_promote import service
+from imbi.common.plugins import base as plugin_base
+
+
+def _job(**overrides: typing.Any) -> service.WatchJob:
+    fields: dict[str, typing.Any] = {
+        'org_slug': 'octo',
+        'project_id': 'p1',
+        'release_id': 'rel1',
+        'tag': '1.2.3',
+        'committish': 'abc1234',
+        'to_environment': 'staging',
+        'from_environment': 'testing',
+        'run_id': '4242',
+        'run_url': 'https://ghe/run/4242',
+        'requested_by': 'daves@aweber.com',
+        'deploy': True,
+    }
+    fields.update(overrides)
+    return service.WatchJob(**fields)
+
+
+def _run(status: str, run_url: str | None = None) -> plugin_base.ArtifactRun:
+    return plugin_base.ArtifactRun(
+        run_id='4242',
+        run_url=run_url,
+        status=typing.cast(typing.Any, status),
+    )
+
+
+class _Harness:
+    """Patches the endpoint helpers ``run_watch`` delegates to."""
+
+    def __init__(self, *statuses: str) -> None:
+        self.poll = mock.AsyncMock(
+            side_effect=[_run(status) for status in statuses]
+        )
+        self.complete = mock.AsyncMock()
+        self.fail = mock.AsyncMock()
+        self.set_status = mock.AsyncMock()
+        self.slept: list[float] = []
+
+    async def sleep(self, seconds: float) -> None:
+        self.slept.append(seconds)
+
+    def __enter__(self) -> _Harness:
+        self._patches = [
+            mock.patch(
+                'imbi.api.endpoints.project_deployments.poll_artifact_run',
+                self.poll,
+            ),
+            mock.patch(
+                'imbi.api.endpoints.project_deployments'
+                '.complete_promote_build',
+                self.complete,
+            ),
+            mock.patch(
+                'imbi.api.endpoints.project_deployments.fail_promote_build',
+                self.fail,
+            ),
+            mock.patch.object(service, 'set_status', self.set_status),
+        ]
+        for patch in self._patches:
+            patch.start()
+        return self
+
+    def __exit__(self, *_exc: object) -> None:
+        for patch in reversed(self._patches):
+            patch.stop()
+
+    def states(self) -> list[str]:
+        return [
+            call.kwargs['status'] for call in self.set_status.await_args_list
+        ]
+
+
+class RunWatchTests(unittest.IsolatedAsyncioTestCase):
+    async def test_success_completes_and_deploys(self) -> None:
+        db = mock.AsyncMock()
+        with _Harness('success') as harness:
+            state = await service.run_watch(
+                db, _job(), sleep=harness.sleep, valkey_client='vk'
+            )
+        self.assertEqual('success', state)
+        harness.complete.assert_awaited_once()
+        harness.fail.assert_not_awaited()
+        kwargs = harness.complete.await_args.kwargs
+        self.assertTrue(kwargs['deploy'])
+        self.assertEqual('1.2.3', kwargs['tag'])
+        self.assertEqual('daves@aweber.com', kwargs['requested_by'])
+        self.assertEqual('vk', kwargs['valkey_client'])
+        # ``deploying`` before the work, ``success`` after it.
+        self.assertEqual(['deploying', 'success'], harness.states())
+
+    async def test_releasable_only_skips_the_deploy_phase(self) -> None:
+        db = mock.AsyncMock()
+        with _Harness('success') as harness:
+            state = await service.run_watch(
+                db, _job(deploy=False, to_environment=''), sleep=harness.sleep
+            )
+        self.assertEqual('success', state)
+        self.assertFalse(harness.complete.await_args.kwargs['deploy'])
+        # Never advertises a deploy phase it isn't going to run.
+        self.assertNotIn('deploying', harness.states())
+
+    async def test_polls_until_terminal(self) -> None:
+        db = mock.AsyncMock()
+        with _Harness('queued', 'in_progress', 'success') as harness:
+            state = await service.run_watch(db, _job(), sleep=harness.sleep)
+        self.assertEqual('success', state)
+        self.assertEqual(3, harness.poll.await_count)
+        # Interval backs off between polls and is capped.
+        self.assertEqual(2, len(harness.slept))
+        self.assertLessEqual(harness.slept[0], harness.slept[1])
+        self.assertLessEqual(max(harness.slept), service.POLL_MAX_SECONDS)
+        self.assertIn('building', harness.states())
+
+    async def test_failed_build_blocks_the_release(self) -> None:
+        db = mock.AsyncMock()
+        with _Harness('failure') as harness:
+            state = await service.run_watch(db, _job(), sleep=harness.sleep)
+        self.assertEqual('build_failed', state)
+        harness.complete.assert_not_awaited()
+        harness.fail.assert_awaited_once()
+        kwargs = harness.fail.await_args.kwargs
+        self.assertEqual('1.2.3', kwargs['tag'])
+        self.assertIn('failure', kwargs['reason'])
+        self.assertEqual(['build_failed'], harness.states())
+
+    async def test_cancelled_build_blocks_the_release(self) -> None:
+        db = mock.AsyncMock()
+        with _Harness('cancelled') as harness:
+            state = await service.run_watch(db, _job(), sleep=harness.sleep)
+        self.assertEqual('build_failed', state)
+        harness.fail.assert_awaited_once()
+        self.assertIn('cancelled', harness.fail.await_args.kwargs['reason'])
+
+    async def test_timeout_blocks_the_release(self) -> None:
+        db = mock.AsyncMock()
+        with _Harness('in_progress') as harness:
+            state = await service.run_watch(
+                db,
+                _job(),
+                sleep=harness.sleep,
+                timeout_seconds=0,
+            )
+        self.assertEqual('build_failed', state)
+        harness.complete.assert_not_awaited()
+        harness.fail.assert_awaited_once()
+        self.assertIn(
+            'did not finish', harness.fail.await_args.kwargs['reason']
+        )
+
+    async def test_missing_run_id_does_not_block(self) -> None:
+        """A dispatch with no run id is unwatchable, not a failed build.
+
+        The build may well be green, so blocking the tag would wedge a
+        release that is fine.  Report it and leave the tag shippable.
+        """
+        db = mock.AsyncMock()
+        with _Harness() as harness:
+            state = await service.run_watch(
+                db, _job(run_id=''), sleep=harness.sleep
+            )
+        self.assertEqual('failed', state)
+        harness.poll.assert_not_awaited()
+        harness.fail.assert_not_awaited()
+        harness.complete.assert_not_awaited()
+        self.assertEqual(['failed'], harness.states())
+
+    async def test_completion_failure_does_not_block(self) -> None:
+        """The build succeeded; only Imbi's follow-through broke."""
+        db = mock.AsyncMock()
+        with _Harness('success') as harness:
+            harness.complete.side_effect = RuntimeError('graph exploded')
+            state = await service.run_watch(db, _job(), sleep=harness.sleep)
+        self.assertEqual('failed', state)
+        harness.fail.assert_not_awaited()
+        self.assertEqual(['deploying', 'failed'], harness.states())
+        error = harness.set_status.await_args_list[-1].kwargs['error']
+        self.assertIn('graph exploded', error)
+
+    async def test_run_url_from_the_poll_is_carried_forward(self) -> None:
+        db = mock.AsyncMock()
+        with _Harness('success') as harness:
+            harness.poll.side_effect = [
+                _run('success', run_url='https://ghe/run/late')
+            ]
+            await service.run_watch(db, _job(run_url=''), sleep=harness.sleep)
+        self.assertEqual(
+            'https://ghe/run/late',
+            harness.complete.await_args.kwargs['run_url'],
+        )
+
+
+class ReadStatusTests(unittest.IsolatedAsyncioTestCase):
+    async def test_missing_project_is_idle(self) -> None:
+        db = mock.AsyncMock()
+        db.execute.return_value = []
+        status = await service.read_status(db, 'p1')
+        self.assertEqual('idle', status.status)
+
+    async def test_unrecognized_status_falls_back_to_idle(self) -> None:
+        db = mock.AsyncMock()
+        db.execute.return_value = [{'status': 'wat', 'tag': '1.0.0'}]
+        status = await service.read_status(db, 'p1')
+        self.assertEqual('idle', status.status)

--- a/apps/api/tests/test_release_promote_service.py
+++ b/apps/api/tests/test_release_promote_service.py
@@ -36,14 +36,32 @@ def _run(status: str, run_url: str | None = None) -> plugin_base.ArtifactRun:
     )
 
 
-class _Harness:
-    """Patches the endpoint helpers ``run_watch`` delegates to."""
+def _deployment(
+    status: str = 'queued', run_id: str = '99'
+) -> plugin_base.DeploymentRun:
+    return plugin_base.DeploymentRun(
+        run_id=run_id,
+        run_url='https://ghe/deployments/99',
+        status=typing.cast(typing.Any, status),
+    )
 
-    def __init__(self, *statuses: str) -> None:
+
+class _Harness:
+    """Patches the endpoint helpers ``run_watch`` delegates to.
+
+    *statuses* drives the build poll; *rollout* drives the rollout poll
+    that follows it.  ``complete_promote_build`` hands back a Deployment
+    by default, because that is what a deployable promote does.
+    """
+
+    def __init__(self, *statuses: str, rollout: tuple[str, ...] = ()) -> None:
         self.poll = mock.AsyncMock(
             side_effect=[_run(status) for status in statuses]
         )
-        self.complete = mock.AsyncMock()
+        self.complete = mock.AsyncMock(return_value=_deployment())
+        self.poll_rollout = mock.AsyncMock(
+            side_effect=[_deployment(status) for status in rollout]
+        )
         self.fail = mock.AsyncMock()
         self.set_status = mock.AsyncMock()
         self.slept: list[float] = []
@@ -56,6 +74,10 @@ class _Harness:
             mock.patch(
                 'imbi.api.endpoints.project_deployments.poll_artifact_run',
                 self.poll,
+            ),
+            mock.patch(
+                'imbi.api.endpoints.project_deployments.poll_promote_rollout',
+                self.poll_rollout,
             ),
             mock.patch(
                 'imbi.api.endpoints.project_deployments'
@@ -85,7 +107,7 @@ class _Harness:
 class RunWatchTests(unittest.IsolatedAsyncioTestCase):
     async def test_success_completes_and_deploys(self) -> None:
         db = mock.AsyncMock()
-        with _Harness('success') as harness:
+        with _Harness('success', rollout=('success',)) as harness:
             state = await service.run_watch(
                 db, _job(), sleep=harness.sleep, valkey_client='vk'
             )
@@ -97,31 +119,142 @@ class RunWatchTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual('1.2.3', kwargs['tag'])
         self.assertEqual('daves@aweber.com', kwargs['requested_by'])
         self.assertEqual('vk', kwargs['valkey_client'])
-        # ``deploying`` before the work, ``success`` after it.
-        self.assertEqual(['deploying', 'success'], harness.states())
+        # ``deploying`` spans creating the Deployment *and* waiting on the
+        # rollout; ``success`` lands only once that rollout is green.
+        self.assertEqual(
+            ['deploying', 'deploying', 'success'], harness.states()
+        )
+
+    async def test_success_waits_for_the_rollout(self) -> None:
+        """``success`` must not land when the Deployment is merely created.
+
+        Regression guard: reporting success at the handover told the UI
+        the promote had shipped while the rollout had not yet started,
+        which tore down the progress toast and refetched the release
+        views before there was anything new to read.
+        """
+        db = mock.AsyncMock()
+        with _Harness(
+            'success', rollout=('in_progress', 'success')
+        ) as harness:
+            state = await service.run_watch(db, _job(), sleep=harness.sleep)
+        self.assertEqual('success', state)
+        self.assertEqual(2, harness.poll_rollout.await_count)
+        self.assertEqual(
+            '99', harness.poll_rollout.await_args.kwargs['run_id']
+        )
+        # Still ``deploying`` on every write until the rollout settles.
+        self.assertEqual(
+            ['deploying', 'deploying', 'deploying', 'success'],
+            harness.states(),
+        )
 
     async def test_releasable_only_skips_the_deploy_phase(self) -> None:
         db = mock.AsyncMock()
         with _Harness('success') as harness:
+            # A build-only promote creates no Deployment to watch.
+            harness.complete.return_value = None
             state = await service.run_watch(
                 db, _job(deploy=False, to_environment=''), sleep=harness.sleep
             )
         self.assertEqual('success', state)
         self.assertFalse(harness.complete.await_args.kwargs['deploy'])
+        harness.poll_rollout.assert_not_awaited()
         # Never advertises a deploy phase it isn't going to run.
         self.assertNotIn('deploying', harness.states())
 
+    async def test_deployment_without_a_run_id_settles_immediately(
+        self,
+    ) -> None:
+        """Nothing to poll is not a failure; the Deployment still exists."""
+        db = mock.AsyncMock()
+        with _Harness('success') as harness:
+            harness.complete.return_value = _deployment(run_id='')
+            state = await service.run_watch(db, _job(), sleep=harness.sleep)
+        self.assertEqual('success', state)
+        harness.poll_rollout.assert_not_awaited()
+
     async def test_polls_until_terminal(self) -> None:
         db = mock.AsyncMock()
-        with _Harness('queued', 'in_progress', 'success') as harness:
+        with _Harness(
+            'queued', 'in_progress', 'success', rollout=('success',)
+        ) as harness:
             state = await service.run_watch(db, _job(), sleep=harness.sleep)
         self.assertEqual('success', state)
         self.assertEqual(3, harness.poll.await_count)
-        # Interval backs off between polls and is capped.
-        self.assertEqual(2, len(harness.slept))
-        self.assertLessEqual(harness.slept[0], harness.slept[1])
-        self.assertLessEqual(max(harness.slept), service.POLL_MAX_SECONDS)
+        # Build intervals back off and are capped; the trailing sleep is
+        # the rollout loop's, which has its own ceiling.
+        build_sleeps = harness.slept[:2]
+        self.assertEqual(2, len(build_sleeps))
+        self.assertLessEqual(build_sleeps[0], build_sleeps[1])
+        self.assertLessEqual(max(build_sleeps), service.POLL_MAX_SECONDS)
         self.assertIn('building', harness.states())
+
+    async def test_rollout_backs_off_and_is_capped(self) -> None:
+        db = mock.AsyncMock()
+        with _Harness(
+            'success', rollout=('queued', 'in_progress', 'success')
+        ) as harness:
+            await service.run_watch(db, _job(), sleep=harness.sleep)
+        # No build sleeps (one poll, terminal), so every sleep is a
+        # rollout sleep.
+        self.assertEqual(3, len(harness.slept))
+        self.assertEqual(service.DEPLOY_POLL_INITIAL_SECONDS, harness.slept[0])
+        self.assertLessEqual(harness.slept[0], harness.slept[1])
+        self.assertLessEqual(
+            max(harness.slept), service.DEPLOY_POLL_MAX_SECONDS
+        )
+
+    async def test_failed_rollout_does_not_block_the_release(self) -> None:
+        """A green build with a red rollout leaves the tag shippable."""
+        db = mock.AsyncMock()
+        with _Harness('success', rollout=('failure',)) as harness:
+            state = await service.run_watch(db, _job(), sleep=harness.sleep)
+        self.assertEqual('deploy_failed', state)
+        # ``fail_promote_build`` is what blocks a tag — never called here.
+        harness.fail.assert_not_awaited()
+        self.assertEqual('deploy_failed', harness.states()[-1])
+        error = harness.set_status.await_args_list[-1].kwargs['error']
+        self.assertIn('staging', error)
+        self.assertIn('not blocked', error)
+
+    async def test_cancelled_rollout_does_not_block_the_release(self) -> None:
+        db = mock.AsyncMock()
+        with _Harness('success', rollout=('cancelled',)) as harness:
+            state = await service.run_watch(db, _job(), sleep=harness.sleep)
+        self.assertEqual('deploy_failed', state)
+        harness.fail.assert_not_awaited()
+
+    async def test_rollout_timeout_does_not_block_the_release(self) -> None:
+        db = mock.AsyncMock()
+        with _Harness('success', rollout=('in_progress',)) as harness:
+            state = await service.run_watch(
+                db,
+                _job(),
+                sleep=harness.sleep,
+                deploy_timeout_seconds=0,
+            )
+        self.assertEqual('deploy_failed', state)
+        harness.fail.assert_not_awaited()
+        error = harness.set_status.await_args_list[-1].kwargs['error']
+        self.assertIn('did not finish', error)
+
+    async def test_lost_rollout_reports_failed_not_deploying(self) -> None:
+        """A poll that blows up must not strand the status on ``deploying``.
+
+        The UI polls until it sees a terminal state, so leaving
+        ``deploying`` behind would spin forever against a promote nothing
+        is driving.
+        """
+        db = mock.AsyncMock()
+        with _Harness('success') as harness:
+            harness.poll_rollout.side_effect = RuntimeError('ghe exploded')
+            state = await service.run_watch(db, _job(), sleep=harness.sleep)
+        self.assertEqual('failed', state)
+        harness.fail.assert_not_awaited()
+        self.assertEqual('failed', harness.states()[-1])
+        error = harness.set_status.await_args_list[-1].kwargs['error']
+        self.assertIn('ghe exploded', error)
 
     async def test_failed_build_blocks_the_release(self) -> None:
         db = mock.AsyncMock()
@@ -190,7 +323,7 @@ class RunWatchTests(unittest.IsolatedAsyncioTestCase):
 
     async def test_run_url_from_the_poll_is_carried_forward(self) -> None:
         db = mock.AsyncMock()
-        with _Harness('success') as harness:
+        with _Harness('success', rollout=('success',)) as harness:
             harness.poll.side_effect = [
                 _run('success', run_url='https://ghe/run/late')
             ]
@@ -198,6 +331,12 @@ class RunWatchTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(
             'https://ghe/run/late',
             harness.complete.await_args.kwargs['run_url'],
+        )
+        # The rollout phase keeps pointing at the build run rather than
+        # swapping in the Deployment's own URL.
+        self.assertEqual(
+            'https://ghe/run/late',
+            harness.set_status.await_args_list[-1].kwargs['artifact_run_url'],
         )
 
 

--- a/apps/gateway/src/imbi/gateway/actions.py
+++ b/apps/gateway/src/imbi/gateway/actions.py
@@ -184,6 +184,55 @@ class ImbiClient(httpx.AsyncClient):
             return []
         return typing.cast('list[dict[str, object]]', response.json())
 
+    async def publish_release(
+        self, org_slug: str, project_id: str, tag: str, prerelease: bool
+    ) -> httpx.Response:
+        """Ratify an Imbi ``Release`` by creating it on the remote.
+
+        Title and notes come from the ``Release`` node, so the gateway
+        sends nothing but the prerelease flag. A 404 means Imbi has no
+        ``Release`` for the tag (nothing to ratify) and a 409 means the
+        release is blocked; both are expected outcomes rather than
+        errors, so they are logged at debug by the caller.
+        """
+        url = (
+            f'/organizations/{org_slug}/projects/{project_id}'
+            f'/deployments/releases/{tag}/publish'
+        )
+        LOGGER.debug('Publishing release %s', url)
+        response = await self.post(url, json={'prerelease': prerelease})
+        if response.is_error and response.status_code not in (
+            http.HTTPStatus.NOT_FOUND,
+            http.HTTPStatus.CONFLICT,
+        ):
+            LOGGER.warning(
+                'Failed to publish release %r: %s', url, response.text
+            )
+        return response
+
+    async def block_release(
+        self, org_slug: str, project_id: str, tag: str, reason: str
+    ) -> httpx.Response:
+        """Block a tag from shipping again, with a reason.
+
+        A 404 means the tag has no ``Release`` node and has never been
+        synced, so there is nothing to block; the caller logs it rather
+        than treating it as a failure.
+        """
+        url = (
+            f'/organizations/{org_slug}/projects/{project_id}'
+            f'/deployments/releases/{tag}/block'
+        )
+        LOGGER.debug('Blocking release %s', url)
+        response = await self.post(url, json={'reason': reason})
+        if response.is_error and (
+            response.status_code != http.HTTPStatus.NOT_FOUND
+        ):
+            LOGGER.warning(
+                'Failed to block release %r: %s', url, response.text
+            )
+        return response
+
     async def put_sbom(
         self,
         org_slug: str,
@@ -217,9 +266,16 @@ class CreateReleaseConfig(pydantic.BaseModel):
     ``version_expression``) is optional; when absent or evaluated to
     null, the release is still created and identified by its
     committish.
+
+    ``title_selector`` is optional and falls back to
+    ``"Release <version>"`` (the tag, or the committish when no tag
+    resolves). It is also *skipped* when the pointer resolves to null:
+    an Imbi-created GitHub Deployment carries no ``description``, so
+    a config pointing at ``/payload/deployment/description`` would
+    otherwise title the release the literal string ``"None"``.
     """
 
-    title_selector: json_pointer.JsonPointer
+    title_selector: json_pointer.JsonPointer | None = None
     committish_expression: str
     version_expression: str | None = None
 
@@ -240,6 +296,44 @@ class AddDeploymentEventConfig(pydantic.BaseModel):
     version_expression: str | None = None
     note_selector: json_pointer.JsonPointer | None = None
     external_run_id_selector: json_pointer.JsonPointer | None = None
+
+
+class PublishReleaseConfig(pydantic.BaseModel):
+    """Validates ``handler_config`` for :func:`publish_release`.
+
+    ``version_expression`` is a CEL expression resolving the tag of the
+    ``Release`` to ratify (typically ``payload.deployment.ref``).
+    ``status_selector`` points at the raw deployment state; the action
+    fires only for states that map to ``success`` (see
+    :data:`_STATUS_MAP`) so the rule's ``filter_expression`` cannot
+    accidentally ratify a failed rollout.
+
+    All JSON-Pointer selectors resolve against the event context, so the
+    webhook body lives under ``/payload``; CEL expressions read
+    ``payload.<field>``.
+    """
+
+    version_expression: str
+    status_selector: json_pointer.JsonPointer
+    prerelease: bool = False
+
+
+class BlockReleaseConfig(pydantic.BaseModel):
+    """Validates ``handler_config`` for :func:`block_release`.
+
+    The mirror of :class:`PublishReleaseConfig`: the action fires only
+    for states that map to ``failed`` -- GitHub's ``failure`` and
+    ``error``. ``inactive`` deliberately does *not* block: it maps to
+    ``rolled_back`` and means the deployment was superseded by a newer
+    one, which is the normal end of every deployment's life.
+
+    ``reason_selector`` is an optional JSON pointer at the block reason;
+    it defaults to a short description of the reported state.
+    """
+
+    version_expression: str
+    status_selector: json_pointer.JsonPointer
+    reason_selector: json_pointer.JsonPointer | None = None
 
 
 class IngestSbomConfig(pydantic.BaseModel):
@@ -336,6 +430,25 @@ def _cel_substring(
 _CEL_FUNCTIONS: dict[str, celpy.CELFunction] = {'substring': _cel_substring}
 
 
+def _deployment_state(
+    selector: json_pointer.JsonPointer, event: object
+) -> tuple[str, str | None]:
+    """Resolve ``(raw_state, imbi_status)`` from a deployment event.
+
+    ``imbi_status`` is ``None`` -- and the caller must skip -- when the
+    producer reported a state :data:`_STATUS_MAP` does not cover. Every
+    action that keys off a deployment state goes through here so the
+    vocabulary is enumerated in exactly one place: a rule written as
+    ``state != "success"`` would sweep in ``inactive`` (a deployment
+    superseded by a newer one), which must never count as a failure.
+    """
+    raw_state = str(selector.resolve(event))
+    status = _STATUS_MAP.get(raw_state)
+    if status is None:
+        LOGGER.warning('Unmapped deployment status %r — skipping', raw_state)
+    return raw_state, status
+
+
 def _evaluate_cel(expression: str, event: object) -> str | None:
     env = celpy.Environment()
     program = env.program(env.compile(expression), functions=_CEL_FUNCTIONS)
@@ -394,10 +507,11 @@ async def create_release(
     ``version_expression`` (optional); when omitted or evaluated to null
     the tag is left off the release. The title is taken from the
     JSONPointer ``title_selector`` (resolved against the event, so the
-    body is under ``/payload``). ``ctx.actor_user_id`` (the resolved
-    Imbi user's email) is passed as ``created_by`` when present;
-    otherwise the API defaults to the gateway's service principal.
-    ``action_config`` arrives pre-validated.
+    body is under ``/payload``), falling back to ``Release <version>``
+    when the selector is unset or does not resolve to a value.
+    ``ctx.actor_user_id`` (the resolved Imbi user's email) is passed as
+    ``created_by`` when present; otherwise the API defaults to the
+    gateway's service principal. ``action_config`` arrives pre-validated.
     """
     del credentials, external_identifier
     committish_value = _evaluate_cel(
@@ -410,15 +524,19 @@ async def create_release(
             ctx.project_id,
         )
         return
-    create_body: dict[str, object] = {
-        'committish': committish_value,
-        'title': str(action_config.title_selector.resolve(event)),
-    }
     version_value: str | None = None
     if action_config.version_expression is not None:
         version_value = _evaluate_cel(action_config.version_expression, event)
-        if version_value is not None:
-            create_body['tag'] = version_value
+    create_body: dict[str, object] = {
+        'committish': committish_value,
+        'title': _resolve_title(
+            action_config.title_selector,
+            event,
+            version_value or committish_value,
+        ),
+    }
+    if version_value is not None:
+        create_body['tag'] = version_value
     if ctx.actor_user_id is not None:
         create_body['created_by'] = ctx.actor_user_id
     async with ImbiClient() as client:
@@ -453,10 +571,8 @@ async def add_deployment_event(
     and CEL expressions read ``payload.<field>``.
     """
     del credentials, external_identifier
-    raw_state = str(action_config.status_selector.resolve(event))
-    status = _STATUS_MAP.get(raw_state)
+    _raw, status = _deployment_state(action_config.status_selector, event)
     if status is None:
-        LOGGER.warning('Unmapped deployment status %r — skipping', raw_state)
         return
     committish_value = _evaluate_cel(
         action_config.committish_expression, event
@@ -507,6 +623,133 @@ async def add_deployment_event(
             ctx.project_id,
             status,
         )
+
+
+async def publish_release(
+    *,
+    ctx: plugin_base.PluginContext,
+    credentials: dict[str, str],
+    external_identifier: str,
+    action_config: PublishReleaseConfig,
+    event: object,
+) -> None:
+    """Ratify a Release when a deployment reports success.
+
+    Imbi's ``promote`` cuts the tag and records the ``Release`` node --
+    the intent to ship. This publishes the GitHub Release for it, which
+    only makes sense once the rollout actually succeeded, so the action
+    is a no-op for every state that does not map to ``success``.
+
+    Missing releases (404) and blocked ones (409) are expected: a
+    deployment can succeed for a tag Imbi never cut, and a release
+    blocked between the deploy and its status webhook must stay
+    unratified. Neither is treated as a failure.
+    """
+    del credentials, external_identifier
+    raw_state, status = _deployment_state(action_config.status_selector, event)
+    if status != 'success':
+        LOGGER.debug(
+            'Deployment state %r is not a success for project %s;'
+            ' not publishing',
+            raw_state,
+            ctx.project_id,
+        )
+        return
+    tag_value = _evaluate_cel(action_config.version_expression, event)
+    if tag_value is None:
+        LOGGER.warning(
+            'Skipping release publish for project %s: version expression'
+            ' evaluated to null',
+            ctx.project_id,
+        )
+        return
+    async with ImbiClient() as client:
+        response = await client.publish_release(
+            ctx.org_slug, ctx.project_id, tag_value, action_config.prerelease
+        )
+    if response.status_code in (
+        http.HTTPStatus.NOT_FOUND,
+        http.HTTPStatus.CONFLICT,
+    ):
+        LOGGER.info(
+            'Release %r for project %s was not published (HTTP %s): %s',
+            tag_value,
+            ctx.project_id,
+            response.status_code,
+            response.text,
+        )
+
+
+async def block_release(
+    *,
+    ctx: plugin_base.PluginContext,
+    credentials: dict[str, str],
+    external_identifier: str,
+    action_config: BlockReleaseConfig,
+    event: object,
+) -> None:
+    """Block a Release when its deployment reports failure.
+
+    The counterpart to :func:`publish_release`: a rollout that fails
+    leaves the tag blocked so nobody re-deploys or re-promotes it while
+    the fix is in flight. Only the states mapping to ``failed``
+    (GitHub's ``failure`` and ``error``) block -- ``inactive`` maps to
+    ``rolled_back``, meaning the deployment was superseded by a newer
+    one, and must not.
+    """
+    del credentials, external_identifier
+    raw_state, status = _deployment_state(action_config.status_selector, event)
+    if status != 'failed':
+        LOGGER.debug(
+            'Deployment state %r is not a failure for project %s;'
+            ' not blocking',
+            raw_state,
+            ctx.project_id,
+        )
+        return
+    tag_value = _evaluate_cel(action_config.version_expression, event)
+    if tag_value is None:
+        LOGGER.warning(
+            'Skipping release block for project %s: version expression'
+            ' evaluated to null',
+            ctx.project_id,
+        )
+        return
+    reason = _resolve_block_reason(
+        action_config.reason_selector, event, raw_state
+    )
+    async with ImbiClient() as client:
+        response = await client.block_release(
+            ctx.org_slug, ctx.project_id, tag_value, reason
+        )
+    if response.status_code == http.HTTPStatus.NOT_FOUND:
+        LOGGER.warning(
+            'No release for tag %r on project %s; block dropped',
+            tag_value,
+            ctx.project_id,
+        )
+
+
+def _resolve_block_reason(
+    selector: json_pointer.JsonPointer | None, event: object, raw_state: str
+) -> str:
+    """Resolve the block reason, defaulting to the reported state.
+
+    The Imbi API requires a non-empty reason of at most 500 characters,
+    so a selector that resolves to null, an empty string, or something
+    longer falls back / is truncated here rather than 422ing the
+    webhook.
+    """
+    resolved: object = None
+    if selector is not None:
+        try:
+            resolved = selector.resolve(event)
+        except jsonpointer.JsonPointerException:
+            resolved = None
+    reason = str(resolved).strip() if resolved is not None else ''
+    if not reason:
+        reason = f'Deployment reported {raw_state}'
+    return reason[:500]
 
 
 async def ingest_sbom(
@@ -712,9 +955,17 @@ def _resolve_committish(expression: str, event: object) -> str | None:
 
 
 def _resolve_title(
-    selector: json_pointer.JsonPointer | None, event: object, tag_value: str
+    selector: json_pointer.JsonPointer | None, event: object, identity: str
 ) -> str:
-    """Resolve the optional title selector with a sensible default."""
+    """Resolve the optional title selector with a sensible default.
+
+    ``identity`` is the release's human identity -- its tag, or the
+    committish when there is no tag -- used to build the
+    ``Release <identity>`` fallback. The default applies when no
+    selector is configured, when the pointer does not resolve, *and*
+    when it resolves to JSON null: stringifying a null would title the
+    release ``"None"``.
+    """
     if selector is not None:
         try:
             resolved = selector.resolve(event)
@@ -722,4 +973,4 @@ def _resolve_title(
             resolved = None
         if resolved is not None:
             return str(resolved)
-    return f'Release {tag_value}'
+    return f'Release {identity}'

--- a/apps/gateway/src/imbi/gateway/notifications.py
+++ b/apps/gateway/src/imbi/gateway/notifications.py
@@ -246,6 +246,14 @@ async def process_notification(  # noqa: PLR0911, PLR0915 - linear webhook pipel
             extra={'webhook_id': webhook_id, 'rules_count': len(parsed_rules)},
         )
         return
+    # Dispatch order is load-bearing, not cosmetic: ``add_deployment_event``
+    # looks its release up and drops the event when it is missing, so it
+    # has to run after ``create_release``; ``publish_release`` has to run
+    # after both. The query orders by ``ordinal`` before collecting, but
+    # that leans on AGE preserving row order through ``collect()`` -- sort
+    # here so the guarantee is the dispatcher's own rather than the
+    # storage engine's.
+    rules.sort(key=lambda rule: rule.ordinal)
 
     LOGGER.debug('webhook: %r', webhook)
     LOGGER.debug('org: %r', org)

--- a/apps/gateway/src/imbi/gateway/plugin.py
+++ b/apps/gateway/src/imbi/gateway/plugin.py
@@ -1,7 +1,8 @@
 """Built-in webhook-action plugin shipped with imbi-gateway.
 
 Wraps the bundled actions (``update_project``, ``create_release``,
-``add_deployment_event``, ``ingest_sbom``) as a
+``add_deployment_event``, ``publish_release``, ``block_release``,
+``ingest_sbom``) as a
 :class:`~imbi.common.plugins.base.WebhookActionsCapability` on a single
 :class:`~imbi.common.plugins.base.Plugin` (slug ``gateway-actions``) so
 they participate in the same discovery, validation, and dispatch flow as
@@ -79,6 +80,27 @@ class GatewayWebhookActions(plugin_base.WebhookActionsCapability):
                 model_path='imbi.gateway.actions:AddDeploymentEventConfig',
             ),
             _descriptor(
+                name='publish_release',
+                label='Publish Release on Successful Deployment',
+                description=(
+                    'Ratifies the matched Imbi Release by creating the '
+                    'remote release for its tag, once a deployment '
+                    'reports success.'
+                ),
+                callable_path='imbi.gateway.actions:publish_release',
+                model_path='imbi.gateway.actions:PublishReleaseConfig',
+            ),
+            _descriptor(
+                name='block_release',
+                label='Block Release on Failed Deployment',
+                description=(
+                    'Blocks the matched Imbi Release from shipping again '
+                    'when a deployment reports failure or error.'
+                ),
+                callable_path='imbi.gateway.actions:block_release',
+                model_path='imbi.gateway.actions:BlockReleaseConfig',
+            ),
+            _descriptor(
                 name='ingest_sbom',
                 label='Ingest CycloneDX SBoM for Release',
                 description=(
@@ -99,8 +121,9 @@ class GatewayActionsPlugin(plugin_base.Plugin):
         name='Gateway Actions',
         description=(
             'Webhook actions shipped with imbi-gateway: update project '
-            'facts, create a release, append a deployment event, and '
-            'ingest CycloneDX SBoMs.'
+            'facts, create a release, append a deployment event, publish '
+            'or block a release on the deployment outcome, and ingest '
+            'CycloneDX SBoMs.'
         ),
         auth_type='none',
         credentials=[],

--- a/apps/gateway/tests/test_actions.py
+++ b/apps/gateway/tests/test_actions.py
@@ -650,6 +650,97 @@ class CreateReleaseTests(helpers.TestCase):
                 event=_event(_DEPLOYMENT_BODY),
             )
 
+    async def test_null_title_selector_falls_back_to_the_version(self) -> None:
+        # An Imbi-created GitHub Deployment carries no ``description``;
+        # stringifying that null used to title the release "None".
+        config = _create_release_config(
+            '{"title_selector": "/payload/deployment/description",'
+            ' "version_expression": "payload.deployment.ref",'
+            ' "committish_expression": "substring(payload.deployment.sha,'
+            ' 0, 7)"}'
+        )
+        with (
+            self.override_environment(ACTIONS_IMBI_TOKEN=_TOKEN),
+            unittest.mock.patch.object(
+                actions.ImbiClient,
+                'create_release',
+                new_callable=unittest.mock.AsyncMock,
+                return_value=httpx.Response(201),
+            ) as mock_create,
+        ):
+            await actions.create_release(
+                ctx=_ctx(),
+                credentials={},
+                external_identifier='',
+                action_config=config,
+                event=_event(
+                    {
+                        'deployment': {
+                            'ref': 'v1.2.3',
+                            'sha': 'abcdef1234567890',
+                            'description': None,
+                        }
+                    }
+                ),
+            )
+
+        self.assertEqual(
+            'Release v1.2.3', mock_create.call_args.args[2]['title']
+        )
+
+    async def test_title_selector_is_optional(self) -> None:
+        config = _create_release_config(
+            '{"version_expression": "payload.deployment.ref",'
+            ' "committish_expression": "substring(payload.deployment.sha,'
+            ' 0, 7)"}'
+        )
+        with (
+            self.override_environment(ACTIONS_IMBI_TOKEN=_TOKEN),
+            unittest.mock.patch.object(
+                actions.ImbiClient,
+                'create_release',
+                new_callable=unittest.mock.AsyncMock,
+                return_value=httpx.Response(201),
+            ) as mock_create,
+        ):
+            await actions.create_release(
+                ctx=_ctx(),
+                credentials={},
+                external_identifier='',
+                action_config=config,
+                event=_event(_DEPLOYMENT_BODY),
+            )
+
+        self.assertEqual(
+            'Release v1.2.3', mock_create.call_args.args[2]['title']
+        )
+
+    async def test_title_falls_back_to_committish_without_a_tag(self) -> None:
+        config = _create_release_config(
+            '{"committish_expression": "substring(payload.deployment.sha,'
+            ' 0, 7)"}'
+        )
+        with (
+            self.override_environment(ACTIONS_IMBI_TOKEN=_TOKEN),
+            unittest.mock.patch.object(
+                actions.ImbiClient,
+                'create_release',
+                new_callable=unittest.mock.AsyncMock,
+                return_value=httpx.Response(201),
+            ) as mock_create,
+        ):
+            await actions.create_release(
+                ctx=_ctx(),
+                credentials={},
+                external_identifier='',
+                action_config=config,
+                event=_event(_DEPLOYMENT_BODY),
+            )
+
+        self.assertEqual(
+            'Release abcdef1', mock_create.call_args.args[2]['title']
+        )
+
     async def test_409_is_treated_as_idempotent(self) -> None:
         with (
             self.override_environment(ACTIONS_IMBI_TOKEN=_TOKEN),
@@ -993,6 +1084,399 @@ class AddDeploymentEventTests(helpers.TestCase):
 
         self.assertTrue(
             any('Release' in line and 'missing' in line for line in cm.output)
+        )
+
+
+def _status_body(state: str) -> dict[str, object]:
+    """A ``deployment_status`` body reporting ``state``."""
+    return {
+        'deployment': {'ref': 'v1.2.3', 'sha': 'abcdef1234567890'},
+        'deployment_status': {'state': state, 'environment': 'production'},
+    }
+
+
+_PUBLISH_CONFIG = (
+    '{"version_expression": "payload.deployment.ref",'
+    ' "status_selector": "/payload/deployment_status/state"}'
+)
+
+
+class PublishReleaseTests(helpers.TestCase):
+    def _config(self, raw: str = _PUBLISH_CONFIG) -> typing.Any:
+        return actions.PublishReleaseConfig.model_validate_json(raw)
+
+    def _patch(self, response: httpx.Response) -> typing.Any:
+        return unittest.mock.patch.object(
+            actions.ImbiClient,
+            'publish_release',
+            new_callable=unittest.mock.AsyncMock,
+            return_value=response,
+        )
+
+    async def test_success_publishes_the_tag(self) -> None:
+        with (
+            self.override_environment(ACTIONS_IMBI_TOKEN=_TOKEN),
+            self._patch(httpx.Response(200, json={'published': True})) as pub,
+        ):
+            await actions.publish_release(
+                ctx=_ctx(),
+                credentials={},
+                external_identifier='',
+                action_config=self._config(),
+                event=_event(_status_body('success')),
+            )
+
+        pub.assert_called_once_with('org', 'proj', 'v1.2.3', False)
+
+    async def test_prerelease_flag_is_forwarded(self) -> None:
+        config = self._config(
+            '{"version_expression": "payload.deployment.ref",'
+            ' "status_selector": "/payload/deployment_status/state",'
+            ' "prerelease": true}'
+        )
+        with (
+            self.override_environment(ACTIONS_IMBI_TOKEN=_TOKEN),
+            self._patch(httpx.Response(200)) as pub,
+        ):
+            await actions.publish_release(
+                ctx=_ctx(),
+                credentials={},
+                external_identifier='',
+                action_config=config,
+                event=_event(_status_body('success')),
+            )
+
+        pub.assert_called_once_with('org', 'proj', 'v1.2.3', True)
+
+    async def test_non_success_states_do_not_publish(self) -> None:
+        for state in ('failure', 'error', 'inactive', 'pending', 'queued'):
+            with self.subTest(state=state):
+                with (
+                    self.override_environment(ACTIONS_IMBI_TOKEN=_TOKEN),
+                    self._patch(httpx.Response(200)) as pub,
+                ):
+                    await actions.publish_release(
+                        ctx=_ctx(),
+                        credentials={},
+                        external_identifier='',
+                        action_config=self._config(),
+                        event=_event(_status_body(state)),
+                    )
+                pub.assert_not_called()
+
+    async def test_unmapped_state_does_not_publish(self) -> None:
+        with (
+            self.override_environment(ACTIONS_IMBI_TOKEN=_TOKEN),
+            self._patch(httpx.Response(200)) as pub,
+            self.assertLogs('imbi.gateway.actions', level='WARNING') as cm,
+        ):
+            await actions.publish_release(
+                ctx=_ctx(),
+                credentials={},
+                external_identifier='',
+                action_config=self._config(),
+                event=_event(_status_body('frobbed')),
+            )
+
+        pub.assert_not_called()
+        self.assertTrue(any('Unmapped' in line for line in cm.output))
+
+    async def test_null_version_is_skipped(self) -> None:
+        config = self._config(
+            '{"version_expression": "payload.deployment.tag",'
+            ' "status_selector": "/payload/deployment_status/state"}'
+        )
+        body = _status_body('success')
+        typing.cast('dict[str, object]', body['deployment'])['tag'] = None
+        with (
+            self.override_environment(ACTIONS_IMBI_TOKEN=_TOKEN),
+            self._patch(httpx.Response(200)) as pub,
+            self.assertLogs('imbi.gateway.actions', level='WARNING') as cm,
+        ):
+            await actions.publish_release(
+                ctx=_ctx(),
+                credentials={},
+                external_identifier='',
+                action_config=config,
+                event=_event(body),
+            )
+
+        pub.assert_not_called()
+        self.assertTrue(any('evaluated to null' in line for line in cm.output))
+
+    async def test_404_and_409_are_not_failures(self) -> None:
+        for status in (404, 409):
+            with self.subTest(status=status):
+                with (
+                    self.override_environment(ACTIONS_IMBI_TOKEN=_TOKEN),
+                    self._patch(httpx.Response(status, json={'detail': 'no'})),
+                    self.assertLogs('imbi.gateway.actions', 'INFO') as cm,
+                ):
+                    await actions.publish_release(
+                        ctx=_ctx(),
+                        credentials={},
+                        external_identifier='',
+                        action_config=self._config(),
+                        event=_event(_status_body('success')),
+                    )
+                self.assertTrue(
+                    any('was not published' in line for line in cm.output)
+                )
+
+
+_BLOCK_CONFIG = (
+    '{"version_expression": "payload.deployment.ref",'
+    ' "status_selector": "/payload/deployment_status/state"}'
+)
+
+
+class BlockReleaseTests(helpers.TestCase):
+    def _config(self, raw: str = _BLOCK_CONFIG) -> typing.Any:
+        return actions.BlockReleaseConfig.model_validate_json(raw)
+
+    def _patch(self, response: httpx.Response) -> typing.Any:
+        return unittest.mock.patch.object(
+            actions.ImbiClient,
+            'block_release',
+            new_callable=unittest.mock.AsyncMock,
+            return_value=response,
+        )
+
+    async def test_failure_states_block_with_a_default_reason(self) -> None:
+        for state in ('failure', 'error'):
+            with self.subTest(state=state):
+                with (
+                    self.override_environment(ACTIONS_IMBI_TOKEN=_TOKEN),
+                    self._patch(httpx.Response(200)) as block,
+                ):
+                    await actions.block_release(
+                        ctx=_ctx(),
+                        credentials={},
+                        external_identifier='',
+                        action_config=self._config(),
+                        event=_event(_status_body(state)),
+                    )
+                block.assert_called_once_with(
+                    'org', 'proj', 'v1.2.3', f'Deployment reported {state}'
+                )
+
+    async def test_inactive_does_not_block(self) -> None:
+        # ``inactive`` maps to ``rolled_back``: the deployment was
+        # superseded by a newer one, which is the normal end of every
+        # deployment's life and must never block the tag.
+        with (
+            self.override_environment(ACTIONS_IMBI_TOKEN=_TOKEN),
+            self._patch(httpx.Response(200)) as block,
+        ):
+            await actions.block_release(
+                ctx=_ctx(),
+                credentials={},
+                external_identifier='',
+                action_config=self._config(),
+                event=_event(_status_body('inactive')),
+            )
+
+        block.assert_not_called()
+
+    async def test_success_and_pending_do_not_block(self) -> None:
+        for state in ('success', 'pending', 'queued', 'in_progress'):
+            with self.subTest(state=state):
+                with (
+                    self.override_environment(ACTIONS_IMBI_TOKEN=_TOKEN),
+                    self._patch(httpx.Response(200)) as block,
+                ):
+                    await actions.block_release(
+                        ctx=_ctx(),
+                        credentials={},
+                        external_identifier='',
+                        action_config=self._config(),
+                        event=_event(_status_body(state)),
+                    )
+                block.assert_not_called()
+
+    async def test_reason_selector_is_used(self) -> None:
+        config = self._config(
+            '{"version_expression": "payload.deployment.ref",'
+            ' "status_selector": "/payload/deployment_status/state",'
+            ' "reason_selector": "/payload/deployment_status/description"}'
+        )
+        body = _status_body('failure')
+        status = typing.cast('dict[str, object]', body['deployment_status'])
+        status['description'] = 'Migration 0042 failed'
+        with (
+            self.override_environment(ACTIONS_IMBI_TOKEN=_TOKEN),
+            self._patch(httpx.Response(200)) as block,
+        ):
+            await actions.block_release(
+                ctx=_ctx(),
+                credentials={},
+                external_identifier='',
+                action_config=config,
+                event=_event(body),
+            )
+
+        block.assert_called_once_with(
+            'org', 'proj', 'v1.2.3', 'Migration 0042 failed'
+        )
+
+    async def test_null_reason_falls_back_to_the_state(self) -> None:
+        config = self._config(
+            '{"version_expression": "payload.deployment.ref",'
+            ' "status_selector": "/payload/deployment_status/state",'
+            ' "reason_selector": "/payload/deployment_status/description"}'
+        )
+        body = _status_body('failure')
+        status = typing.cast('dict[str, object]', body['deployment_status'])
+        status['description'] = None
+        with (
+            self.override_environment(ACTIONS_IMBI_TOKEN=_TOKEN),
+            self._patch(httpx.Response(200)) as block,
+        ):
+            await actions.block_release(
+                ctx=_ctx(),
+                credentials={},
+                external_identifier='',
+                action_config=config,
+                event=_event(body),
+            )
+
+        block.assert_called_once_with(
+            'org', 'proj', 'v1.2.3', 'Deployment reported failure'
+        )
+
+    async def test_overlong_reason_is_truncated(self) -> None:
+        config = self._config(
+            '{"version_expression": "payload.deployment.ref",'
+            ' "status_selector": "/payload/deployment_status/state",'
+            ' "reason_selector": "/payload/deployment_status/description"}'
+        )
+        body = _status_body('failure')
+        status = typing.cast('dict[str, object]', body['deployment_status'])
+        status['description'] = 'x' * 600
+        with (
+            self.override_environment(ACTIONS_IMBI_TOKEN=_TOKEN),
+            self._patch(httpx.Response(200)) as block,
+        ):
+            await actions.block_release(
+                ctx=_ctx(),
+                credentials={},
+                external_identifier='',
+                action_config=config,
+                event=_event(body),
+            )
+
+        self.assertEqual(500, len(block.call_args.args[3]))
+
+    async def test_missing_release_logs_a_warning(self) -> None:
+        with (
+            self.override_environment(ACTIONS_IMBI_TOKEN=_TOKEN),
+            self._patch(httpx.Response(404, json={'detail': 'missing'})),
+            self.assertLogs('imbi.gateway.actions', level='WARNING') as cm,
+        ):
+            await actions.block_release(
+                ctx=_ctx(),
+                credentials={},
+                external_identifier='',
+                action_config=self._config(),
+                event=_event(_status_body('failure')),
+            )
+
+        self.assertTrue(any('block dropped' in line for line in cm.output))
+
+
+class ImbiClientPublishReleaseTests(helpers.TestCase):
+    async def test_url_body_and_error_logging(self) -> None:
+        with (
+            self.override_environment(ACTIONS_IMBI_TOKEN=_TOKEN),
+            unittest.mock.patch.object(
+                actions.ImbiClient,
+                'post',
+                new_callable=unittest.mock.AsyncMock,
+                return_value=httpx.Response(200),
+            ) as mock_post,
+        ):
+            async with actions.ImbiClient() as client:
+                await client.publish_release('org', 'proj', 'v1.2.3', True)
+
+        mock_post.assert_called_once_with(
+            '/organizations/org/projects/proj/deployments/releases'
+            '/v1.2.3/publish',
+            json={'prerelease': True},
+        )
+
+    async def test_server_error_logs_warning(self) -> None:
+        with (
+            self.override_environment(ACTIONS_IMBI_TOKEN=_TOKEN),
+            unittest.mock.patch.object(
+                actions.ImbiClient,
+                'post',
+                new_callable=unittest.mock.AsyncMock,
+                return_value=httpx.Response(500, text='boom'),
+            ),
+            self.assertLogs('imbi.gateway.actions', level='WARNING') as cm,
+        ):
+            async with actions.ImbiClient() as client:
+                await client.publish_release('org', 'proj', 'v1.2.3', False)
+
+        self.assertTrue(
+            any('Failed to publish release' in line for line in cm.output)
+        )
+
+    async def test_404_and_409_do_not_log_warning(self) -> None:
+        for status in (404, 409):
+            with self.subTest(status=status):
+                with (
+                    self.override_environment(ACTIONS_IMBI_TOKEN=_TOKEN),
+                    unittest.mock.patch.object(
+                        actions.ImbiClient,
+                        'post',
+                        new_callable=unittest.mock.AsyncMock,
+                        return_value=httpx.Response(status),
+                    ),
+                    self.assertNoLogs('imbi.gateway.actions', 'WARNING'),
+                ):
+                    async with actions.ImbiClient() as client:
+                        await client.publish_release(
+                            'org', 'proj', 'v1.2.3', False
+                        )
+
+
+class ImbiClientBlockReleaseTests(helpers.TestCase):
+    async def test_url_and_body(self) -> None:
+        with (
+            self.override_environment(ACTIONS_IMBI_TOKEN=_TOKEN),
+            unittest.mock.patch.object(
+                actions.ImbiClient,
+                'post',
+                new_callable=unittest.mock.AsyncMock,
+                return_value=httpx.Response(200),
+            ) as mock_post,
+        ):
+            async with actions.ImbiClient() as client:
+                await client.block_release('org', 'proj', 'v1.2.3', 'nope')
+
+        mock_post.assert_called_once_with(
+            '/organizations/org/projects/proj/deployments/releases'
+            '/v1.2.3/block',
+            json={'reason': 'nope'},
+        )
+
+    async def test_server_error_logs_warning(self) -> None:
+        with (
+            self.override_environment(ACTIONS_IMBI_TOKEN=_TOKEN),
+            unittest.mock.patch.object(
+                actions.ImbiClient,
+                'post',
+                new_callable=unittest.mock.AsyncMock,
+                return_value=httpx.Response(500, text='boom'),
+            ),
+            self.assertLogs('imbi.gateway.actions', level='WARNING') as cm,
+        ):
+            async with actions.ImbiClient() as client:
+                await client.block_release('org', 'proj', 'v1.2.3', 'nope')
+
+        self.assertTrue(
+            any('Failed to block release' in line for line in cm.output)
         )
 
 

--- a/apps/gateway/tests/test_notifications.py
+++ b/apps/gateway/tests/test_notifications.py
@@ -861,6 +861,27 @@ class ProcessNotificationTests(helpers.TestCase):
         }
         self.assertEqual({self.proj_id, second_proj_id}, project_ids)
 
+    async def test_handlers_run_in_ordinal_order(self) -> None:
+        # Ordering is load-bearing: ``add_deployment_event`` drops its
+        # event when the release is missing, so it has to run after
+        # ``create_release``, and ``publish_release`` after both.  The
+        # rules are created out of order so a pass can't come for free
+        # from insertion order.
+        for ordinal in (3, 1, 2):
+            await self._add_rule(
+                handler_config=json.dumps({'label': f'rule-{ordinal}'}),
+                ordinal=ordinal,
+            )
+        response = await self._post(
+            self.webhook_id, {'repo': {'id': self.ext_id}}
+        )
+        self.assertEqual(202, response.status_code)
+        labels = [
+            typing.cast('StubActionConfig', call['action_config']).label
+            for call in ACTION_CALLS
+        ]
+        self.assertEqual(['rule-1', 'rule-2', 'rule-3'], labels)
+
     async def test_project_not_found_for_external_id(self) -> None:
         await self._add_rule(filter_expression='true')
         body = {'repo': {'id': 'no-such-external-id'}}

--- a/docs/common/plugins/commit-sync.md
+++ b/docs/common/plugins/commit-sync.md
@@ -50,6 +50,15 @@ class GitHubCommitSync(CommitSyncCapability):
   Re-running is safe: the ClickHouse `commits` / `tags` tables are
   `ReplacingMergeTree` and dedupe against rows the webhook already
   recorded.
+- **`sync_tag`** *(optional, default raises `NotImplementedError`)* —
+  record the single tag named `tag`. Returns rows written (0 or 1). The
+  host calls this when it already knows which tag appeared — completing a
+  promote whose release build created it, where an API-created tag fires
+  no `push` delivery — so cost should be flat in the repo's age rather
+  than growing with it. Return `0` rather than raising when the tag does
+  not exist on the remote: a build that failed before tagging is an
+  expected outcome. A plugin that does not implement it falls back to a
+  queued `sync_all_history`.
 - **`check_available`** *(optional, default `True`)* — whether an
   on-demand sync can run for `ctx` right now. Override to report `False`
   when the remote / repository cannot be resolved so the host can hide

--- a/docs/gateway/webhook-filter-expressions.md
+++ b/docs/gateway/webhook-filter-expressions.md
@@ -54,6 +54,25 @@ identical to a rule's `filter_expression`. For example, a body field is
 `payload.deployment.sha` in both a filter and a `committish_expression`, and a
 selector reads `/payload/deployment/ref`.
 
+## Rule ordering
+
+Matching rules run in ascending `ordinal` order, and for the release actions
+that order is load-bearing rather than cosmetic:
+
+1. `create_release` — creates the Imbi `Release` the rest key off.
+2. `add_deployment_event` — looks the release up and **drops the event** when
+   it is missing, so it must run after `create_release`.
+3. `publish_release` / `block_release` — ratify or block that release once the
+   deployment reports its outcome.
+
+Rules that key off a deployment state should enumerate the states they act on
+rather than negating one. `state != "success"` sweeps in `inactive`, which
+means the deployment was superseded by a newer one — the normal end of every
+deployment's life, not a failure. The `publish_release` and `block_release`
+actions enforce this themselves (they fire only on states mapping to `success`
+and `failed` respectively), so a filter can be as broad as
+`type == "deployment_status"`.
+
 ## Redacted headers
 
 Headers that may carry credentials or webhook signatures are replaced with

--- a/ui/src/api/endpoints.ts
+++ b/ui/src/api/endpoints.ts
@@ -2370,6 +2370,46 @@ export const getProjectDeploymentSyncStatus = (
     signal,
   )
 
+// Dispatch-driven promote
+
+// `building` — the Release workflow is running; it creates the tag and
+// the remote Release. `deploying` — the build was green and Imbi has
+// created the Deployment. `build_failed` — the build failed or timed
+// out, and the release is blocked. `failed` — the build outcome is
+// unknown, or Imbi could not finish the promote; the tag is still
+// shippable.
+export type PromoteState =
+  | 'build_failed'
+  | 'building'
+  | 'deploying'
+  | 'failed'
+  | 'idle'
+  | 'success'
+
+export interface PromoteStatus {
+  artifact_run_id: null | string
+  artifact_run_url: null | string
+  committish: null | string
+  environment: null | string
+  error: null | string
+  from_environment: null | string
+  requested_by: null | string
+  status: PromoteState
+  tag: null | string
+  updated_at: null | string
+}
+
+export const getPromoteStatus = (
+  orgSlug: string,
+  projectId: string,
+  signal?: AbortSignal,
+): Promise<PromoteStatus> =>
+  apiClient.get<PromoteStatus>(
+    `${deploymentsBase(orgSlug, projectId)}/promote-status`,
+    undefined,
+    signal,
+  )
+
 // Lifecycle push-sync
 
 export interface LifecycleSyncError {

--- a/ui/src/api/endpoints.ts
+++ b/ui/src/api/endpoints.ts
@@ -2373,14 +2373,17 @@ export const getProjectDeploymentSyncStatus = (
 // Dispatch-driven promote
 
 // `building` — the Release workflow is running; it creates the tag and
-// the remote Release. `deploying` — the build was green and Imbi has
-// created the Deployment. `build_failed` — the build failed or timed
-// out, and the release is blocked. `failed` — the build outcome is
-// unknown, or Imbi could not finish the promote; the tag is still
-// shippable.
+// the remote Release. `deploying` — the build was green and the
+// Deployment Imbi created is rolling out. `build_failed` — the build
+// failed or timed out, and the release is blocked. `deploy_failed` — the
+// build was green but the rollout failed or timed out; the release is
+// *not* blocked, so the same tag can be redeployed. `failed` — the build
+// outcome is unknown, or Imbi could not finish the promote; the tag is
+// still shippable.
 export type PromoteState =
   | 'build_failed'
   | 'building'
+  | 'deploy_failed'
   | 'deploying'
   | 'failed'
   | 'idle'

--- a/ui/src/components/ProjectDetail.tsx
+++ b/ui/src/components/ProjectDetail.tsx
@@ -46,9 +46,11 @@ import { DependenciesTab } from '@/components/dependencies/DependenciesTab'
 import { ConnectIdentityPrompt } from '@/components/deploy/ConnectIdentityPrompt'
 import {
   type DeploymentRunStarted,
+  type ReleaseBuildStarted,
   ReleaseModal,
 } from '@/components/deploy/DeploymentModal'
 import { DeploymentRunWatcher } from '@/components/deploy/DeploymentRunWatcher'
+import { ReleaseBuildWatcher } from '@/components/deploy/ReleaseBuildWatcher'
 import { DeploymentsTab } from '@/components/deployments/DeploymentsTab'
 import { ProjectDocumentsTab } from '@/components/documents/ProjectDocumentsTab'
 import { OperationsLog } from '@/components/OperationsLog'
@@ -424,6 +426,40 @@ export function ProjectDetail({
           })
         }
         return prev.filter((r) => r.runId !== runId)
+      })
+    },
+    [queryClient],
+  )
+  // In-flight dispatch-driven promotes (one ReleaseBuildWatcher each).
+  // Keyed on the toast id rather than a run id: the build phase has no
+  // Deployment, and the workflow run id can be absent on appliances
+  // whose dispatch answers without one.
+  const [activeBuilds, setActiveBuilds] = useState<ReleaseBuildStarted[]>([])
+  const handleBuildStarted = useCallback((build: ReleaseBuildStarted) => {
+    setActiveBuilds((prev) =>
+      prev.some((b) => b.toastId === build.toastId) ? prev : [...prev, build],
+    )
+  }, [])
+  const handleBuildTerminal = useCallback(
+    (toastId: number | string) => {
+      setActiveBuilds((prev) => {
+        const settled = prev.find((b) => b.toastId === toastId)
+        if (settled) {
+          // A finished promote moved the release *and* the deployment,
+          // so refresh both the release train and the project's own
+          // views for whichever project triggered it.
+          void queryClient.invalidateQueries({
+            queryKey: [
+              'currentReleases',
+              settled.originOrgSlug,
+              settled.originProjectId,
+            ],
+          })
+          void queryClient.invalidateQueries({
+            predicate: (q) => q.queryKey.includes(settled.originProjectId),
+          })
+        }
+        return prev.filter((b) => b.toastId !== toastId)
       })
     },
     [queryClient],
@@ -1309,7 +1345,11 @@ export function ProjectDetail({
                   />
                 </div>
               )}
-            <ReleasesTab orgSlug={orgSlug} project={project} />
+            <ReleasesTab
+              onBuildStarted={handleBuildStarted}
+              orgSlug={orgSlug}
+              project={project}
+            />
           </TabsContent>
         )}
         {hasDeploymentsTab && (
@@ -1334,6 +1374,7 @@ export function ProjectDetail({
               canTrigger={canTriggerDeployments}
               connectLabel={deploymentConnectLabel}
               environments={sortedEnvironments}
+              onBuildStarted={handleBuildStarted}
               onRunStarted={handleRunStarted}
               orgSlug={orgSlug}
               projectId={project.id}
@@ -1393,6 +1434,7 @@ export function ProjectDetail({
               fromEnvironment={fromSlug}
               initialAction={isPromoteModal ? 'promote' : 'deploy'}
               initialEnvSlug={initialSubId}
+              onBuildStarted={handleBuildStarted}
               onOpenChange={(open) => {
                 if (!open) closeModal()
               }}
@@ -1421,6 +1463,20 @@ export function ProjectDetail({
           runId={run.runId}
           runUrl={run.runUrl}
           toastId={run.toastId}
+        />
+      ))}
+      {activeBuilds.map((build) => (
+        // Bound to the org/project that dispatched the build, for the
+        // same reason as the run watchers above.
+        <ReleaseBuildWatcher
+          envName={build.envName}
+          key={build.toastId}
+          onTerminal={() => handleBuildTerminal(build.toastId)}
+          orgSlug={build.originOrgSlug}
+          projectId={build.originProjectId}
+          runUrl={build.runUrl}
+          tag={build.tag}
+          toastId={build.toastId}
         />
       ))}
       <RelocatePreviewDialog

--- a/ui/src/components/ProjectDetail.tsx
+++ b/ui/src/components/ProjectDetail.tsx
@@ -51,6 +51,7 @@ import {
 } from '@/components/deploy/DeploymentModal'
 import { DeploymentRunWatcher } from '@/components/deploy/DeploymentRunWatcher'
 import { ReleaseBuildWatcher } from '@/components/deploy/ReleaseBuildWatcher'
+import { useAdoptInFlightPromote } from '@/components/deploy/useAdoptInFlightPromote'
 import { DeploymentsTab } from '@/components/deployments/DeploymentsTab'
 import { ProjectDocumentsTab } from '@/components/documents/ProjectDocumentsTab'
 import { OperationsLog } from '@/components/OperationsLog'
@@ -464,6 +465,27 @@ export function ProjectDetail({
     },
     [queryClient],
   )
+  // `promote-status` reports the environment as a slug; the toast wants
+  // the name the rest of the UI shows.
+  const envNameForSlug = useCallback(
+    (slug: null | string) =>
+      slug
+        ? (sortedEnvironments.find((env) => env.slug === slug)?.name ?? slug)
+        : null,
+    [sortedEnvironments],
+  )
+  // A promote outlives the page that started it, so ask on mount whether
+  // one is already running rather than only learning about it from the
+  // click that dispatched it. Without this a reload mid-promote loses
+  // the watcher for good.
+  useAdoptInFlightPromote({
+    enabled: !!orgSlug && !!project.id,
+    envName: envNameForSlug,
+    hasActiveBuild: activeBuilds.some((b) => b.originProjectId === project.id),
+    onBuildStarted: handleBuildStarted,
+    orgSlug,
+    projectId: project.id,
+  })
 
   // Overview-only: feeds ProjectAttributesSection inside <TabsContent
   // value="overview">. The other tabs render their own components.

--- a/ui/src/components/deploy/DeploymentModal.tsx
+++ b/ui/src/components/deploy/DeploymentModal.tsx
@@ -40,6 +40,28 @@ export interface DeploymentRunStarted {
   toastId: number | string
 }
 
+/**
+ * A dispatched release build being followed by `ReleaseBuildWatcher`.
+ *
+ * The build-phase counterpart to {@link DeploymentRunStarted}. It
+ * carries no run id because there is no Deployment yet — and won't be
+ * one the browser ever sees, since the promote watcher creates it
+ * server-side. The watcher polls `/deployments/promote-status` keyed on
+ * the project instead.
+ */
+export interface ReleaseBuildStarted {
+  /** Target env, or `null` for a release-only cut. */
+  envName: null | string
+  /** Org slug the promote was triggered from. */
+  originOrgSlug: string
+  /** Project id the promote was triggered from. */
+  originProjectId: string
+  /** Workflow run URL, when the remote reported one. */
+  runUrl?: null | string
+  tag: string
+  toastId: number | string
+}
+
 interface ReleaseModalProps {
   canDeploy: boolean
   canPromote: boolean
@@ -51,6 +73,7 @@ interface ReleaseModalProps {
   fromEnvironment?: string
   initialAction: 'deploy' | 'promote'
   initialEnvSlug: string
+  onBuildStarted?: (build: ReleaseBuildStarted) => void
   onOpenChange: (open: boolean) => void
   onRunStarted?: (run: DeploymentRunStarted) => void
   open: boolean
@@ -68,6 +91,7 @@ export function ReleaseModal({
   fromEnvironment,
   initialAction,
   initialEnvSlug,
+  onBuildStarted,
   onOpenChange,
   onRunStarted,
   open,
@@ -136,6 +160,7 @@ export function ReleaseModal({
                   environments={environments}
                   fromCommittish={fromCommittish}
                   fromEnvironment={fromEnvironment as string}
+                  onBuildStarted={onBuildStarted}
                   onClose={() => onOpenChange(false)}
                   onRunStarted={onRunStarted}
                   open={open && tab === 'promote'}

--- a/ui/src/components/deploy/PromoteTab.tsx
+++ b/ui/src/components/deploy/PromoteTab.tsx
@@ -21,10 +21,20 @@ import { extractApiErrorDetail } from '@/lib/apiError'
 import { cn } from '@/lib/utils'
 import type { DraftReleaseNotesResponse, Environment } from '@/types'
 
+import { handleDispatchedBuild } from './releaseBuildHandoff'
+
 interface PromoteTabProps {
   environments: Environment[]
   fromCommittish?: null | string
   fromEnvironment: string
+  /**
+   * Called instead of `onRunStarted` when the project has a Release
+   * workflow configured: the promote dispatched a build rather than
+   * creating a Deployment, so there is a build to follow, not a run.
+   */
+  onBuildStarted?: (
+    build: import('./DeploymentModal').ReleaseBuildStarted,
+  ) => void
   onClose: () => void
   onRunStarted?: (run: import('./DeploymentModal').DeploymentRunStarted) => void
   open: boolean
@@ -39,6 +49,7 @@ export function PromoteTab({
   environments,
   fromCommittish,
   fromEnvironment,
+  onBuildStarted,
   onClose,
   onRunStarted,
   open,
@@ -173,6 +184,22 @@ export function PromoteTab({
       const releaseUrl = data.release_url
       const runUrl = data.run.run_url
       const tagLabel = data.tag ?? tag
+      // Dispatch-driven promote: the Release workflow is building, and
+      // it — not Imbi — creates the tag and the remote Release. There is
+      // no Deployment to watch yet, so follow the promote status
+      // instead. See ReleaseBuildWatcher.
+      if (
+        handleDispatchedBuild(data, {
+          envName: toEnvName,
+          onBuildStarted,
+          orgSlug,
+          projectId,
+          tagFallback: tag,
+        })
+      ) {
+        onClose()
+        return
+      }
       // Prefer the run URL when present; fall back to the release URL
       // so the watcher's recreated toast still has a useful action.
       const actionUrl = runUrl ?? releaseUrl
@@ -421,11 +448,15 @@ export function PromoteTab({
       </section>
 
       {/* Footer */}
+      {/* Deliberately path-agnostic: whether the release workflow builds
+          first depends on server-side plugin configuration this tab
+          can't see, so the copy must be true either way. */}
       <p className="text-tertiary text-xs">
-        On promote, a release{' '}
-        <span className="font-mono">{tag || 'vX.Y.Z'}</span> will be created at{' '}
+        On promote, release <span className="font-mono">{tag || 'vX.Y.Z'}</span>{' '}
+        is cut from{' '}
         <span className="font-mono">{selectedSha?.slice(0, 7) ?? '—'}</span> and
-        rolled out to {toEnvironment}.
+        rolled out to {toEnvironment}. If this project has a release workflow,
+        that build runs first and must succeed before anything ships.
       </p>
       <div className="border-tertiary bg-secondary/30 -mx-6 mt-2 -mb-4 flex items-center justify-end gap-2 border-t px-6 py-4">
         <Button onClick={onClose} type="button" variant="ghost">

--- a/ui/src/components/deploy/ReleaseBuildWatcher.test.tsx
+++ b/ui/src/components/deploy/ReleaseBuildWatcher.test.tsx
@@ -1,0 +1,213 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { render, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import * as endpoints from '@/api/endpoints'
+
+import { ReleaseBuildWatcher } from './ReleaseBuildWatcher'
+
+// fallow-ignore-next-line unresolved-import
+vi.mock('@/api/endpoints', async () => {
+  const actual =
+    await vi.importActual<typeof import('@/api/endpoints')>('@/api/endpoints')
+  return {
+    ...actual,
+    getPromoteStatus: vi.fn(),
+  }
+})
+
+vi.mock('sonner', () => ({
+  toast: {
+    error: vi.fn(),
+    loading: vi.fn(),
+    message: vi.fn(),
+    success: vi.fn(),
+  },
+}))
+
+function renderWatcher(
+  props: Partial<{
+    envName: null | string
+    onTerminal: () => void
+    runUrl: null | string
+    tag: string
+    toastId: string
+  }> = {},
+) {
+  const onTerminal = props.onTerminal ?? vi.fn()
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  const utils = render(
+    <QueryClientProvider client={client}>
+      <ReleaseBuildWatcher
+        envName={props.envName === undefined ? 'staging' : props.envName}
+        onTerminal={onTerminal}
+        orgSlug="acme"
+        projectId="p1"
+        runUrl={props.runUrl ?? null}
+        tag={props.tag ?? '0.1.5'}
+        toastId={props.toastId ?? 'toast-1'}
+      />
+    </QueryClientProvider>,
+  )
+  return { ...utils, client, onTerminal }
+}
+
+function status(
+  overrides: Partial<endpoints.PromoteStatus> = {},
+): endpoints.PromoteStatus {
+  return {
+    artifact_run_id: '4242',
+    artifact_run_url: 'https://ghe/run/4242',
+    committish: 'e6a13a0',
+    environment: 'staging',
+    error: null,
+    from_environment: 'testing',
+    requested_by: 'daves@aweber.com',
+    status: 'building',
+    tag: '0.1.5',
+    updated_at: null,
+    ...overrides,
+  }
+}
+
+describe('ReleaseBuildWatcher', () => {
+  let getPromoteStatus: ReturnType<typeof vi.fn>
+  let toast: {
+    error: ReturnType<typeof vi.fn>
+    loading: ReturnType<typeof vi.fn>
+    message: ReturnType<typeof vi.fn>
+    success: ReturnType<typeof vi.fn>
+  }
+
+  beforeEach(async () => {
+    getPromoteStatus = vi.mocked(endpoints.getPromoteStatus)
+    const sonner = await import('sonner')
+    toast = sonner.toast as unknown as typeof toast
+    getPromoteStatus.mockReset()
+    toast.error.mockReset()
+    toast.loading.mockReset()
+    toast.message.mockReset()
+    toast.success.mockReset()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('renders nothing', async () => {
+    getPromoteStatus.mockResolvedValue(status())
+    const { container } = renderWatcher()
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('shows a build toast while building', async () => {
+    getPromoteStatus.mockResolvedValue(status())
+    const { onTerminal } = renderWatcher()
+    await waitFor(() => {
+      expect(toast.loading).toHaveBeenCalled()
+    })
+    expect(onTerminal).not.toHaveBeenCalled()
+    expect(toast.loading.mock.calls[0][0]).toMatch(/Building release 0\.1\.5/)
+  })
+
+  it('keeps watching through the deploy phase', async () => {
+    // ``deploying`` is not terminal: the rollout's outcome arrives on
+    // this same status, so handing off here would drop it.
+    getPromoteStatus.mockResolvedValue(status({ status: 'deploying' }))
+    const { onTerminal } = renderWatcher()
+    await waitFor(() => {
+      expect(toast.loading).toHaveBeenCalled()
+    })
+    expect(toast.loading.mock.calls[0][0]).toMatch(/Deploying 0\.1\.5 to/)
+    expect(onTerminal).not.toHaveBeenCalled()
+  })
+
+  it('reports success', async () => {
+    getPromoteStatus.mockResolvedValue(status({ status: 'success' }))
+    const { onTerminal } = renderWatcher()
+    await waitFor(() => {
+      expect(toast.success).toHaveBeenCalled()
+      expect(onTerminal).toHaveBeenCalled()
+    })
+    expect(toast.success.mock.calls[0][0]).toMatch(/Released 0\.1\.5/)
+    expect(toast.success.mock.calls[0][1].id).toBe('toast-1')
+  })
+
+  it('reports a failed build and says the release is blocked', async () => {
+    getPromoteStatus.mockResolvedValue(
+      status({
+        error: 'The release build failure. The release is blocked;',
+        status: 'build_failed',
+      }),
+    )
+    const { onTerminal } = renderWatcher()
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalled()
+      expect(onTerminal).toHaveBeenCalled()
+    })
+    expect(toast.error.mock.calls[0][0]).toMatch(/Release build for 0\.1\.5/)
+    expect(toast.error.mock.calls[0][1].description).toMatch(/blocked/)
+  })
+
+  it('distinguishes a lost build from a failed one', async () => {
+    // ``failed`` means Imbi could not confirm or finish, and the tag is
+    // deliberately still shippable — so this must not read as an error.
+    getPromoteStatus.mockResolvedValue(
+      status({ error: 'no run id', status: 'failed' }),
+    )
+    const { onTerminal } = renderWatcher()
+    await waitFor(() => {
+      expect(toast.message).toHaveBeenCalled()
+      expect(onTerminal).toHaveBeenCalled()
+    })
+    expect(toast.error).not.toHaveBeenCalled()
+    expect(toast.message.mock.calls[0][0]).toMatch(/Lost track/)
+  })
+
+  it('omits the environment for a release-only cut', async () => {
+    getPromoteStatus.mockResolvedValue(
+      status({ environment: null, status: 'success' }),
+    )
+    renderWatcher({ envName: null })
+    await waitFor(() => {
+      expect(toast.success).toHaveBeenCalled()
+    })
+    expect(toast.success.mock.calls[0][0]).toBe('Released 0.1.5')
+  })
+
+  it('links the toast action at the build run', async () => {
+    getPromoteStatus.mockResolvedValue(status({ status: 'success' }))
+    renderWatcher()
+    await waitFor(() => {
+      expect(toast.success).toHaveBeenCalled()
+    })
+    const opts = toast.success.mock.calls[0][1]
+    expect(opts.action.label).toBe('View build')
+    const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null)
+    opts.action.onClick()
+    expect(openSpy).toHaveBeenCalledWith(
+      'https://ghe/run/4242',
+      '_blank',
+      'noopener',
+    )
+  })
+
+  // Slow by design: the watcher sets ``retry: 3``, so a persistent
+  // error only surfaces after TanStack's backoff (1s + 2s + 4s) is
+  // exhausted. Waiting it out tests the real give-up path rather than
+  // weakening the component's retry policy for the test's convenience.
+  it('gives up when status polling errors out', async () => {
+    getPromoteStatus.mockRejectedValue(new Error('boom'))
+    const { onTerminal } = renderWatcher()
+    await waitFor(
+      () => {
+        expect(toast.message).toHaveBeenCalled()
+        expect(onTerminal).toHaveBeenCalled()
+      },
+      { timeout: 15_000 },
+    )
+    expect(toast.message.mock.calls[0][1].description).toMatch(/polling failed/)
+  }, 20_000)
+})

--- a/ui/src/components/deploy/ReleaseBuildWatcher.test.tsx
+++ b/ui/src/components/deploy/ReleaseBuildWatcher.test.tsx
@@ -124,6 +124,36 @@ describe('ReleaseBuildWatcher', () => {
     expect(onTerminal).not.toHaveBeenCalled()
   })
 
+  it('ignores a terminal status left over from an earlier promote', async () => {
+    // `promote-status` is project-scoped, so a warm cache (or a read
+    // that beats the dispatch's own status write) can hand this watcher
+    // the *previous* promote's `success`. Settling on it would report
+    // that outcome against this tag and kill the toast on click.
+    getPromoteStatus.mockResolvedValue(
+      status({ status: 'success', tag: '0.1.9' }),
+    )
+    const { onTerminal } = renderWatcher({ tag: '0.1.10' })
+    await waitFor(() => {
+      expect(getPromoteStatus).toHaveBeenCalled()
+    })
+    expect(onTerminal).not.toHaveBeenCalled()
+    expect(toast.success).not.toHaveBeenCalled()
+  })
+
+  it('settles once the status catches up to its own tag', async () => {
+    getPromoteStatus
+      .mockResolvedValueOnce(status({ status: 'success', tag: '0.1.9' }))
+      .mockResolvedValue(status({ status: 'success', tag: '0.1.10' }))
+    const { onTerminal } = renderWatcher({ tag: '0.1.10' })
+    await waitFor(
+      () => {
+        expect(onTerminal).toHaveBeenCalled()
+      },
+      { timeout: 10_000 },
+    )
+    expect(toast.success.mock.calls[0][0]).toMatch(/Released 0\.1\.10/)
+  }, 15_000)
+
   it('reports success', async () => {
     getPromoteStatus.mockResolvedValue(status({ status: 'success' }))
     const { onTerminal } = renderWatcher()
@@ -149,6 +179,25 @@ describe('ReleaseBuildWatcher', () => {
     })
     expect(toast.error.mock.calls[0][0]).toMatch(/Release build for 0\.1\.5/)
     expect(toast.error.mock.calls[0][1].description).toMatch(/blocked/)
+  })
+
+  it('reports a failed rollout and says the release is not blocked', async () => {
+    // The mirror of ``build_failed``: the build was green, so the tag is
+    // real and redeployable — telling the user it is blocked would send
+    // them to unblock something that was never blocked.
+    getPromoteStatus.mockResolvedValue(
+      status({
+        error: 'The deployment of 0.1.5 to staging failure.',
+        status: 'deploy_failed',
+      }),
+    )
+    const { onTerminal } = renderWatcher()
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalled()
+      expect(onTerminal).toHaveBeenCalled()
+    })
+    expect(toast.error.mock.calls[0][0]).toMatch(/Deploying 0\.1\.5 to staging/)
+    expect(toast.error.mock.calls[0][1].description).not.toMatch(/blocked;/)
   })
 
   it('distinguishes a lost build from a failed one', async () => {

--- a/ui/src/components/deploy/ReleaseBuildWatcher.tsx
+++ b/ui/src/components/deploy/ReleaseBuildWatcher.tsx
@@ -1,0 +1,168 @@
+import { useEffect, useRef } from 'react'
+
+import { useQuery } from '@tanstack/react-query'
+import {
+  CheckCircle2,
+  ExternalLink,
+  Loader2,
+  Rocket,
+  XCircle,
+} from 'lucide-react'
+import { toast } from 'sonner'
+
+import { getPromoteStatus, type PromoteStatus } from '@/api/endpoints'
+
+/** States the watcher stops polling on. */
+const TERMINAL_STATES: ReadonlySet<PromoteStatus['status']> = new Set([
+  'build_failed',
+  'failed',
+  'success',
+])
+
+interface ReleaseBuildWatcherProps {
+  /** Where the promote is heading; `null` for a release-only cut. */
+  envName: null | string
+  onTerminal: () => void
+  orgSlug: string
+  projectId: string
+  /** Workflow run URL known at dispatch time. */
+  runUrl?: null | string
+  tag: string
+  toastId: number | string
+}
+
+/**
+ * Follows a dispatched promote via `/deployments/promote-status`.
+ *
+ * Covers the whole two-phase lifecycle — `building` while the release
+ * workflow cuts the tag and builds the artifact, then `deploying` once
+ * Imbi has created the Deployment — rather than handing off to
+ * {@link DeploymentRunWatcher} partway. It has to: the Deployment is
+ * created by the promote watcher on the server, so the browser never
+ * learns its run id and has nothing to poll `/runs/{id}` with.
+ * `promote-status` reports both phases, so one poll tells the whole
+ * story.
+ *
+ * Polls more slowly than the deployment watcher on purpose: a release
+ * build takes minutes, and can sit queued behind another release since
+ * the workflow serializes per repository, so a 4s tick would be
+ * thousands of wasted requests.
+ *
+ * Renders nothing — a side-effect component the parent mounts per
+ * in-flight promote.
+ */
+export function ReleaseBuildWatcher(props: ReleaseBuildWatcherProps): null {
+  const { envName, onTerminal, orgSlug, projectId, runUrl, tag, toastId } =
+    props
+
+  const settledRef = useRef(false)
+
+  const query = useQuery<PromoteStatus>({
+    enabled: !settledRef.current,
+    queryFn: ({ signal }) => getPromoteStatus(orgSlug, projectId, signal),
+    queryKey: ['promote-status', orgSlug, projectId],
+    refetchInterval: (q) => {
+      if (settledRef.current) return false
+      const status = q.state.data?.status
+      if (status && TERMINAL_STATES.has(status)) return false
+      return 6000
+    },
+    refetchIntervalInBackground: false,
+    retry: 3,
+  })
+
+  useEffect(() => {
+    if (settledRef.current) return
+    const data = query.data
+    if (!data) return
+    const url = data.artifact_run_url ?? runUrl
+    const action = url
+      ? {
+          label: 'View build',
+          onClick: () => window.open(url, '_blank', 'noopener'),
+        }
+      : undefined
+    const target = envName ? ` to ${envName}` : ''
+
+    if (data.status === 'building') {
+      toast.loading(`Building release ${tag}…`, {
+        action,
+        description: 'The release workflow is cutting the tag and building.',
+        icon: <Loader2 className="size-4 animate-spin" />,
+        id: toastId,
+      })
+      return
+    }
+    if (data.status === 'deploying') {
+      // The build is green: the tag and the remote Release now exist and
+      // Imbi has created the Deployment. Keep polling — the rollout's
+      // outcome arrives on this same status.
+      toast.loading(`Deploying ${tag}${target}…`, {
+        action,
+        icon: <Loader2 className="size-4 animate-spin" />,
+        id: toastId,
+      })
+      return
+    }
+    if (data.status === 'success') {
+      settledRef.current = true
+      toast.success(envName ? `Released ${tag}${target}` : `Released ${tag}`, {
+        action,
+        icon: <CheckCircle2 className="size-4 text-emerald-500" />,
+        id: toastId,
+      })
+      onTerminal()
+      return
+    }
+    if (data.status === 'build_failed') {
+      settledRef.current = true
+      toast.error(`Release build for ${tag} failed`, {
+        action,
+        description:
+          data.error ??
+          'The release is blocked. Fix the build and promote a new ' +
+            'version, or unblock this one to retry it.',
+        icon: <XCircle className="size-4 text-rose-500" />,
+        id: toastId,
+      })
+      onTerminal()
+      return
+    }
+    if (data.status === 'failed') {
+      settledRef.current = true
+      // Not a failed build: Imbi lost track of it, or could not finish
+      // after it went green. The tag is deliberately left shippable.
+      toast.message(`Lost track of the release build for ${tag}`, {
+        action,
+        description:
+          data.error ??
+          'Check the workflow run; the tag was not blocked, so it can ' +
+            'still be deployed once green.',
+        icon: <Rocket className="size-4" />,
+        id: toastId,
+      })
+      onTerminal()
+    }
+    // `idle` — nothing recorded yet; keep polling.
+  }, [query.data, envName, onTerminal, runUrl, tag, toastId])
+
+  useEffect(() => {
+    if (!query.isError || settledRef.current) return
+    settledRef.current = true
+    const url = runUrl
+    toast.message(`Lost track of the release build for ${tag}`, {
+      action: url
+        ? {
+            label: 'View build',
+            onClick: () => window.open(url, '_blank', 'noopener'),
+          }
+        : undefined,
+      description: 'Status polling failed; check the workflow run directly.',
+      icon: <ExternalLink className="size-4" />,
+      id: toastId,
+    })
+    onTerminal()
+  }, [query.isError, onTerminal, runUrl, tag, toastId])
+
+  return null
+}

--- a/ui/src/components/deploy/ReleaseBuildWatcher.tsx
+++ b/ui/src/components/deploy/ReleaseBuildWatcher.tsx
@@ -15,6 +15,7 @@ import { getPromoteStatus, type PromoteStatus } from '@/api/endpoints'
 /** States the watcher stops polling on. */
 const TERMINAL_STATES: ReadonlySet<PromoteStatus['status']> = new Set([
   'build_failed',
+  'deploy_failed',
   'failed',
   'success',
 ])
@@ -63,7 +64,11 @@ export function ReleaseBuildWatcher(props: ReleaseBuildWatcherProps): null {
     queryKey: ['promote-status', orgSlug, projectId],
     refetchInterval: (q) => {
       if (settledRef.current) return false
-      const status = q.state.data?.status
+      const data = q.state.data
+      // Not ours yet (see the effect below) — a terminal status from
+      // someone else's promote must not stop this one's polling.
+      if (isForAnotherPromote(data, tag)) return 6000
+      const status = data?.status
       if (status && TERMINAL_STATES.has(status)) return false
       return 6000
     },
@@ -75,6 +80,9 @@ export function ReleaseBuildWatcher(props: ReleaseBuildWatcherProps): null {
     if (settledRef.current) return
     const data = query.data
     if (!data) return
+    // Keep the loading toast up and keep polling until the status is
+    // actually about this promote.
+    if (isForAnotherPromote(data, tag)) return
     const url = data.artifact_run_url ?? runUrl
     const action = url
       ? {
@@ -104,6 +112,22 @@ export function ReleaseBuildWatcher(props: ReleaseBuildWatcherProps): null {
       })
       return
     }
+    if (data.status === 'deploy_failed') {
+      settledRef.current = true
+      // The build was green, so unlike `build_failed` the release is not
+      // blocked — the same tag can be redeployed once the cause is fixed.
+      toast.error(`Deploying ${tag}${target} failed`, {
+        action,
+        description:
+          data.error ??
+          'The release is not blocked — redeploy this tag once the ' +
+            'cause is fixed.',
+        icon: <XCircle className="size-4 text-rose-500" />,
+        id: toastId,
+      })
+      onTerminal()
+      return
+    }
     if (data.status === 'success') {
       settledRef.current = true
       toast.success(envName ? `Released ${tag}${target}` : `Released ${tag}`, {
@@ -130,14 +154,16 @@ export function ReleaseBuildWatcher(props: ReleaseBuildWatcherProps): null {
     }
     if (data.status === 'failed') {
       settledRef.current = true
-      // Not a failed build: Imbi lost track of it, or could not finish
-      // after it went green. The tag is deliberately left shippable.
-      toast.message(`Lost track of the release build for ${tag}`, {
+      // Nothing failed outright: Imbi lost track of the build, or could
+      // not finish after it went green — which now covers losing the
+      // rollout too, so this says "promote" rather than "build". The tag
+      // is deliberately left shippable either way.
+      toast.message(`Lost track of the promote for ${tag}`, {
         action,
         description:
           data.error ??
-          'Check the workflow run; the tag was not blocked, so it can ' +
-            'still be deployed once green.',
+          'Check the run directly; the tag was not blocked, so it can ' +
+            'still be deployed.',
         icon: <Rocket className="size-4" />,
         id: toastId,
       })
@@ -165,4 +191,24 @@ export function ReleaseBuildWatcher(props: ReleaseBuildWatcherProps): null {
   }, [query.isError, onTerminal, runUrl, tag, toastId])
 
   return null
+}
+
+/**
+ * True when `data` describes a promote other than the one being watched.
+ *
+ * `promote-status` is *project*-scoped: it reports whichever promote ran
+ * most recently, so between mounting and the server's first write this
+ * watcher can be handed the previous promote's terminal status — from a
+ * warm query cache, or from a read that lands before the dispatch's own
+ * status write. Settling on it would report someone else's outcome
+ * against this tag and tear the toast down seconds after the click.
+ *
+ * A blank tag is treated as ours: the server has written a status but
+ * not yet a tag, which is a state of *this* promote, not another one.
+ */
+function isForAnotherPromote(
+  data: PromoteStatus | undefined,
+  tag: string,
+): boolean {
+  return !!data?.tag && data.tag !== tag
 }

--- a/ui/src/components/deploy/ReleaseBuildWatcher.tsx
+++ b/ui/src/components/deploy/ReleaseBuildWatcher.tsx
@@ -11,6 +11,7 @@ import {
 import { toast } from 'sonner'
 
 import { getPromoteStatus, type PromoteStatus } from '@/api/endpoints'
+import { sanitizeHttpUrl } from '@/lib/utils'
 
 /** States the watcher stops polling on. */
 const TERMINAL_STATES: ReadonlySet<PromoteStatus['status']> = new Set([
@@ -83,7 +84,10 @@ export function ReleaseBuildWatcher(props: ReleaseBuildWatcherProps): null {
     // Keep the loading toast up and keep polling until the status is
     // actually about this promote.
     if (isForAnotherPromote(data, tag)) return
-    const url = data.artifact_run_url ?? runUrl
+    // Both sides are plugin-reported, so neither is trusted to reach
+    // `window.open` unchecked.
+    const url =
+      sanitizeHttpUrl(data.artifact_run_url) ?? sanitizeHttpUrl(runUrl)
     const action = url
       ? {
           label: 'View build',
@@ -175,7 +179,7 @@ export function ReleaseBuildWatcher(props: ReleaseBuildWatcherProps): null {
   useEffect(() => {
     if (!query.isError || settledRef.current) return
     settledRef.current = true
-    const url = runUrl
+    const url = sanitizeHttpUrl(runUrl)
     toast.message(`Lost track of the release build for ${tag}`, {
       action: url
         ? {

--- a/ui/src/components/deploy/releaseBuildHandoff.test.tsx
+++ b/ui/src/components/deploy/releaseBuildHandoff.test.tsx
@@ -1,0 +1,105 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { DeploymentTriggerResponse } from '@/types'
+
+import { handleDispatchedBuild } from './releaseBuildHandoff'
+
+vi.mock('sonner', () => ({
+  toast: {
+    loading: vi.fn(() => 'toast-1'),
+    warning: vi.fn(),
+  },
+}))
+
+function response(
+  overrides: Partial<DeploymentTriggerResponse> = {},
+): DeploymentTriggerResponse {
+  return {
+    artifact_run_id: '4242',
+    artifact_run_url: 'https://ghe/run/4242',
+    phase: 'building',
+    plugin_id: 'p-1',
+    plugin_slug: 'github',
+    recorded: true,
+    run: { run_id: '', status: 'queued' },
+    tag: '0.1.5',
+    watched: true,
+    ...overrides,
+  }
+}
+
+describe('handleDispatchedBuild', () => {
+  let toast: {
+    loading: ReturnType<typeof vi.fn>
+    warning: ReturnType<typeof vi.fn>
+  }
+
+  beforeEach(async () => {
+    const sonner = await import('sonner')
+    toast = sonner.toast as unknown as typeof toast
+    toast.loading.mockReset()
+    toast.loading.mockReturnValue('toast-1')
+    toast.warning.mockReset()
+  })
+
+  const options = (onBuildStarted = vi.fn()) => ({
+    envName: 'staging',
+    onBuildStarted,
+    orgSlug: 'acme',
+    projectId: 'p1',
+    tagFallback: 'fallback',
+  })
+
+  it('claims a dispatched build and hands it to the watcher', () => {
+    const onBuildStarted = vi.fn()
+    const handled = handleDispatchedBuild(response(), options(onBuildStarted))
+    expect(handled).toBe(true)
+    expect(toast.loading).toHaveBeenCalled()
+    expect(toast.loading.mock.calls[0][0]).toMatch(/Building release 0\.1\.5/)
+    expect(onBuildStarted).toHaveBeenCalledWith({
+      envName: 'staging',
+      originOrgSlug: 'acme',
+      originProjectId: 'p1',
+      runUrl: 'https://ghe/run/4242',
+      tag: '0.1.5',
+      toastId: 'toast-1',
+    })
+  })
+
+  it('ignores the inline path so its caller keeps its own toast', () => {
+    const onBuildStarted = vi.fn()
+    const handled = handleDispatchedBuild(
+      response({ phase: null, run: { run_id: '99', status: 'queued' } }),
+      options(onBuildStarted),
+    )
+    expect(handled).toBe(false)
+    expect(toast.loading).not.toHaveBeenCalled()
+    expect(onBuildStarted).not.toHaveBeenCalled()
+  })
+
+  it('claims the response even when run_id is empty', () => {
+    // The regression this helper exists for: callers gate their live
+    // toast on ``data.run.run_id``, which is '' on the dispatch path, so
+    // without this they fall through to a terminal "Promoted!" toast
+    // minutes before the deployment exists.
+    const handled = handleDispatchedBuild(
+      response({ run: { run_id: '', status: 'queued' } }),
+      options(),
+    )
+    expect(handled).toBe(true)
+  })
+
+  it('falls back to the requested tag when none is echoed', () => {
+    handleDispatchedBuild(response({ tag: null }), options())
+    expect(toast.loading.mock.calls[0][0]).toMatch(/Building release fallback/)
+  })
+
+  it('surfaces a dispatch warning alongside the build toast', () => {
+    handleDispatchedBuild(
+      response({ warning: 'no watcher queued', watched: false }),
+      options(),
+    )
+    expect(toast.warning).toHaveBeenCalled()
+    expect(toast.warning.mock.calls[0][1].description).toBe('no watcher queued')
+  })
+})

--- a/ui/src/components/deploy/releaseBuildHandoff.tsx
+++ b/ui/src/components/deploy/releaseBuildHandoff.tsx
@@ -1,6 +1,8 @@
 import { Loader2 } from 'lucide-react'
 import { toast } from 'sonner'
 
+import { sanitizeHttpUrl } from '@/lib/utils'
+
 import type { ReleaseBuildStarted } from './DeploymentModal'
 
 /**
@@ -50,7 +52,9 @@ export function handleDispatchedBuild(
   if (data.phase !== 'building') return false
   const { envName, onBuildStarted, orgSlug, projectId, tagFallback } = options
   const tagLabel = data.tag ?? tagFallback
-  const buildUrl = data.artifact_run_url ?? null
+  // Plugin-reported, so it is untrusted input on its way to
+  // `window.open`; a `javascript:` URL there runs in this origin.
+  const buildUrl = sanitizeHttpUrl(data.artifact_run_url)
   const toastId = toast.loading(`Building release ${tagLabel}…`, {
     action: buildUrl
       ? {

--- a/ui/src/components/deploy/releaseBuildHandoff.tsx
+++ b/ui/src/components/deploy/releaseBuildHandoff.tsx
@@ -1,0 +1,80 @@
+import { Loader2 } from 'lucide-react'
+import { toast } from 'sonner'
+
+import type { ReleaseBuildStarted } from './DeploymentModal'
+
+/**
+ * The dispatch-path fields shared by `DeploymentTriggerResponse` (a
+ * promote) and `CutReleaseResponse` (a library release cut). Both can
+ * come back as a dispatched build, and both need the same handling.
+ */
+export interface DispatchedBuildResponse {
+  artifact_run_url?: null | string
+  phase?: 'building' | null
+  tag?: null | string
+  warning?: null | string
+}
+
+interface HandoffOptions {
+  /** Target env, or `null` for a release-only cut. */
+  envName: null | string
+  onBuildStarted?: (build: ReleaseBuildStarted) => void
+  orgSlug: string
+  projectId: string
+  /** Tag to show if the response didn't echo one back. */
+  tagFallback: string
+}
+
+/**
+ * Take over a promote response that dispatched a release build.
+ *
+ * Returns `true` when it handled the response, so callers can `return`
+ * instead of running their normal "there is a Deployment to watch" path.
+ * Returns `false` for the inline path, which is unchanged.
+ *
+ * This exists as a shared helper rather than an inline branch because
+ * three separate call sites can receive a dispatched build — the promote
+ * modal, the Deployments tab's release train, and the library
+ * release-cut card — and each previously assumed its response was
+ * either synchronous or carried a watchable Deployment. On the dispatch
+ * path neither holds: `run.run_id` is `''` and no release URL exists
+ * yet, so a caller that hasn't been taught about `phase` falls straight
+ * through to a terminal "Released!" toast minutes before anything ships.
+ * Keeping the check in one place means a fourth entry point can't
+ * reintroduce that.
+ */
+export function handleDispatchedBuild(
+  data: DispatchedBuildResponse,
+  options: HandoffOptions,
+): boolean {
+  if (data.phase !== 'building') return false
+  const { envName, onBuildStarted, orgSlug, projectId, tagFallback } = options
+  const tagLabel = data.tag ?? tagFallback
+  const buildUrl = data.artifact_run_url ?? null
+  const toastId = toast.loading(`Building release ${tagLabel}…`, {
+    action: buildUrl
+      ? {
+          label: 'View build',
+          onClick: () => window.open(buildUrl, '_blank', 'noopener'),
+        }
+      : undefined,
+    description:
+      'The release workflow is cutting the tag and building the artifact.',
+    icon: <Loader2 className="size-4 animate-spin" />,
+  })
+  onBuildStarted?.({
+    envName,
+    originOrgSlug: orgSlug,
+    originProjectId: projectId,
+    runUrl: buildUrl,
+    tag: tagLabel,
+    toastId,
+  })
+  if (data.warning) {
+    toast.warning(`Release build for ${tagLabel} needs attention`, {
+      description: data.warning,
+      duration: 10_000,
+    })
+  }
+  return true
+}

--- a/ui/src/components/deploy/useAdoptInFlightPromote.test.tsx
+++ b/ui/src/components/deploy/useAdoptInFlightPromote.test.tsx
@@ -1,0 +1,178 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { render, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import * as endpoints from '@/api/endpoints'
+
+import { useAdoptInFlightPromote } from './useAdoptInFlightPromote'
+
+// fallow-ignore-next-line unresolved-import
+vi.mock('@/api/endpoints', async () => {
+  const actual =
+    await vi.importActual<typeof import('@/api/endpoints')>('@/api/endpoints')
+  return {
+    ...actual,
+    getPromoteStatus: vi.fn(),
+  }
+})
+
+vi.mock('sonner', () => ({
+  toast: { loading: vi.fn() },
+}))
+
+function Harness({
+  hasActiveBuild = false,
+  onBuildStarted,
+}: {
+  hasActiveBuild?: boolean
+  onBuildStarted: (build: unknown) => void
+}) {
+  useAdoptInFlightPromote({
+    enabled: true,
+    envName: (slug) => (slug === 'staging' ? 'Staging' : slug),
+    hasActiveBuild,
+    onBuildStarted: onBuildStarted as never,
+    orgSlug: 'acme',
+    projectId: 'p1',
+  })
+  return null
+}
+
+function renderHook(props: { hasActiveBuild?: boolean } = {}) {
+  const onBuildStarted = vi.fn()
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  const utils = render(
+    <QueryClientProvider client={client}>
+      <Harness {...props} onBuildStarted={onBuildStarted} />
+    </QueryClientProvider>,
+  )
+  return { ...utils, client, onBuildStarted }
+}
+
+function status(
+  overrides: Partial<endpoints.PromoteStatus> = {},
+): endpoints.PromoteStatus {
+  return {
+    artifact_run_id: '4242',
+    artifact_run_url: 'https://ghe/run/4242',
+    committish: 'e6a13a0',
+    environment: 'staging',
+    error: null,
+    from_environment: 'testing',
+    requested_by: 'daves@aweber.com',
+    status: 'building',
+    tag: '0.1.9',
+    updated_at: null,
+    ...overrides,
+  }
+}
+
+describe('useAdoptInFlightPromote', () => {
+  let getPromoteStatus: ReturnType<typeof vi.fn>
+  let toast: { loading: ReturnType<typeof vi.fn> }
+
+  beforeEach(async () => {
+    getPromoteStatus = vi.mocked(endpoints.getPromoteStatus)
+    const sonner = await import('sonner')
+    toast = sonner.toast as unknown as typeof toast
+    getPromoteStatus.mockReset()
+    toast.loading.mockReset()
+    toast.loading.mockReturnValue('promote:p1')
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('adopts a build that was already running when it mounted', async () => {
+    getPromoteStatus.mockResolvedValue(status())
+    const { onBuildStarted } = renderHook()
+    await waitFor(() => {
+      expect(onBuildStarted).toHaveBeenCalled()
+    })
+    expect(toast.loading.mock.calls[0][0]).toMatch(/Building release 0\.1\.9/)
+    expect(onBuildStarted.mock.calls[0][0]).toMatchObject({
+      envName: 'Staging',
+      originOrgSlug: 'acme',
+      originProjectId: 'p1',
+      tag: '0.1.9',
+    })
+  })
+
+  it('adopts a rollout and resolves the env slug to its name', async () => {
+    getPromoteStatus.mockResolvedValue(status({ status: 'deploying' }))
+    const { onBuildStarted } = renderHook()
+    await waitFor(() => {
+      expect(onBuildStarted).toHaveBeenCalled()
+    })
+    expect(toast.loading.mock.calls[0][0]).toBe('Deploying 0.1.9 to Staging…')
+  })
+
+  it('ignores a project with nothing in flight', async () => {
+    getPromoteStatus.mockResolvedValue(status({ status: 'idle' }))
+    const { onBuildStarted } = renderHook()
+    await waitFor(() => {
+      expect(getPromoteStatus).toHaveBeenCalled()
+    })
+    expect(onBuildStarted).not.toHaveBeenCalled()
+    expect(toast.loading).not.toHaveBeenCalled()
+  })
+
+  it('ignores a settled promote', async () => {
+    getPromoteStatus.mockResolvedValue(status({ status: 'success' }))
+    const { onBuildStarted } = renderHook()
+    await waitFor(() => {
+      expect(getPromoteStatus).toHaveBeenCalled()
+    })
+    expect(onBuildStarted).not.toHaveBeenCalled()
+  })
+
+  it('does not double up on a promote this page already started', async () => {
+    // The dispatching mutation already mounted a watcher; adopting on top
+    // of it would drive the same toast from two places.
+    getPromoteStatus.mockResolvedValue(status())
+    const { onBuildStarted } = renderHook({ hasActiveBuild: true })
+    await waitFor(() => {
+      expect(getPromoteStatus).toHaveBeenCalled()
+    })
+    expect(onBuildStarted).not.toHaveBeenCalled()
+    expect(toast.loading).not.toHaveBeenCalled()
+  })
+
+  it('does not write into the watcher’s cache entry', async () => {
+    // Regression guard: when both shared the ``promote-status`` key,
+    // this fetch seeded that entry at page load, and a watcher mounting
+    // on a later click read the finished promote synchronously and
+    // settled against it before its own first fetch resolved.
+    getPromoteStatus.mockResolvedValue(status({ status: 'success' }))
+    const { client } = renderHook()
+    await waitFor(() => {
+      expect(getPromoteStatus).toHaveBeenCalled()
+    })
+    expect(
+      client.getQueryData(['promote-status', 'acme', 'p1']),
+    ).toBeUndefined()
+  })
+
+  it('adopts at most once per mount', async () => {
+    // Guards the loop: the watcher removes itself on terminal, which
+    // would flip ``hasActiveBuild`` back to false while the cache still
+    // held ``building`` — re-adopting there would spawn watchers forever.
+    getPromoteStatus.mockResolvedValue(status())
+    const { onBuildStarted, rerender } = renderHook()
+    await waitFor(() => {
+      expect(onBuildStarted).toHaveBeenCalledTimes(1)
+    })
+    rerender(
+      <QueryClientProvider
+        client={new QueryClient({ defaultOptions: { queries: {} } })}
+      >
+        <Harness onBuildStarted={onBuildStarted} />
+      </QueryClientProvider>,
+    )
+    await new Promise((resolve) => setTimeout(resolve, 50))
+    expect(onBuildStarted).toHaveBeenCalledTimes(1)
+  })
+})

--- a/ui/src/components/deploy/useAdoptInFlightPromote.test.tsx
+++ b/ui/src/components/deploy/useAdoptInFlightPromote.test.tsx
@@ -141,6 +141,31 @@ describe('useAdoptInFlightPromote', () => {
     expect(toast.loading).not.toHaveBeenCalled()
   })
 
+  it('drops a run URL with an unsafe scheme', async () => {
+    // `artifact_run_url` is whatever the deployment plugin reported, and
+    // it lands in `window.open` — a `javascript:` URL would run in this
+    // origin. Falling back to no action is the safe degradation.
+    getPromoteStatus.mockResolvedValue(
+      status({ artifact_run_url: 'javascript:alert(1)' }),
+    )
+    const { onBuildStarted } = renderHook()
+    await waitFor(() => {
+      expect(onBuildStarted).toHaveBeenCalled()
+    })
+    expect(toast.loading.mock.calls[0][1].action).toBeUndefined()
+    expect(onBuildStarted.mock.calls[0][0].runUrl).toBeNull()
+  })
+
+  it('keeps an https run URL', async () => {
+    getPromoteStatus.mockResolvedValue(status())
+    const { onBuildStarted } = renderHook()
+    await waitFor(() => {
+      expect(onBuildStarted).toHaveBeenCalled()
+    })
+    expect(toast.loading.mock.calls[0][1].action.label).toBe('View build')
+    expect(onBuildStarted.mock.calls[0][0].runUrl).toBe('https://ghe/run/4242')
+  })
+
   it('does not write into the watcher’s cache entry', async () => {
     // Regression guard: when both shared the ``promote-status`` key,
     // this fetch seeded that entry at page load, and a watcher mounting

--- a/ui/src/components/deploy/useAdoptInFlightPromote.tsx
+++ b/ui/src/components/deploy/useAdoptInFlightPromote.tsx
@@ -5,6 +5,7 @@ import { Loader2 } from 'lucide-react'
 import { toast } from 'sonner'
 
 import { getPromoteStatus, type PromoteStatus } from '@/api/endpoints'
+import { sanitizeHttpUrl } from '@/lib/utils'
 
 import type { ReleaseBuildStarted } from './DeploymentModal'
 
@@ -87,7 +88,10 @@ export function useAdoptInFlightPromote({
     if (hasActiveBuild) return
 
     const tag = data.tag ?? 'release'
-    const runUrl = data.artifact_run_url ?? null
+    // The run URL is whatever the deployment plugin reported, so it is
+    // untrusted input on its way into `window.open` — a `javascript:`
+    // or `data:` URL there would execute in this origin.
+    const runUrl = sanitizeHttpUrl(data.artifact_run_url)
     const target = envName(data.environment)
     const action = runUrl
       ? {

--- a/ui/src/components/deploy/useAdoptInFlightPromote.tsx
+++ b/ui/src/components/deploy/useAdoptInFlightPromote.tsx
@@ -1,0 +1,121 @@
+import { useEffect, useRef } from 'react'
+
+import { useQuery } from '@tanstack/react-query'
+import { Loader2 } from 'lucide-react'
+import { toast } from 'sonner'
+
+import { getPromoteStatus, type PromoteStatus } from '@/api/endpoints'
+
+import type { ReleaseBuildStarted } from './DeploymentModal'
+
+/** Statuses that mean a promote is still running and worth watching. */
+const IN_FLIGHT: ReadonlySet<PromoteStatus['status']> = new Set([
+  'building',
+  'deploying',
+])
+
+interface AdoptInFlightPromoteOptions {
+  /** Skip the lookup entirely, e.g. before the project id is known. */
+  enabled: boolean
+  /** Resolves the status' environment *slug* to its display name. */
+  envName: (slug: null | string) => null | string
+  /** True when this project already has a watcher mounted. */
+  hasActiveBuild: boolean
+  onBuildStarted: (build: ReleaseBuildStarted) => void
+  orgSlug: string
+  projectId: string
+}
+
+/**
+ * Pick up a promote that is already running when this mounts.
+ *
+ * A promote outlives the page that started it — the build alone takes
+ * minutes — but the watcher that follows it is component state, seeded
+ * only by the mutation that dispatched it. So a reload, a navigation
+ * away and back, or simply opening the project in a second window left
+ * the promote unwatched: the server kept driving it to completion while
+ * the browser showed nothing and never refreshed when it landed.
+ *
+ * `promote-status` is project-scoped and already reports the in-flight
+ * state, so the fix is to ask on mount rather than to only ever learn
+ * about a promote from the click that started it.
+ *
+ * Deliberately one-shot: it decides once per mount and then stops, so a
+ * settled watcher can't be re-adopted from a stale `deploying` still
+ * sitting in the query cache, which would spawn watchers forever. The
+ * cost is that a promote started in *another* window after this one
+ * mounted isn't picked up until the next mount — worth it to keep the
+ * adoption rule impossible to get into a loop.
+ */
+export function useAdoptInFlightPromote({
+  enabled,
+  envName,
+  hasActiveBuild,
+  onBuildStarted,
+  orgSlug,
+  projectId,
+}: AdoptInFlightPromoteOptions): void {
+  const decidedRef = useRef(false)
+
+  const query = useQuery<PromoteStatus>({
+    enabled: enabled && !decidedRef.current,
+    queryFn: ({ signal }) => getPromoteStatus(orgSlug, projectId, signal),
+    // Deliberately NOT the watcher's ``promote-status`` key. Sharing it
+    // seeds that cache entry at page load with whatever promote ran
+    // last, and a ``ReleaseBuildWatcher`` mounting later reads it
+    // synchronously — settling against the *previous* promote's outcome
+    // before its own first fetch resolves. One extra request per mount
+    // is the cost of keeping the two from contaminating each other.
+    queryKey: ['promote-status-adoption', orgSlug, projectId],
+    // A cached status from a previous visit says nothing about now, and
+    // the whole point is to catch a promote that started while this page
+    // was not mounted.
+    refetchOnMount: 'always',
+    retry: false,
+    staleTime: 0,
+  })
+
+  useEffect(() => {
+    if (decidedRef.current) return
+    const data = query.data
+    if (!data) return
+    // One shot, whichever way it goes — including "nothing in flight".
+    decidedRef.current = true
+    if (!IN_FLIGHT.has(data.status)) return
+    // The mutation that started this promote already mounted a watcher;
+    // adopting here too would double every toast update.
+    if (hasActiveBuild) return
+
+    const tag = data.tag ?? 'release'
+    const runUrl = data.artifact_run_url ?? null
+    const target = envName(data.environment)
+    const action = runUrl
+      ? {
+          label: 'View build',
+          onClick: () => window.open(runUrl, '_blank', 'noopener'),
+        }
+      : undefined
+    const toastId = toast.loading(
+      data.status === 'building'
+        ? `Building release ${tag}…`
+        : `Deploying ${tag}${target ? ` to ${target}` : ''}…`,
+      {
+        action,
+        description:
+          data.status === 'building'
+            ? 'The release workflow is cutting the tag and building.'
+            : undefined,
+        icon: <Loader2 className="size-4 animate-spin" />,
+        id: `promote:${projectId}`,
+      },
+    )
+    onBuildStarted({
+      envName: target,
+      originOrgSlug: orgSlug,
+      originProjectId: projectId,
+      runUrl,
+      tag,
+      toastId,
+    })
+  }, [query.data, envName, hasActiveBuild, onBuildStarted, orgSlug, projectId])
+}

--- a/ui/src/components/deployments/DeploymentsTab.tsx
+++ b/ui/src/components/deployments/DeploymentsTab.tsx
@@ -6,7 +6,10 @@ import { useQuery } from '@tanstack/react-query'
 
 import { listCurrentReleases, listRecentCommits } from '@/api/endpoints'
 import { getReleaseHistory } from '@/api/releases'
-import type { DeploymentRunStarted } from '@/components/deploy/DeploymentModal'
+import type {
+  DeploymentRunStarted,
+  ReleaseBuildStarted,
+} from '@/components/deploy/DeploymentModal'
 import { Sk, SkText } from '@/components/ui/skeleton'
 import { useTheme } from '@/contexts/ThemeContext'
 import { deriveChipColors } from '@/lib/chip-colors'
@@ -23,6 +26,7 @@ interface DeploymentsTabProps {
   connectLabel: string
   /** Pipeline environments, already sorted ascending by sort_order. */
   environments: Environment[]
+  onBuildStarted?: (build: ReleaseBuildStarted) => void
   onRunStarted?: (run: DeploymentRunStarted) => void
   orgSlug: string
   projectId: string
@@ -50,6 +54,7 @@ export function DeploymentsTab({
   canTrigger,
   connectLabel,
   environments,
+  onBuildStarted,
   onRunStarted,
   orgSlug,
   projectId,
@@ -109,7 +114,12 @@ export function DeploymentsTab({
   }
   const selectedStage = stages.find((s) => s.env.slug === effectiveSlug) ?? null
 
-  const actions = useDeploymentActions({ onRunStarted, orgSlug, projectId })
+  const actions = useDeploymentActions({
+    onBuildStarted,
+    onRunStarted,
+    orgSlug,
+    projectId,
+  })
   const { isSyncing, sync } = useDeploymentSync(orgSlug, projectId)
 
   if (currentLoading || historyLoading || commitsLoading) {

--- a/ui/src/components/deployments/useDeploymentActions.tsx
+++ b/ui/src/components/deployments/useDeploymentActions.tsx
@@ -7,7 +7,11 @@ import { toast } from 'sonner'
 
 import { ApiError } from '@/api/client'
 import { promoteDeployment, triggerDeployment } from '@/api/endpoints'
-import type { DeploymentRunStarted } from '@/components/deploy/DeploymentModal'
+import type {
+  DeploymentRunStarted,
+  ReleaseBuildStarted,
+} from '@/components/deploy/DeploymentModal'
+import { handleDispatchedBuild } from '@/components/deploy/releaseBuildHandoff'
 import { extractApiErrorDetail } from '@/lib/apiError'
 
 export interface DeploymentActions {
@@ -39,12 +43,18 @@ export interface PromoteRequest {
 }
 
 interface UseDeploymentActionsOptions {
+  /**
+   * Called instead of `onRunStarted` when a promote dispatched a
+   * release build rather than creating a Deployment.
+   */
+  onBuildStarted?: (build: ReleaseBuildStarted) => void
   onRunStarted?: (run: DeploymentRunStarted) => void
   orgSlug: string
   projectId: string
 }
 
 export function useDeploymentActions({
+  onBuildStarted,
   onRunStarted,
   orgSlug,
   projectId,
@@ -145,6 +155,22 @@ export function useDeploymentActions({
     // fallow-ignore-next-line complexity
     onSuccess: (data, req) => {
       invalidate()
+      // Dispatch-driven promote: the release build owns the tag and the
+      // remote Release, and no Deployment exists yet — so ``run_id`` is
+      // empty and the ``onRunStarted`` check below would fall straight
+      // through to a terminal "Promoted!" toast, minutes before anything
+      // ships. Hand off to the build watcher instead.
+      if (
+        handleDispatchedBuild(data, {
+          envName: req.toEnvName,
+          onBuildStarted,
+          orgSlug,
+          projectId,
+          tagFallback: req.tag,
+        })
+      ) {
+        return
+      }
       const releaseUrl = data.release_url
       const runUrl = data.run.run_url
       const tagLabel = data.tag ?? req.tag

--- a/ui/src/components/releases/ReleaseReadyCard.tsx
+++ b/ui/src/components/releases/ReleaseReadyCard.tsx
@@ -21,6 +21,10 @@ import { useCutReleaseMutation } from './useCutReleaseMutation'
 
 interface ReleaseReadyCardProps {
   drift: ReleaseDrift
+  /** Forwarded when the cut dispatched a build rather than tagging. */
+  onBuildStarted?: (
+    build: import('@/components/deploy/DeploymentModal').ReleaseBuildStarted,
+  ) => void
   onCut: () => void
   orgSlug: string
   projectId: string
@@ -36,6 +40,7 @@ interface TagFieldsProps {
 // fallow-ignore-next-line complexity
 export function ReleaseReadyCard({
   drift,
+  onBuildStarted,
   onCut,
   orgSlug,
   projectId,
@@ -81,6 +86,7 @@ export function ReleaseReadyCard({
   }, [])
 
   const { cut, isPending } = useCutReleaseMutation({
+    onBuildStarted,
     onSuccess: onCut,
     orgSlug,
     projectId,

--- a/ui/src/components/releases/ReleasesTab.tsx
+++ b/ui/src/components/releases/ReleasesTab.tsx
@@ -13,12 +13,19 @@ import { ReleaseHistory } from './ReleaseHistory'
 import { ReleaseReadyCard } from './ReleaseReadyCard'
 
 interface ReleasesTabProps {
+  onBuildStarted?: (
+    build: import('@/components/deploy/DeploymentModal').ReleaseBuildStarted,
+  ) => void
   orgSlug: string
   project: Pick<Project, 'id' | 'links' | 'name'>
 }
 
 // fallow-ignore-next-line complexity
-export function ReleasesTab({ orgSlug, project }: ReleasesTabProps) {
+export function ReleasesTab({
+  onBuildStarted,
+  orgSlug,
+  project,
+}: ReleasesTabProps) {
   const enabled = !!orgSlug && !!project.id
   const {
     data: drift,
@@ -71,6 +78,7 @@ export function ReleasesTab({ orgSlug, project }: ReleasesTabProps) {
         {drift ? (
           <ReleaseReadyCard
             drift={drift}
+            onBuildStarted={onBuildStarted}
             onCut={() => {}}
             orgSlug={orgSlug}
             projectId={project.id}

--- a/ui/src/components/releases/useCutReleaseMutation.tsx
+++ b/ui/src/components/releases/useCutReleaseMutation.tsx
@@ -3,10 +3,17 @@ import { toast } from 'sonner'
 
 import { ApiError } from '@/api/client'
 import { cutRelease } from '@/api/releases'
+import type { ReleaseBuildStarted } from '@/components/deploy/DeploymentModal'
+import { handleDispatchedBuild } from '@/components/deploy/releaseBuildHandoff'
 import { extractApiErrorDetail } from '@/lib/apiError'
 import type { CutReleaseRequest } from '@/types'
 
 interface UseCutReleaseOptions {
+  /**
+   * Called when the cut dispatched a release build instead of creating
+   * the tag inline, so the caller can mount a `ReleaseBuildWatcher`.
+   */
+  onBuildStarted?: (build: ReleaseBuildStarted) => void
   onSuccess?: () => void
   orgSlug: string
   projectId: string
@@ -18,11 +25,16 @@ interface UseCutReleaseResult {
 }
 
 /**
- * Cut a tag + GitHub release for a library project. Unlike deploy/promote
- * there is no async workflow run to watch — the cut response is synchronous,
- * so we go straight to a success toast and invalidate the release queries.
+ * Cut a tag + GitHub release for a library project.
+ *
+ * Synchronous only when the project has no Release workflow configured:
+ * then the tag and release already exist by the time this returns and a
+ * success toast is honest. With one configured the response comes back
+ * `phase: 'building'` — the dispatched workflow is what creates them —
+ * so the toast has to follow the build instead of declaring victory.
  */
 export function useCutReleaseMutation({
+  onBuildStarted,
   onSuccess,
   orgSlug,
   projectId,
@@ -46,6 +58,19 @@ export function useCutReleaseMutation({
         ['project-releases', orgSlug, projectId],
       ]) {
         void queryClient.invalidateQueries({ queryKey: key })
+      }
+      if (
+        handleDispatchedBuild(data, {
+          // A library release has no deploy target.
+          envName: null,
+          onBuildStarted,
+          orgSlug,
+          projectId,
+          tagFallback: data.tag,
+        })
+      ) {
+        onSuccess?.()
+        return
       }
       const url = data.release_url
       toast.success(

--- a/ui/src/types/index.ts
+++ b/ui/src/types/index.ts
@@ -582,11 +582,18 @@ export interface CutReleaseRequest {
 }
 
 export interface CutReleaseResponse {
+  artifact_run_id?: null | string
+  artifact_run_url?: null | string
   committish: string
+  // Set when the project has a Release workflow configured: the tag and
+  // the remote Release do not exist yet — the dispatched build creates
+  // them — so `release_url` is null and the cut is *not* synchronous.
+  phase?: 'building' | null
   recorded: boolean
   release_url: null | string
   tag: string
   warning?: null | string
+  watched?: boolean
 }
 
 // Dashboard types are hand-written: the /admin/dashboard/* endpoints are
@@ -704,6 +711,14 @@ export interface DeploymentTriggerRequest {
 }
 
 export interface DeploymentTriggerResponse {
+  artifact_run_id?: null | string
+  artifact_run_url?: null | string
+  // Set only when the project has a Release workflow configured. On
+  // that path the dispatched build owns the tag and the remote
+  // Release, so `run` is not a live rollout and there is nothing to
+  // poll at /runs/{id} yet — follow /deployments/promote-status
+  // instead until it reports `deploying`.
+  phase?: 'building' | null
   plugin_id: string
   plugin_slug: string
   recorded: boolean
@@ -717,6 +732,9 @@ export interface DeploymentTriggerResponse {
   // itself still records a DeploymentEvent; the UI surfaces this as
   // an amber inline note.
   warning?: null | string
+  // False when the build was dispatched but no watcher could be
+  // queued — the build runs, but Imbi will not finish the promote.
+  watched?: boolean
 }
 
 export interface Document {


### PR DESCRIPTION
## Summary

Promote now dispatches the project's Release workflow, waits for it, and only then creates the Imbi `Release` and the Deployment — or blocks the release if the build failed. Also lands the ENG-101 split that makes the GitHub Release the ratification of a rollout rather than something cut alongside the tag.

## Problem

Promoting a project shipped a version that was never built.

`_handle_promote` cut the tag itself and immediately created a GitHub Deployment. Nothing ever dispatched the repo's `release.yml`, which is `workflow_dispatch`-only, so no wheel and no image were built at the promoted version. Observed on `apis/pse-api-example`: tag `0.1.4` was cut, the `Deploy` workflow ran green, and no artifact at `0.1.4` existed anywhere.

The plugin half of this was already done and closed under ENG-100 — `create_deployment_artifact` and `get_artifact_run_status` have shipped, and `artifact_workflow` is a declared capability option described as *"Workflow dispatched to build the release artifact before a deployment is triggered."* But `rg create_deployment_artifact apps/` returned nothing outside tests: no endpoint, worker, or gateway action ever called it. ENG-100's host-side requirements (persist `workflow_run_id`, resync tags on success) were never implemented.

## Solution

Gated on the **Release workflow** (`artifact_workflow`) capability option. Blank leaves today's behaviour untouched, which is correct for projects whose artifacts are built outside Imbi.

Four commits, reviewable in order:

1. **Split tag creation from release ratification** (ENG-101) — `_cut_tag` / `_create_remote_release`, and a `releases/{tag}/publish` endpoint that ratifies a recorded Release from the node's own title and notes.
2. **Publish or block a release on the deployment outcome** (ENG-101) — gateway actions on `deployment_status`. States are enumerated explicitly rather than negated: `inactive` means superseded, and must not block.
3. **Dispatch the release workflow and wait for the build** (ENG-100) — new `release_promote/` Valkey-stream worker polls the run, then resolves the tagged commit, attaches the release link and run id, resyncs tags, and creates the Deployment. Failure blocks the release.
4. **Follow a dispatched release build in the UI** (ENG-100) — `ReleaseBuildWatcher` polls `/deployments/promote-status` through both phases.

Decisions worth a reviewer's attention:

- **The `commit` input is always sent.** `release-tag.yaml` reads an empty `commit` as *"release the tip of the default branch"*, so omitting it would tag a different tree than the one being promoted and still report success. There is a dedicated test for this.
- **Build-failure blocks are scoped to the tag.** `_blocked_release` matches on tag *or* committish, so a naive block would wedge the commit and refuse the ordinary fix of promoting a bumped version off the same tree. Manual blocks keep the broad commit-wide semantics.
- **The `Release` node is recorded before dispatching**, because a failed build needs something to block. A node can therefore exist for a tag the remote never carries; the block and its reason distinguish that.
- **Watch jobs run concurrently**, unlike the resync consumer they are modelled on. A job lives for the length of a build, so serial handling would let one project's build stall every other project's promote behind it.
- **The UI watcher covers the rollout too** rather than handing off to `DeploymentRunWatcher`. The Deployment is created server-side, so the browser never learns its run id.

## Impact

- **Deployment attribution on the remote changes.** The Deployment is now created by the background worker using the Integration's service credential, so it appears as the App (`imbi[bot]`) rather than the promoting user. Imbi's own records still credit the person: `DeploymentEvent.performed_by` and the `operations_log` row both carry their principal. `deployer[bot]` handles this with a `payload.actor_override`; adopting that is a follow-up if the Deploy workflow reads it.
- **Requires `create_deployment: false`** on the release workflow for projects that opt in, so Imbi owns Deployment creation — the D6 seam ENG-101 describes.
- **Rollout is opt-in per project** via the Release workflow option, so nothing changes until an operator sets it.
- Adds one Valkey consumer to the API process, bounded at 8 concurrent watch jobs with a 45-minute timeout. The timeout covers queueing, not just build duration: `release.yml` serializes per repository.
- **Known gap, not addressed here:** `deployment_status` webhooks do not appear to reach dev environments — `pse-api-example` has no repo-level webhook. This flow no longer depends on that webhook, but `add_deployment_event` still does. Related to ENG-105.

## Testing

- **2924 tests pass** across `apps/api` and `apps/gateway`; **673 UI tests** across 86 files
- Each commit was verified to pass in isolation — commit 1 was tested with the rest of the work stashed (2665 passing) to confirm the ENG-101 half stands alone
- `moon run :lint` and `api:typecheck` clean; `ui:build` (tsc + vite) clean; pre-commit clean on every touched file
- New coverage: watcher poll loop terminal states, timeout, missing run id, reclaim safety, dispatch input mapping, releasable-only skipping the deploy, block scoping, and a regression test that the UI handoff claims the response even when `run_id` is empty
- **Verified end to end against `apis/pse-api-example`**: dispatch at 20:12 → `Release 0.1.5 to staging` green → Deployment created by `imbi[bot]` at 20:15 → `Deploy` green

https://aweber.atlassian.net/browse/ENG-100