### PR TITLE
Link Projects PR badges to the project pull-requests tab

### DIFF
--- a/ui/src/components/ProjectsView.tsx
+++ b/ui/src/components/ProjectsView.tsx
@@ -677,18 +677,22 @@ export function ProjectsView() {
 
                 <div className="border-tertiary mt-auto border-t pt-[18px]">
                   <div className="flex min-h-8 flex-wrap items-center gap-2">
-                    <span
-                      className={`border-accent bg-accent text-accent inline-flex items-center gap-1 rounded-md border px-1.5 py-0.5 text-xs ${(project.open_pr_count ?? 0) > 0 ? '' : 'invisible'}`}
+                    <Link
+                      aria-label={`View pull requests for ${project.name}`}
+                      className={`border-accent bg-accent text-accent relative z-10 inline-flex items-center gap-1 rounded-md border px-1.5 py-0.5 text-xs ${(project.open_pr_count ?? 0) > 0 ? '' : 'pointer-events-none invisible'}`}
+                      to={`/projects/${project.id}/pull-requests`}
                     >
                       <GitPullRequest className="size-3.5" />
                       <span>{project.open_pr_count ?? 0}</span>
-                    </span>
-                    <span
-                      className={`border-info bg-info text-info inline-flex items-center gap-1 rounded-md border px-1.5 py-0.5 text-xs ${(project.viewer_open_pr_count ?? 0) > 0 ? '' : 'invisible'}`}
+                    </Link>
+                    <Link
+                      aria-label={`View your pull requests for ${project.name}`}
+                      className={`border-info bg-info text-info relative z-10 inline-flex items-center gap-1 rounded-md border px-1.5 py-0.5 text-xs ${(project.viewer_open_pr_count ?? 0) > 0 ? '' : 'pointer-events-none invisible'}`}
+                      to={`/projects/${project.id}/pull-requests`}
                     >
                       <User className="size-3.5" />
                       <span>{project.viewer_open_pr_count ?? 0}</span>
-                    </span>
+                    </Link>
                     <div className="ml-auto flex flex-wrap items-center gap-2">
                       <DriftCell inline project={project} />
                     </div>
@@ -1663,16 +1667,24 @@ const ProjectListRow = React.memo(function ProjectListRow({
       <div className="w-40 shrink-0 px-6 py-4 whitespace-nowrap">
         <div className="flex items-center justify-center gap-1.5">
           {(project.open_pr_count ?? 0) > 0 && (
-            <span className="border-accent bg-accent text-accent inline-flex items-center gap-1.5 rounded-md border px-2 py-1 font-mono text-xs">
+            <Link
+              aria-label={`View pull requests for ${project.name}`}
+              className="border-accent bg-accent text-accent relative z-10 inline-flex items-center gap-1.5 rounded-md border px-2 py-1 font-mono text-xs"
+              to={`/projects/${project.id}/pull-requests`}
+            >
               <GitPullRequest className="size-3.5" />
               <span>{project.open_pr_count}</span>
-            </span>
+            </Link>
           )}
           {(project.viewer_open_pr_count ?? 0) > 0 && (
-            <span className="border-info bg-info text-info inline-flex items-center gap-1.5 rounded-md border px-2 py-1 font-mono text-xs">
+            <Link
+              aria-label={`View your pull requests for ${project.name}`}
+              className="border-info bg-info text-info relative z-10 inline-flex items-center gap-1.5 rounded-md border px-2 py-1 font-mono text-xs"
+              to={`/projects/${project.id}/pull-requests`}
+            >
               <User className="size-3.5" />
               <span>{project.viewer_open_pr_count}</span>
-            </span>
+            </Link>
           )}
         </div>
       </div>


### PR DESCRIPTION
## Summary
The PR count badges in the Projects page "PRs" column now link to that project's pull-requests tab instead of the project overview.

## Problem
Issue #203: clicking the PR icon on the Projects page landed on `/projects/{id}` rather than `/projects/{id}/pull-requests`. The badges were plain `<span>`s rendered underneath the full-card/full-row overlay `Link`, so every click was absorbed by the overlay and routed to the project overview.

## Solution
In `ui/src/components/ProjectsView.tsx`, for both the grid card and the list row:
- Render both badges (all open PRs, viewer's open PRs) as `Link`s to `/projects/{id}/pull-requests`.
- Add `relative z-10` so they stack above the overlay link and receive the click.
- Give the grid view's zero-count placeholder badge `pointer-events-none` so the invisible layout spacer is not clickable.
- Add aria-labels to both badges.

## Impact
UI-only. No API, schema, or route changes — `/projects/:projectId/:tab?` already accepts `pull-requests`. The whole-card link to the project overview is unchanged everywhere else on the card/row.

## Testing
- `npm run lint` — 0 errors
- `npx tsc --noEmit` — clean
- `npm run format:check` — clean
- `npx vitest run` — 88 files, 697 tests passing

Fixes #203