### PR TITLE
ENG-102: Warn and confirm before promoting a failing commit

### DIFF
--- a/apps/api/src/imbi/api/endpoints/_helpers.py
+++ b/apps/api/src/imbi/api/endpoints/_helpers.py
@@ -187,6 +187,8 @@ def deployed_operation_log(
     from_environment: str | None = None,
     external_run_id: str | None = None,
     occurred_at: datetime.datetime | None = None,
+    ci_status: str = 'unknown',
+    ci_override: bool = False,
 ) -> common_models.OperationLog:
     """Build a ``Deployed`` ``operations_log`` row.
 
@@ -208,11 +210,20 @@ def deployed_operation_log(
     ``argMax(performed_by, occurred_at)`` -- the row must sort by when
     the deploy actually happened, not when it was recorded. Omitting it
     keeps the model default (now).
+
+    ``ci_status`` is the rolled-up CI state of ``commit_sha`` as observed
+    when the promote / release was requested, and ``ci_override`` records
+    that an operator acknowledged a failing one to get here (ENG-102).
+    Both default to the "nothing was checked" case so the backfill and
+    resync callers, which observe deployments rather than CI, need not
+    supply them.
     """
     safe_run_url = safe_audit_url(run_url)
     description = json.dumps(
         {
             'action': action,
+            'ci_override': ci_override,
+            'ci_status': ci_status,
             'commit_sha': commit_sha,
             'plugin_slug': plugin_slug,
             'run_url': safe_run_url,

--- a/apps/api/src/imbi/api/endpoints/project_deployments.py
+++ b/apps/api/src/imbi/api/endpoints/project_deployments.py
@@ -3186,8 +3186,6 @@ async def _set_release_ci_override(
     MATCH (:Project {{id: {project_id}}})
           -[:HAS_RELEASE]->(r:Release {{id: {release_id}}})
     SET r.ci_status_at_promote = {ci_status},
-        r.ci_override_by = {overridden_by},
-        r.ci_override_at = {overridden_at},
         r.updated_at = {now}
     RETURN r.id AS rid
     """
@@ -3197,9 +3195,34 @@ async def _set_release_ci_override(
             'project_id': project_id,
             'release_id': release_id,
             'ci_status': ci_status,
-            'overridden_by': overridden_by if overridden else '',
-            'overridden_at': now if overridden else '',
             'now': now,
+        },
+        ['rid'],
+    )
+    if not overridden:
+        return
+    # Only ever written, never blanked.  ``_upsert_release_node`` keys on
+    # ``(project, committish, tag)``, so re-promoting one tag lands on the
+    # same node and runs this a second time -- and a CI re-run that turns
+    # the commit green makes that the expected sequence.  Clearing the
+    # actor on that pass would erase the acknowledgement someone actually
+    # made, dropping the override badge from release history and making
+    # :func:`_release_ci_override` report a clean promote for a release
+    # that shipped over a failing build.
+    override_query: typing.LiteralString = """
+    MATCH (:Project {{id: {project_id}}})
+          -[:HAS_RELEASE]->(r:Release {{id: {release_id}}})
+    SET r.ci_override_by = {overridden_by},
+        r.ci_override_at = {overridden_at}
+    RETURN r.id AS rid
+    """
+    await db.execute(
+        override_query,
+        {
+            'project_id': project_id,
+            'release_id': release_id,
+            'overridden_by': overridden_by,
+            'overridden_at': now,
         },
         ['rid'],
     )

--- a/apps/api/src/imbi/api/endpoints/project_deployments.py
+++ b/apps/api/src/imbi/api/endpoints/project_deployments.py
@@ -129,6 +129,13 @@ class PromoteActionRequest(pydantic.BaseModel):
     release_name: str | None = None
     release_notes_markdown: str = ''
     prerelease: bool = False
+    #: Operator acknowledgement that ``from_committish`` has a failing CI
+    #: run.  Without it a red commit is refused with a 409; with it the
+    #: promote proceeds and the override is recorded (see
+    #: :func:`_assert_ci_not_failing`).  Only ``fail`` is gated -- an
+    #: ``unknown`` status means CI never ran or the token cannot read
+    #: check-runs, which must not stand in for a failure.
+    acknowledge_ci_failure: bool = False
 
 
 DeploymentRequestBody = typing.Annotated[
@@ -246,6 +253,20 @@ class PromotionOption(pydantic.BaseModel):
     commits_pending: int | None = None
 
 
+class CommitCheckStatus(pydantic.BaseModel):
+    """Live rolled-up CI status for one commit.
+
+    Backs the promote / release forms' pre-flight warning.  Read live from
+    the plugin rather than from the synced ``commits`` table because it is
+    the same call the promote gate itself makes -- a banner sourced from
+    the (possibly lagging) sync could tell the operator the commit is
+    green and then have the promote refused.
+    """
+
+    committish: str
+    ci_status: plugin_base.CheckStatus = 'unknown'
+
+
 class RecentCommit(pydantic.BaseModel):
     """A commit row read from the ClickHouse ``commits`` table.
 
@@ -317,6 +338,13 @@ class ReleaseHistoryEntry(pydantic.BaseModel):
     blocked_reason: str | None = None
     blocked_by: str | None = None
     blocked_at: datetime.datetime | None = None
+    #: Set when the release was cut over a *failing* CI run that an
+    #: operator explicitly acknowledged (ENG-102).  ``ci_status`` above is
+    #: the commit's CI state as it stands *now*; this is the record of what
+    #: was known, and decided, at promote time -- the two differ once a
+    #: re-run turns the commit green after the fact.
+    ci_override_by: str | None = None
+    ci_override_at: datetime.datetime | None = None
 
 
 class ReleaseBlockRequest(pydantic.BaseModel):
@@ -377,6 +405,9 @@ class ReleaseCutRequest(pydantic.BaseModel):
     release_name: str | None = None
     release_notes_markdown: str = ''
     prerelease: bool = False
+    #: Same gate as the promote path; see
+    #: :attr:`PromoteActionRequest.acknowledge_ci_failure`.
+    acknowledge_ci_failure: bool = False
 
 
 class ReleaseCutResponse(pydantic.BaseModel):
@@ -713,6 +744,87 @@ def _handler(resolved: ResolvedCapability) -> DeploymentCapability:
     return typing.cast(DeploymentCapability, resolved.capability_cls())
 
 
+async def _resolve_ci_status(
+    handler: DeploymentCapability,
+    ctx: PluginContext,
+    credentials: dict[str, str],
+    committish: str,
+) -> plugin_base.CheckStatus:
+    """Roll up the CI check-runs status for *committish*.
+
+    Never raises: a plugin that has no CI concept, a token that cannot read
+    check-runs, and a transport error all answer ``'unknown'``.  That is
+    the whole point -- the caller gates on ``'fail'`` alone, so a failure
+    to *ask* must never read as a failing build.
+    """
+    try:
+        return await call_with_timeout(
+            handler.get_check_status(
+                ctx,
+                _resolve_credentials(ctx, credentials),
+                committish=committish,
+            )
+        )
+    except Exception:  # noqa: BLE001
+        LOGGER.debug(
+            'get_check_status failed for %s on project %s; treating the CI '
+            'status as unknown',
+            committish,
+            ctx.project_id,
+            exc_info=True,
+        )
+        return 'unknown'
+
+
+async def _assert_ci_not_failing(
+    handler: DeploymentCapability,
+    ctx: PluginContext,
+    credentials: dict[str, str],
+    *,
+    committish: str,
+    acknowledged: bool,
+    action: str,
+) -> plugin_base.CheckStatus:
+    """Refuse a promote / release off a red commit unless acknowledged.
+
+    Returns the observed status so the caller can record it alongside the
+    release.  This is a warning, not a block: an operator who has seen the
+    failure and decided to ship anyway sets ``acknowledged`` and the
+    override is recorded (:func:`_set_release_ci_override`).
+
+    ``committish`` must be the commit on the default branch, never the tag
+    being cut.  Tag-triggered workflow runs skip the test jobs, so a tag
+    has no meaningful check status of its own -- gating on it would ask a
+    question whose answer is always ``unknown``.
+
+    Only ``'fail'`` gates.  ``'warn'`` (a cancelled or stale run) is not a
+    failing build, and ``'unknown'`` means CI never ran or the token lacks
+    the scope to look -- treating either as a failure would refuse most
+    promotes.
+    """
+    status = await _resolve_ci_status(handler, ctx, credentials, committish)
+    if status != 'fail':
+        return status
+    short = versioning.short_committish(committish)
+    if not acknowledged:
+        raise fastapi.HTTPException(
+            status_code=409,
+            detail=(
+                f'CI failed for commit {short}. Review the failing checks '
+                f'before you {action} it; to {action} it anyway, resubmit '
+                'with acknowledge_ci_failure=true.'
+            ),
+        )
+    LOGGER.warning(
+        'CI failure overridden: project=%s action=%s commit=%s actor=%s',
+        ctx.project_id,
+        action,
+        short,
+        ctx.actor_user_id,
+    )
+    return status
+
+
 def _require_deployment_sync_support(resolved: ResolvedCapability) -> None:
     """Raise 400 unless the plugin opts into deployment resync.
 
@@ -766,6 +878,8 @@ async def _record_deployment_audit(
     external_run_id: str | None = None,
     release_url: str | None = None,
     from_environment: str | None = None,
+    ci_status: str = 'unknown',
+    ci_override: bool = False,
 ) -> None:
     """Write a deployment audit row to the ``operations_log``.
 
@@ -780,6 +894,11 @@ async def _record_deployment_audit(
     operations-log UI can render directly.  ``committish`` is *also*
     recorded as ``commit_sha`` in the audit JSON so the UI can correlate
     a tagged promotion with the untagged deploy of the same commit.
+
+    ``ci_status`` / ``ci_override`` carry the promote-time CI decision
+    (ENG-102).  Deploys leave them at their defaults: a deploy ships a
+    commit some earlier promote or release already gated, so the CI
+    question is not this row's to answer.
     """
     entry = deployed_operation_log(
         project_id=project_id,
@@ -795,6 +914,8 @@ async def _record_deployment_audit(
         release_url=release_url,
         from_environment=from_environment,
         external_run_id=external_run_id,
+        ci_status=ci_status,
+        ci_override=ci_override,
     )
     row = entry.model_dump(by_alias=True, mode='python')
     row['is_deleted'] = 1 if entry.is_deleted else 0
@@ -1555,6 +1676,42 @@ async def compare_refs(
     return result
 
 
+@project_deployments_router.get('/check-status')
+async def get_commit_check_status(
+    org_slug: str,
+    project_id: str,
+    db: graph.Pool,
+    auth: typing.Annotated[
+        permissions.AuthContext,
+        fastapi.Depends(
+            permissions.require_permission('project:deployment:read'),
+        ),
+    ],
+    committish: str = fastapi.Query(...),
+    source: str | None = None,
+) -> CommitCheckStatus:
+    """Roll up the CI check-runs status for one commit.
+
+    The pre-flight read behind the promote / release forms' CI warning.  It
+    is deliberately the *same* call the promote gate makes
+    (:func:`_assert_ci_not_failing`) rather than a read of the synced
+    ``commits`` table, so what the operator is shown and what the gate
+    enforces cannot disagree.
+
+    Never errors on the plugin's behalf: an unreachable or unauthorized
+    check-runs API answers ``'unknown'``, which is also the status that
+    does not gate a promote.
+    """
+    resolved, ctx, credentials = await _resolve_and_context(
+        db, org_slug, project_id, auth, source=source
+    )
+    status = await _resolve_ci_status(
+        _handler(resolved), ctx, credentials, committish
+    )
+    await persist_link_writeback(db, ctx)
+    return CommitCheckStatus(committish=committish, ci_status=status)
+
+
 @project_deployments_router.post('', status_code=202)
 async def trigger_deployment(
     org_slug: str,
@@ -2217,6 +2374,7 @@ async def _dispatch_release_build(
     to_environment: str = '',
     from_environment: str = '',
     deploy: bool,
+    ci_status: plugin_base.CheckStatus = 'unknown',
 ) -> _DispatchedBuild:
     """Record the release, dispatch its build, and queue the watcher.
 
@@ -2254,6 +2412,15 @@ async def _dispatch_release_build(
         notes_markdown=notes_markdown,
         release_url=None,
         created_by=auth.principal_name,
+    )
+    # Stamped before the dispatch, for the same reason the node itself is:
+    # the decision to ship a red commit has to outlive a build that fails.
+    await _set_release_ci_override(
+        db,
+        project_id=project_id,
+        release_id=release_id,
+        ci_status=ci_status,
+        overridden_by=auth.principal_name,
     )
     inputs = {
         _RELEASE_WORKFLOW_DESCRIPTION_INPUT: title,
@@ -2368,6 +2535,7 @@ async def _promote_via_dispatch(
     credentials: dict[str, str],
     handler: DeploymentCapability,
     valkey_client: typing.Any,
+    ci_status: plugin_base.CheckStatus = 'unknown',
 ) -> DeploymentTriggerResponse:
     """Dispatch the project's Release workflow instead of cutting the tag.
 
@@ -2391,6 +2559,7 @@ async def _promote_via_dispatch(
         to_environment=body.to_environment,
         from_environment=body.from_environment,
         deploy=await _project_is_deployable(db, project_id),
+        ci_status=ci_status,
     )
     return DeploymentTriggerResponse(
         run=DeploymentRun(run_id='', status='queued'),
@@ -2488,6 +2657,18 @@ async def _handle_promote(
     )
     handler = _handler(resolved)
 
+    # Last gate before anything irreversible: no tag has been cut and no
+    # build dispatched yet, so a 409 here leaves nothing to clean up and
+    # the client can simply resubmit with the acknowledgement set.
+    ci_status = await _assert_ci_not_failing(
+        handler,
+        ctx,
+        credentials,
+        committish=body.from_committish,
+        acknowledged=body.acknowledge_ci_failure,
+        action='promote',
+    )
+
     # A project with a Release workflow configured takes the
     # dispatch-and-watch path: the workflow builds the artifact, cuts the
     # annotated tag and creates the remote Release, and only then does
@@ -2509,6 +2690,7 @@ async def _handle_promote(
             credentials=credentials,
             handler=handler,
             valkey_client=valkey_client,
+            ci_status=ci_status,
         )
 
     warnings: list[str] = []
@@ -2591,6 +2773,13 @@ async def _handle_promote(
         release_url=release_url,
         created_by=auth.principal_name,
     )
+    await _set_release_ci_override(
+        db,
+        project_id=project_id,
+        release_id=release_id,
+        ci_status=ci_status,
+        overridden_by=auth.principal_name,
+    )
 
     # 5. Record the deployment event.
     note = f'via {resolved.plugin_slug}'
@@ -2633,6 +2822,8 @@ async def _handle_promote(
         external_run_id=str(run.run_id) if run.run_id else None,
         release_url=release_url,
         from_environment=body.from_environment,
+        ci_status=ci_status,
+        ci_override=ci_status == 'fail',
     )
     return DeploymentTriggerResponse(
         run=run,
@@ -2963,6 +3154,95 @@ async def _set_release_artifact_run(
     )
 
 
+async def _set_release_ci_override(
+    db: graph.Graph,
+    *,
+    project_id: str,
+    release_id: str,
+    ci_status: plugin_base.CheckStatus,
+    overridden_by: str,
+) -> None:
+    """Record the CI status a release was cut against.
+
+    ``ci_status == 'fail'`` is exactly the case an operator had to
+    acknowledge to get here -- :func:`_assert_ci_not_failing` refuses it
+    otherwise -- so the actor and timestamp are stamped on that and only
+    that.  The status itself is recorded either way, because "shipped
+    green" and "shipped without CI ever having run" are different facts
+    and a blank property could not tell them apart.
+
+    Written here, at promote time, rather than only folded into the
+    ``operations_log`` row: on the dispatch path that row is written by the
+    watcher *after* a green build, so an override whose release build then
+    failed would otherwise leave no trace of the decision anywhere.
+
+    Kept off :func:`_upsert_release_node` for the same reason
+    :func:`_set_release_artifact_run` is -- that function is also the
+    resync's writer, and resync observes deployments, not CI.
+    """
+    overridden = ci_status == 'fail'
+    now = datetime.datetime.now(datetime.UTC).isoformat()
+    query: typing.LiteralString = """
+    MATCH (:Project {{id: {project_id}}})
+          -[:HAS_RELEASE]->(r:Release {{id: {release_id}}})
+    SET r.ci_status_at_promote = {ci_status},
+        r.ci_override_by = {overridden_by},
+        r.ci_override_at = {overridden_at},
+        r.updated_at = {now}
+    RETURN r.id AS rid
+    """
+    await db.execute(
+        query,
+        {
+            'project_id': project_id,
+            'release_id': release_id,
+            'ci_status': ci_status,
+            'overridden_by': overridden_by if overridden else '',
+            'overridden_at': now if overridden else '',
+            'now': now,
+        },
+        ['rid'],
+    )
+
+
+async def _release_ci_override(
+    db: graph.Graph,
+    *,
+    project_id: str,
+    release_id: str,
+) -> tuple[str, bool]:
+    """Read back ``(ci_status_at_promote, was_overridden)`` for a release.
+
+    Lets the dispatch path's audit row carry the promote-time CI decision
+    without threading it through the serialized ``WatchJob`` -- the
+    ``Release`` node stamped by :func:`_set_release_ci_override` stays the
+    single source of truth, and a node written by an older build (no such
+    properties) reads as ``('unknown', False)``.
+    """
+    query: typing.LiteralString = """
+    MATCH (:Project {{id: {project_id}}})
+          -[:HAS_RELEASE]->(r:Release {{id: {release_id}}})
+    RETURN r.ci_status_at_promote AS ci_status,
+           r.ci_override_by AS overridden_by
+    """
+    try:
+        rows = await db.execute(
+            query,
+            {'project_id': project_id, 'release_id': release_id},
+            ['ci_status', 'overridden_by'],
+        )
+    except Exception:  # noqa: BLE001
+        LOGGER.debug(
+            'CI override read failed for release %s', release_id, exc_info=True
+        )
+        return 'unknown', False
+    if not rows:
+        return 'unknown', False
+    status = graph.parse_agtype(rows[0].get('ci_status'))
+    overridden_by = graph.parse_agtype(rows[0].get('overridden_by'))
+    return str(status) if status else 'unknown', bool(overridden_by)
+
+
 async def _sync_promoted_tag(
     db: graph.Graph,
     *,
@@ -3161,6 +3441,12 @@ async def complete_promote_build(
             release_id,
             appended,
         )
+    # The CI decision was made (and stamped on the Release node) back when
+    # the operator pressed promote, minutes ago; read it back rather than
+    # re-asking the plugin, whose answer may have changed since.
+    ci_status, ci_override = await _release_ci_override(
+        db, project_id=project_id, release_id=release_id
+    )
     await _record_deployment_audit(
         project_id=project_id,
         project_slug=ctx.project_slug,
@@ -3174,6 +3460,8 @@ async def complete_promote_build(
         external_run_id=str(run.run_id) if run.run_id else None,
         release_url=release_url,
         from_environment=from_environment or None,
+        ci_status=ci_status,
+        ci_override=ci_override,
     )
     return run
 
@@ -3932,6 +4220,8 @@ async def get_release_history(
                 blocked_reason=node.get('blocked_reason'),
                 blocked_by=node.get('blocked_by'),
                 blocked_at=blocked_at,
+                ci_override_by=node.get('ci_override_by') or None,
+                ci_override_at=node.get('ci_override_at') or None,
             )
         )
     # Order by released version (highest semver first) so the head of the
@@ -3993,6 +4283,18 @@ async def cut_release(
     )
     handler = _handler(resolved)
 
+    # Same gate as the promote path, and for the same reason: a library
+    # release off a red commit is still a red artifact, and nothing
+    # irreversible has happened yet.
+    ci_status = await _assert_ci_not_failing(
+        handler,
+        ctx,
+        credentials,
+        committish=body.committish,
+        acknowledged=body.acknowledge_ci_failure,
+        action='release',
+    )
+
     # With a Release workflow configured, the build owns the tag and the
     # remote Release, exactly as on the promote path -- the only
     # difference is that nothing is deployed afterwards.  See
@@ -4013,6 +4315,7 @@ async def cut_release(
             title=body.release_name or body.tag,
             notes_markdown=body.release_notes_markdown,
             deploy=False,
+            ci_status=ci_status,
         )
         return ReleaseCutResponse(
             tag=body.tag,
@@ -4050,7 +4353,7 @@ async def cut_release(
     await persist_link_writeback(db, ctx)
 
     committish = body.committish[:7].lower()
-    await _upsert_release_node(
+    release_id = await _upsert_release_node(
         db,
         project_id=project_id,
         tag=body.tag,
@@ -4059,6 +4362,13 @@ async def cut_release(
         notes_markdown=body.release_notes_markdown,
         release_url=release_url,
         created_by=auth.principal_name,
+    )
+    await _set_release_ci_override(
+        db,
+        project_id=project_id,
+        release_id=release_id,
+        ci_status=ci_status,
+        overridden_by=auth.principal_name,
     )
 
     LOGGER.info(
@@ -4081,6 +4391,8 @@ async def cut_release(
         plugin_slug=resolved.plugin_slug,
         run_url=None,
         release_url=release_url,
+        ci_status=ci_status,
+        ci_override=ci_status == 'fail',
     )
     return ReleaseCutResponse(
         tag=body.tag,

--- a/apps/api/tests/endpoints/test_project_deployments.py
+++ b/apps/api/tests/endpoints/test_project_deployments.py
@@ -2156,11 +2156,26 @@ class CiGateTestCase(ProjectDeploymentsTestCase):
             )
 
     def _ci_stamps(self) -> list[dict[str, typing.Any]]:
-        """Params of every ``_set_release_ci_override`` write that ran."""
+        """Params of every ``ci_status_at_promote`` write that ran."""
         return [
             call.args[1]
             for call in self.mock_db.execute.await_args_list
             if 'ci_status_at_promote' in call.args[0]
+        ]
+
+    def _ci_override_writes(self) -> list[dict[str, typing.Any]]:
+        """Params of every override-actor write that ran.
+
+        A separate statement from the status write on purpose, so that a
+        later green promote of the same tag cannot blank an override --
+        which makes "did the actor get written at all?" the thing to
+        assert, not what value the status write carried for it.
+        """
+        return [
+            call.args[1]
+            for call in self.mock_db.execute.await_args_list
+            if 'ci_override_by' in call.args[0]
+            and 'ci_status_at_promote' not in call.args[0]
         ]
 
     def _audit_description(self) -> dict[str, typing.Any]:
@@ -2235,23 +2250,52 @@ class CiGateTestCase(ProjectDeploymentsTestCase):
         stamps = self._ci_stamps()
         self.assertEqual(1, len(stamps))
         self.assertEqual('fail', stamps[0]['ci_status'])
-        self.assertEqual('admin@example.com', stamps[0]['overridden_by'])
-        self.assertTrue(stamps[0]['overridden_at'])
+        overrides = self._ci_override_writes()
+        self.assertEqual(1, len(overrides))
+        self.assertEqual('admin@example.com', overrides[0]['overridden_by'])
+        self.assertTrue(overrides[0]['overridden_at'])
 
     def test_green_promote_records_the_status_without_an_actor(self) -> None:
         """A clean promote is still recorded, but is not an override.
 
         Keeping the status either way is what lets a reader tell "shipped
-        green" from "shipped with CI never having run"; leaving the actor
-        blank is what keeps it from looking like a decision someone made.
+        green" from "shipped with CI never having run"; writing no actor
+        at all is what keeps it from looking like a decision someone made
+        -- and, on a re-promote of a tag that was acknowledged while red,
+        what keeps the real decision from being blanked.
         """
         self._use('pass')
         self.assertEqual(202, self._promote().status_code)
         stamps = self._ci_stamps()
         self.assertEqual(1, len(stamps))
         self.assertEqual('pass', stamps[0]['ci_status'])
-        self.assertEqual('', stamps[0]['overridden_by'])
-        self.assertEqual('', stamps[0]['overridden_at'])
+        self.assertNotIn('overridden_by', stamps[0])
+        self.assertNotIn('overridden_at', stamps[0])
+        self.assertEqual([], self._ci_override_writes())
+
+    def test_green_repromote_keeps_an_earlier_override(self) -> None:
+        """Re-promoting a tag after CI goes green preserves the record.
+
+        ``_upsert_release_node`` keys on ``(project, committish, tag)``,
+        so the second promote writes to the same ``Release`` node.  A CI
+        re-run that turns the commit green makes this the expected
+        sequence, and blanking the actor on it would erase an
+        acknowledgement that really happened.
+        """
+        self._use('fail')
+        self.assertEqual(
+            202, self._promote(acknowledge_ci_failure=True).status_code
+        )
+        self._use('pass')
+        self.assertEqual(202, self._promote().status_code)
+
+        stamps = self._ci_stamps()
+        self.assertEqual(['fail', 'pass'], [s['ci_status'] for s in stamps])
+        # The green pass touched the status only -- the sole override
+        # write is still the acknowledged one.
+        overrides = self._ci_override_writes()
+        self.assertEqual(1, len(overrides))
+        self.assertEqual('admin@example.com', overrides[0]['overridden_by'])
 
     def test_acknowledged_promote_records_the_override_in_the_ops_log(
         self,
@@ -2290,7 +2334,9 @@ class CiGateTestCase(ProjectDeploymentsTestCase):
         stamps = self._ci_stamps()
         self.assertEqual(1, len(stamps))
         self.assertEqual('fail', stamps[0]['ci_status'])
-        self.assertEqual('admin@example.com', stamps[0]['overridden_by'])
+        overrides = self._ci_override_writes()
+        self.assertEqual(1, len(overrides))
+        self.assertEqual('admin@example.com', overrides[0]['overridden_by'])
 
     def test_cut_release_proceeds_when_ci_unknown(self) -> None:
         self._use('unknown')
@@ -2377,7 +2423,9 @@ class DispatchCiGateTestCase(CiGateTestCase):
         stamps = self._ci_stamps()
         self.assertEqual(1, len(stamps))
         self.assertEqual('fail', stamps[0]['ci_status'])
-        self.assertEqual('admin@example.com', stamps[0]['overridden_by'])
+        overrides = self._ci_override_writes()
+        self.assertEqual(1, len(overrides))
+        self.assertEqual('admin@example.com', overrides[0]['overridden_by'])
 
     # The two inherited ops-log assertions do not hold on this path, and
     # why they don't is the whole reason the Release node is stamped: the

--- a/apps/api/tests/endpoints/test_project_deployments.py
+++ b/apps/api/tests/endpoints/test_project_deployments.py
@@ -144,6 +144,31 @@ class _DispatchingDeploymentPlugin(_FakeDeploymentPlugin):
         return ArtifactRun(run_id=run_id, status='in_progress')
 
 
+def _ci_plugin(
+    status: str = 'fail',
+    *,
+    raises: bool = False,
+    base: type[DeploymentCapability] = _FakeDeploymentPlugin,
+) -> type[DeploymentCapability]:
+    """A deployment plugin whose ``get_check_status`` answers *status*.
+
+    ``_FakeDeploymentPlugin`` deliberately does *not* override
+    ``get_check_status`` -- it inherits the capability's ``'unknown'``
+    default, which is the status that never gates a promote, so every
+    other test in this module stays unaffected by the CI gate.
+    """
+
+    class _CiPlugin(base):  # type: ignore[valid-type, misc]
+        async def get_check_status(  # type: ignore[override]
+            self, ctx, credentials, committish
+        ):
+            if raises:
+                raise RuntimeError('check-runs unavailable')
+            return status
+
+    return _CiPlugin
+
+
 class _FakeNoSyncDeploymentPlugin(_FakeDeploymentPlugin):
     """Deployment plugin that opts *out* of resync."""
 
@@ -2086,6 +2111,362 @@ class DispatchDrivenPromoteTestCase(ProjectDeploymentsTestCase):
         self.assertIsNone(response.json()['phase'])
         self.assertEqual([], _DispatchingDeploymentPlugin.dispatches)
         self.create_tag.assert_awaited_once()
+
+
+class CiGateTestCase(ProjectDeploymentsTestCase):
+    """ENG-102: promote / release off a red commit warns and confirms.
+
+    The gate is deliberately narrow -- only ``'fail'`` stops anything.
+    ``'unknown'`` is the status a project with no CI, a token without the
+    check-runs scope, or a commit whose checks never ran all report, and
+    treating that as a failure would refuse most promotes.
+    """
+
+    _BASE = '/organizations/myorg/projects/proj1/deployments'
+    _PROMOTE: typing.ClassVar[dict[str, typing.Any]] = {
+        'action': 'promote',
+        'from_environment': 'testing',
+        'to_environment': 'staging',
+        'from_committish': '1a9c610',
+        'tag': 'v6.4.0',
+    }
+    _CUT: typing.ClassVar[dict[str, typing.Any]] = {
+        'committish': '1a9c610',
+        'tag': 'v6.5.0',
+    }
+
+    def _use(
+        self, status: str = 'fail', *, raises: bool = False
+    ) -> type[DeploymentCapability]:
+        handler = _ci_plugin(status, raises=raises)
+        self.mocks['resolve_capability'].return_value = _make_resolved(
+            handler, options={'owner': 'octo', 'repo': 'demo'}
+        )
+        return handler
+
+    def _promote(self, **overrides: typing.Any) -> httpx.Response:
+        self.mocks['append_deployment_event'].return_value = mock.Mock()
+        with testclient.TestClient(self.test_app) as client:
+            return client.post(self._BASE, json={**self._PROMOTE, **overrides})
+
+    def _cut(self, **overrides: typing.Any) -> httpx.Response:
+        with testclient.TestClient(self.test_app) as client:
+            return client.post(
+                f'{self._BASE}/releases/cut', json={**self._CUT, **overrides}
+            )
+
+    def _ci_stamps(self) -> list[dict[str, typing.Any]]:
+        """Params of every ``_set_release_ci_override`` write that ran."""
+        return [
+            call.args[1]
+            for call in self.mock_db.execute.await_args_list
+            if 'ci_status_at_promote' in call.args[0]
+        ]
+
+    def _audit_description(self) -> dict[str, typing.Any]:
+        ch = self.mocks['clickhouse'].return_value
+        args, _ = ch.insert.call_args
+        row = dict(zip(args[2], args[1][0], strict=False))
+        return typing.cast(
+            'dict[str, typing.Any]', json.loads(row['description'])
+        )
+
+    # -- The gate ---------------------------------------------------------
+
+    def test_promote_409_when_ci_failed(self) -> None:
+        self._use('fail')
+        response = self._promote()
+        self.assertEqual(response.status_code, 409)
+        detail = response.json()['detail']
+        self.assertIn('CI failed for commit 1a9c610', detail)
+        self.assertIn('acknowledge_ci_failure=true', detail)
+
+    def test_promote_gate_runs_before_any_side_effect(self) -> None:
+        """A refused promote must leave nothing behind to clean up.
+
+        This is what makes the 409 safe to retry with the acknowledgement
+        set: no tag was cut, no Release node written, and no deployment
+        event recorded, so the resubmit is a first attempt, not a repair.
+        """
+        self._use('fail')
+        cut_tag = self._start(
+            mock.patch(f'{_MODULE}._promote_cut_tag', return_value=None)
+        )
+        upsert = self._start(
+            mock.patch(f'{_MODULE}._upsert_release_node', return_value='rel1')
+        )
+        self.assertEqual(409, self._promote().status_code)
+        cut_tag.assert_not_called()
+        upsert.assert_not_called()
+        self.mocks['append_deployment_event'].assert_not_called()
+
+    def test_promote_proceeds_when_ci_unknown(self) -> None:
+        """The design note's load-bearing case: unknown is not failure."""
+        self._use('unknown')
+        self.assertEqual(202, self._promote().status_code)
+
+    def test_promote_proceeds_when_ci_warns(self) -> None:
+        # ``warn`` is a cancelled or stale run, not a failing one.
+        self._use('warn')
+        self.assertEqual(202, self._promote().status_code)
+
+    def test_promote_proceeds_when_ci_passes(self) -> None:
+        self._use('pass')
+        self.assertEqual(202, self._promote().status_code)
+
+    def test_promote_proceeds_when_the_ci_lookup_raises(self) -> None:
+        """A plugin that cannot answer must not read as a failing build."""
+        self._use('fail', raises=True)
+        self.assertEqual(202, self._promote().status_code)
+
+    def test_promote_allowed_when_acknowledged(self) -> None:
+        self._use('fail')
+        response = self._promote(acknowledge_ci_failure=True)
+        self.assertEqual(response.status_code, 202)
+        self.assertEqual('v6.4.0', response.json()['tag'])
+
+    # -- The record -------------------------------------------------------
+
+    def test_acknowledged_promote_stamps_the_release_node(self) -> None:
+        self._use('fail')
+        self.assertEqual(
+            202, self._promote(acknowledge_ci_failure=True).status_code
+        )
+        stamps = self._ci_stamps()
+        self.assertEqual(1, len(stamps))
+        self.assertEqual('fail', stamps[0]['ci_status'])
+        self.assertEqual('admin@example.com', stamps[0]['overridden_by'])
+        self.assertTrue(stamps[0]['overridden_at'])
+
+    def test_green_promote_records_the_status_without_an_actor(self) -> None:
+        """A clean promote is still recorded, but is not an override.
+
+        Keeping the status either way is what lets a reader tell "shipped
+        green" from "shipped with CI never having run"; leaving the actor
+        blank is what keeps it from looking like a decision someone made.
+        """
+        self._use('pass')
+        self.assertEqual(202, self._promote().status_code)
+        stamps = self._ci_stamps()
+        self.assertEqual(1, len(stamps))
+        self.assertEqual('pass', stamps[0]['ci_status'])
+        self.assertEqual('', stamps[0]['overridden_by'])
+        self.assertEqual('', stamps[0]['overridden_at'])
+
+    def test_acknowledged_promote_records_the_override_in_the_ops_log(
+        self,
+    ) -> None:
+        self._use('fail')
+        self.assertEqual(
+            202, self._promote(acknowledge_ci_failure=True).status_code
+        )
+        description = self._audit_description()
+        self.assertTrue(description['ci_override'])
+        self.assertEqual('fail', description['ci_status'])
+
+    def test_clean_promote_records_no_override_in_the_ops_log(self) -> None:
+        self._use('pass')
+        self.assertEqual(202, self._promote().status_code)
+        description = self._audit_description()
+        self.assertFalse(description['ci_override'])
+        self.assertEqual('pass', description['ci_status'])
+
+    # -- releases/cut -----------------------------------------------------
+
+    def test_cut_release_409_when_ci_failed(self) -> None:
+        self._use('fail')
+        response = self._cut()
+        self.assertEqual(response.status_code, 409)
+        detail = response.json()['detail']
+        self.assertIn('CI failed for commit 1a9c610', detail)
+        # The action name comes from the caller, so the copy fits the flow.
+        self.assertIn('before you release it', detail)
+
+    def test_cut_release_allowed_when_acknowledged(self) -> None:
+        self._use('fail')
+        response = self._cut(acknowledge_ci_failure=True)
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual('v6.5.0', response.json()['tag'])
+        stamps = self._ci_stamps()
+        self.assertEqual(1, len(stamps))
+        self.assertEqual('fail', stamps[0]['ci_status'])
+        self.assertEqual('admin@example.com', stamps[0]['overridden_by'])
+
+    def test_cut_release_proceeds_when_ci_unknown(self) -> None:
+        self._use('unknown')
+        self.assertEqual(201, self._cut().status_code)
+
+    # -- The pre-flight read ----------------------------------------------
+
+    def test_check_status_endpoint_reports_the_plugin_status(self) -> None:
+        self._use('fail')
+        with testclient.TestClient(self.test_app) as client:
+            response = client.get(
+                f'{self._BASE}/check-status?committish=1a9c610'
+            )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            {'committish': '1a9c610', 'ci_status': 'fail'}, response.json()
+        )
+
+    def test_check_status_endpoint_degrades_to_unknown(self) -> None:
+        """The banner must render even when check-runs cannot be read."""
+        self._use('fail', raises=True)
+        with testclient.TestClient(self.test_app) as client:
+            response = client.get(
+                f'{self._BASE}/check-status?committish=1a9c610'
+            )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual('unknown', response.json()['ci_status'])
+
+
+class DispatchCiGateTestCase(CiGateTestCase):
+    """The CI gate also covers the dispatch-driven promote path.
+
+    This is the path where a red commit matters most: the Release workflow
+    itself cuts the tag, so without the gate Imbi would hand a failing
+    commit to a build whose whole job is to make it a release.
+    """
+
+    def _use(
+        self, status: str = 'fail', *, raises: bool = False
+    ) -> type[DeploymentCapability]:
+        """Resolve to a dispatching plugin with a Release workflow set."""
+        _DispatchingDeploymentPlugin.dispatches.clear()
+        _DispatchingDeploymentPlugin.run_id = '4242'
+        handler = _ci_plugin(
+            status, raises=raises, base=_DispatchingDeploymentPlugin
+        )
+        self.mocks['resolve_capability'].return_value = _make_resolved(
+            handler,
+            options={'owner': 'octo', 'repo': 'demo'},
+            capability_options={'artifact_workflow': 'release.yml'},
+        )
+        self._start(
+            mock.patch(f'{_MODULE}._project_is_deployable', return_value=True)
+        )
+        self._start(
+            mock.patch(
+                f'{_MODULE}.release_promote_queue.enqueue_release_promote',
+                return_value=True,
+            )
+        )
+        self._start(
+            mock.patch(
+                f'{_MODULE}.release_promote_service.set_status',
+                return_value=None,
+            )
+        )
+        return handler
+
+    def test_dispatch_refused_when_ci_failed(self) -> None:
+        self._use('fail')
+        self.assertEqual(409, self._promote().status_code)
+        # Nothing was dispatched, so no build can tag the red commit.
+        self.assertEqual([], _DispatchingDeploymentPlugin.dispatches)
+
+    def test_dispatch_allowed_when_acknowledged(self) -> None:
+        self._use('fail')
+        response = self._promote(acknowledge_ci_failure=True)
+        self.assertEqual(response.status_code, 202)
+        self.assertEqual('building', response.json()['phase'])
+        self.assertEqual(1, len(_DispatchingDeploymentPlugin.dispatches))
+        # Stamped before the dispatch, because on this path the ops-log row
+        # is only written after a *green* build -- an override whose build
+        # then failed would otherwise leave no trace of the decision.
+        stamps = self._ci_stamps()
+        self.assertEqual(1, len(stamps))
+        self.assertEqual('fail', stamps[0]['ci_status'])
+        self.assertEqual('admin@example.com', stamps[0]['overridden_by'])
+
+    # The two inherited ops-log assertions do not hold on this path, and
+    # why they don't is the whole reason the Release node is stamped: the
+    # audit row is not written until the build lands, so it cannot be the
+    # only record of a decision made now.  ``_release_ci_override`` is what
+    # carries it across that gap (see ReleaseCiOverrideTestCase).
+
+    def test_acknowledged_promote_records_the_override_in_the_ops_log(
+        self,
+    ) -> None:
+        self._use('fail')
+        self.assertEqual(
+            202, self._promote(acknowledge_ci_failure=True).status_code
+        )
+        self.mocks['clickhouse'].return_value.insert.assert_not_called()
+
+    def test_clean_promote_records_no_override_in_the_ops_log(self) -> None:
+        self._use('pass')
+        self.assertEqual(202, self._promote().status_code)
+        self.mocks['clickhouse'].return_value.insert.assert_not_called()
+
+
+class ReleaseCiOverrideTestCase(unittest.IsolatedAsyncioTestCase):
+    """Reading the promote-time CI decision back off the Release node.
+
+    The dispatch path's audit row is written minutes later by the watcher,
+    which must report what was decided at promote time rather than
+    re-asking the plugin -- a re-run could have turned the commit green in
+    between, and the row would then claim nothing was overridden.
+    """
+
+    async def test_reads_the_stamped_status_and_override(self) -> None:
+        db = mock.AsyncMock()
+        db.execute = mock.AsyncMock(
+            return_value=[
+                {'ci_status': 'fail', 'overridden_by': 'daves@aweber.com'}
+            ]
+        )
+        status, overridden = await project_deployments._release_ci_override(
+            db, project_id='p1', release_id='r1'
+        )
+        self.assertEqual('fail', status)
+        self.assertTrue(overridden)
+
+    async def test_blank_actor_is_not_an_override(self) -> None:
+        db = mock.AsyncMock()
+        db.execute = mock.AsyncMock(
+            return_value=[{'ci_status': 'pass', 'overridden_by': ''}]
+        )
+        status, overridden = await project_deployments._release_ci_override(
+            db, project_id='p1', release_id='r1'
+        )
+        self.assertEqual('pass', status)
+        self.assertFalse(overridden)
+
+    async def test_release_written_before_this_feature_reads_unknown(
+        self,
+    ) -> None:
+        db = mock.AsyncMock()
+        db.execute = mock.AsyncMock(
+            return_value=[{'ci_status': None, 'overridden_by': None}]
+        )
+        self.assertEqual(
+            ('unknown', False),
+            await project_deployments._release_ci_override(
+                db, project_id='p1', release_id='r1'
+            ),
+        )
+
+    async def test_missing_release_reads_unknown(self) -> None:
+        db = mock.AsyncMock()
+        db.execute = mock.AsyncMock(return_value=[])
+        self.assertEqual(
+            ('unknown', False),
+            await project_deployments._release_ci_override(
+                db, project_id='p1', release_id='r1'
+            ),
+        )
+
+    async def test_a_failed_read_does_not_sink_the_audit_row(self) -> None:
+        """The audit row matters more than the CI annotation on it."""
+        db = mock.AsyncMock()
+        db.execute = mock.AsyncMock(side_effect=RuntimeError('AGE is down'))
+        self.assertEqual(
+            ('unknown', False),
+            await project_deployments._release_ci_override(
+                db, project_id='p1', release_id='r1'
+            ),
+        )
 
 
 class BuildFailureBlockScopeTestCase(unittest.IsolatedAsyncioTestCase):

--- a/ui/src/api/endpoints.ts
+++ b/ui/src/api/endpoints.ts
@@ -19,6 +19,7 @@ import type {
   ClientCredential,
   ClientCredentialCreate,
   ClientCredentialCreated,
+  CommitCheckStatus,
   ConfigKeyResponse,
   ConfigKeyValueResponse,
   ConfigPrefixResponse,
@@ -2258,6 +2259,26 @@ export const compareDeploymentRefs = (
   if (source) search.set('source', source)
   return apiClient.get<DeploymentCompareResult>(
     `${deploymentsBase(orgSlug, projectId)}/compare?${search.toString()}`,
+    undefined,
+    signal,
+  )
+}
+
+// Live CI check-runs status for one commit. Backs the promote / release
+// forms' CI warning; the API answers `unknown` rather than erroring when
+// check-runs can't be read, and `unknown` is also what doesn't gate a
+// promote — so this never needs error handling at the call site.
+export const getCommitCheckStatus = (
+  orgSlug: string,
+  projectId: string,
+  committish: string,
+  source?: string,
+  signal?: AbortSignal,
+): Promise<CommitCheckStatus> => {
+  const search = new URLSearchParams({ committish })
+  if (source) search.set('source', source)
+  return apiClient.get<CommitCheckStatus>(
+    `${deploymentsBase(orgSlug, projectId)}/check-status?${search.toString()}`,
     undefined,
     signal,
   )

--- a/ui/src/components/deploy/CiFailureNotice.test.tsx
+++ b/ui/src/components/deploy/CiFailureNotice.test.tsx
@@ -1,0 +1,84 @@
+import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+
+import { render } from '@/test/utils'
+import type { DeploymentCommitCiStatus } from '@/types'
+
+import { CiFailureNotice, ciNeedsAcknowledgement } from './CiFailureNotice'
+
+function renderNotice(
+  ciStatus: DeploymentCommitCiStatus | undefined,
+  overrides: Partial<{
+    acknowledged: boolean
+    action: 'promote' | 'release'
+    onAcknowledgedChange: (next: boolean) => void
+  }> = {},
+) {
+  return render(
+    <CiFailureNotice
+      acknowledged={overrides.acknowledged ?? false}
+      action={overrides.action ?? 'promote'}
+      ciStatus={ciStatus}
+      onAcknowledgedChange={overrides.onAcknowledgedChange ?? vi.fn()}
+      sha="aaa1111bbbb2222"
+    />,
+  )
+}
+
+describe('ciNeedsAcknowledgement', () => {
+  it('gates on a failure and nothing else', () => {
+    expect(ciNeedsAcknowledgement('fail')).toBe(true)
+    // `warn` is a cancelled or stale run, not a failing one; `unknown`
+    // means CI never ran or the token cannot read check-runs. Gating on
+    // either would put a confirmation in front of most promotes.
+    expect(ciNeedsAcknowledgement('warn')).toBe(false)
+    expect(ciNeedsAcknowledgement('pass')).toBe(false)
+    expect(ciNeedsAcknowledgement('unknown')).toBe(false)
+    // Still loading.
+    expect(ciNeedsAcknowledgement(undefined)).toBe(false)
+  })
+})
+
+describe('CiFailureNotice', () => {
+  it('renders nothing for a status that does not gate', () => {
+    for (const status of ['pass', 'warn', 'unknown', undefined] as const) {
+      const { unmount } = renderNotice(status)
+      expect(screen.queryByText(/CI failed/)).not.toBeInTheDocument()
+      unmount()
+    }
+  })
+
+  it('names the short sha so the warning is about a specific commit', () => {
+    renderNotice('fail')
+    expect(screen.getByText('CI failed for aaa1111')).toBeInTheDocument()
+  })
+
+  it('reports the acknowledgement upward rather than owning it', async () => {
+    // The submit button lives in the parent form, so the parent has to own
+    // the flag — this component only reports the toggle.
+    const onAcknowledgedChange = vi.fn()
+    renderNotice('fail', { onAcknowledgedChange })
+    const box = screen.getByRole('checkbox', { name: /Promote anyway/i })
+    expect(box).not.toBeChecked()
+    await userEvent.setup().click(box)
+    expect(onAcknowledgedChange).toHaveBeenCalledWith(true)
+  })
+
+  it('reflects the acknowledgement the parent holds', () => {
+    renderNotice('fail', { acknowledged: true })
+    expect(
+      screen.getByRole('checkbox', { name: /Promote anyway/i }),
+    ).toBeChecked()
+  })
+
+  it("uses the caller's verb", () => {
+    renderNotice('fail', { action: 'release' })
+    expect(
+      screen.getByRole('checkbox', { name: /Release anyway/i }),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText(/Releasing anyway is still your call/),
+    ).toBeInTheDocument()
+  })
+})

--- a/ui/src/components/deploy/CiFailureNotice.tsx
+++ b/ui/src/components/deploy/CiFailureNotice.tsx
@@ -1,0 +1,101 @@
+/* eslint-disable react-refresh/only-export-components */
+import { useQuery } from '@tanstack/react-query'
+
+import { getCommitCheckStatus } from '@/api/endpoints'
+import { Alert } from '@/components/ui/alert'
+import { Checkbox } from '@/components/ui/checkbox'
+import type { DeploymentCommitCiStatus } from '@/types'
+
+interface CiFailureNoticeProps {
+  acknowledged: boolean
+  /** What the operator is about to do, for the confirmation copy. */
+  action: 'promote' | 'release'
+  ciStatus: DeploymentCommitCiStatus | undefined
+  onAcknowledgedChange: (next: boolean) => void
+  sha: null | string
+}
+
+/**
+ * Danger strip + acknowledgement checkbox shown when the selected commit's
+ * CI failed. Renders nothing otherwise.
+ *
+ * Deliberately an inline strip rather than a confirm dialog: two of the
+ * three callers already live inside a `Dialog`, and the warning belongs
+ * beside the commit being chosen — an operator should see it while
+ * picking, not only after committing to the click.
+ */
+export function CiFailureNotice({
+  acknowledged,
+  action,
+  ciStatus,
+  onAcknowledgedChange,
+  sha,
+}: CiFailureNoticeProps) {
+  if (!ciNeedsAcknowledgement(ciStatus)) return null
+  const verb = action === 'promote' ? 'Promote' : 'Release'
+  const gerund = action === 'promote' ? 'Promoting' : 'Releasing'
+  return (
+    <Alert
+      title={`CI failed for ${sha?.slice(0, 7) ?? 'this commit'}`}
+      variant="danger"
+    >
+      <div className="flex flex-col gap-2">
+        <span>
+          The checks on this commit reported a failure. Review them before
+          shipping it — {gerund} anyway is still your call, but it will be
+          recorded against the release.
+        </span>
+        <label className="flex w-fit cursor-pointer items-center gap-2 text-xs font-medium">
+          <Checkbox
+            aria-label={`${verb} anyway despite the failing CI run`}
+            checked={acknowledged}
+            onCheckedChange={(checked) =>
+              onAcknowledgedChange(checked === true)
+            }
+          />
+          {verb} anyway
+        </label>
+      </div>
+    </Alert>
+  )
+}
+
+/** Whether `status` is the one state that needs an acknowledgement. */
+export function ciNeedsAcknowledgement(
+  status: DeploymentCommitCiStatus | undefined,
+): boolean {
+  return status === 'fail'
+}
+
+/**
+ * Live CI status for one commit.
+ *
+ * Read from the plugin rather than from the `ci_status` already carried on
+ * synced commit rows: this is the same call the API's promote gate makes,
+ * so the warning and the gate cannot disagree. A synced status can lag, and
+ * a banner that says "green" over a promote the server then refuses is
+ * worse than no banner at all.
+ *
+ * `unknown` is the answer for a project with no CI, a token that cannot
+ * read check-runs, and a commit whose checks never ran — none of which the
+ * API gates on, so none of which this warns about.
+ */
+export function useCommitCheckStatus(
+  orgSlug: string,
+  projectId: string,
+  sha: null | string,
+): DeploymentCommitCiStatus | undefined {
+  const { data } = useQuery({
+    enabled: !!orgSlug && !!projectId && !!sha,
+    queryFn: ({ signal }) =>
+      getCommitCheckStatus(
+        orgSlug,
+        projectId,
+        sha as string,
+        undefined,
+        signal,
+      ),
+    queryKey: ['commitCheckStatus', orgSlug, projectId, sha],
+  })
+  return data?.ci_status
+}

--- a/ui/src/components/deploy/CiFailureNotice.tsx
+++ b/ui/src/components/deploy/CiFailureNotice.tsx
@@ -79,13 +79,21 @@ export function ciNeedsAcknowledgement(
  * `unknown` is the answer for a project with no CI, a token that cannot
  * read check-runs, and a commit whose checks never ran — none of which the
  * API gates on, so none of which this warns about.
+ *
+ * `ciPending` is what callers must gate submission on. An unresolved query
+ * has no `ci_status`, and "no status" is indistinguishable from `unknown`
+ * here — so without it a fast click would submit a failing commit before
+ * the answer landed and take a bare 409 instead of the acknowledgement
+ * flow. `isLoading` (not `isPending`) is deliberate: a query disabled for
+ * a null `sha` is pending forever, and that must not wedge the button —
+ * those callers already gate on the missing sha.
  */
 export function useCommitCheckStatus(
   orgSlug: string,
   projectId: string,
   sha: null | string,
-): DeploymentCommitCiStatus | undefined {
-  const { data } = useQuery({
+): { ciPending: boolean; ciStatus: DeploymentCommitCiStatus | undefined } {
+  const { data, isLoading } = useQuery({
     enabled: !!orgSlug && !!projectId && !!sha,
     queryFn: ({ signal }) =>
       getCommitCheckStatus(
@@ -97,5 +105,5 @@ export function useCommitCheckStatus(
       ),
     queryKey: ['commitCheckStatus', orgSlug, projectId, sha],
   })
-  return data?.ci_status
+  return { ciPending: isLoading, ciStatus: data?.ci_status }
 }

--- a/ui/src/components/deploy/PromoteTab.test.tsx
+++ b/ui/src/components/deploy/PromoteTab.test.tsx
@@ -1,0 +1,271 @@
+import { screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import * as endpoints from '@/api/endpoints'
+import { render } from '@/test/utils'
+import type {
+  CurrentReleaseEnvironment,
+  DeploymentCompareResult,
+  Environment,
+} from '@/types'
+
+import { PromoteTab } from './PromoteTab'
+
+// fallow-ignore-next-line unresolved-import
+vi.mock('@/api/endpoints', async () => {
+  const actual =
+    await vi.importActual<typeof import('@/api/endpoints')>('@/api/endpoints')
+  return {
+    ...actual,
+    compareDeploymentRefs: vi.fn(),
+    draftReleaseNotes: vi.fn(),
+    getCommitCheckStatus: vi.fn(),
+    listCurrentReleases: vi.fn(),
+    promoteDeployment: vi.fn(),
+  }
+})
+
+vi.mock('sonner', () => ({
+  toast: {
+    error: vi.fn(),
+    loading: vi.fn(),
+    success: vi.fn(),
+    warning: vi.fn(),
+  },
+}))
+
+const ENV_TESTING: Environment = {
+  description: null,
+  icon: null,
+  label_color: null,
+  name: 'Testing',
+  organization: { name: 'Acme', slug: 'acme' },
+  relationships: null,
+  slug: 'testing',
+  sort_order: 0,
+  updated_at: null,
+}
+
+const ENV_STAGING: Environment = {
+  ...ENV_TESTING,
+  name: 'Staging',
+  slug: 'staging',
+  sort_order: 1,
+}
+
+// The commit list this tab shows comes from `compare()`, which carries no
+// check status at all — every `ci_status` here is `unknown`, which is
+// precisely why the tab needs its own live lookup.
+const COMPARE: DeploymentCompareResult = {
+  additions: 1,
+  ahead: 2,
+  base_sha: 'v2.6.0',
+  behind: 0,
+  commits: [
+    {
+      author: 'bob',
+      ci_status: 'unknown',
+      is_head: false,
+      message: 'fix: broken thing',
+      sha: 'bbb2222',
+      short_sha: 'bbb2222',
+    },
+    {
+      author: 'alice',
+      ci_status: 'unknown',
+      is_head: true,
+      message: 'feat: add thing',
+      sha: 'aaa1111',
+      short_sha: 'aaa1111',
+    },
+  ],
+  deletions: 0,
+  files_changed: 1,
+  head_sha: 'aaa1111',
+  pr_numbers: [],
+}
+
+const CURRENT: CurrentReleaseEnvironment[] = [
+  {
+    ci_status: null,
+    current_status: null,
+    environment: { name: 'Testing', slug: 'testing' },
+    external_run_url: null,
+    last_event_at: '2026-01-02T00:00:00Z',
+    release: { committish: 'aaa1111', tag: 'v2.7.0' },
+  },
+  {
+    ci_status: null,
+    current_status: null,
+    environment: { name: 'Staging', slug: 'staging' },
+    external_run_url: null,
+    last_event_at: '2026-01-01T00:00:00Z',
+    release: { committish: 'bbb2222', tag: 'v2.6.0' },
+  },
+]
+
+function renderPromoteTab() {
+  return render(
+    <PromoteTab
+      environments={[ENV_TESTING, ENV_STAGING]}
+      fromEnvironment="testing"
+      onClose={vi.fn()}
+      open={true}
+      orgSlug="acme"
+      projectId="p1"
+      toEnvironment="staging"
+    />,
+  )
+}
+
+/** The tip commit is what the tab preselects. */
+const promoteButton = () =>
+  screen.getByRole('button', { name: /& deploy to staging/i })
+
+describe('PromoteTab — failing CI on the build being promoted', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(endpoints.listCurrentReleases).mockResolvedValue(CURRENT)
+    vi.mocked(endpoints.compareDeploymentRefs).mockResolvedValue(COMPARE)
+    vi.mocked(endpoints.draftReleaseNotes).mockResolvedValue({
+      bump: 'minor',
+      commits_considered: 2,
+      degraded: false,
+      notes_markdown: '## Notes',
+      reasoning: 'a feature landed',
+      version: 'v2.8.0',
+    })
+    vi.mocked(endpoints.promoteDeployment).mockResolvedValue({
+      plugin_id: 'p-1',
+      plugin_slug: 'github-deployment',
+      recorded: true,
+      run: { run_id: '', status: 'queued' },
+      tag: 'v2.8.0',
+    })
+  })
+
+  it('asks the API about the selected commit, not the tag', async () => {
+    // The design note that drives the whole ticket: a tag-triggered run
+    // skips the tests, so the tag has no CI status worth reading.
+    vi.mocked(endpoints.getCommitCheckStatus).mockResolvedValue({
+      ci_status: 'pass',
+      committish: 'aaa1111',
+    })
+    renderPromoteTab()
+    await waitFor(() => {
+      expect(endpoints.getCommitCheckStatus).toHaveBeenCalledWith(
+        'acme',
+        'p1',
+        'aaa1111',
+        undefined,
+        expect.anything(),
+      )
+    })
+  })
+
+  it('warns and holds the promote until it is acknowledged', async () => {
+    vi.mocked(endpoints.getCommitCheckStatus).mockResolvedValue({
+      ci_status: 'fail',
+      committish: 'aaa1111',
+    })
+    renderPromoteTab()
+    await waitFor(() => {
+      expect(screen.getByText(/CI failed for aaa1111/)).toBeInTheDocument()
+    })
+    expect(promoteButton()).toBeDisabled()
+  })
+
+  it('promotes once acknowledged, and tells the API it was', async () => {
+    const user = userEvent.setup()
+    vi.mocked(endpoints.getCommitCheckStatus).mockResolvedValue({
+      ci_status: 'fail',
+      committish: 'aaa1111',
+    })
+    renderPromoteTab()
+    await waitFor(() => {
+      expect(screen.getByText(/CI failed for aaa1111/)).toBeInTheDocument()
+    })
+    await user.click(screen.getByRole('checkbox', { name: /Promote anyway/i }))
+    await waitFor(() => {
+      expect(promoteButton()).not.toBeDisabled()
+    })
+    await user.click(promoteButton())
+    await waitFor(() => {
+      expect(endpoints.promoteDeployment).toHaveBeenCalledWith(
+        'acme',
+        'p1',
+        expect.objectContaining({
+          acknowledge_ci_failure: true,
+          from_committish: 'aaa1111',
+        }),
+      )
+    })
+  })
+
+  it('does not warn on a green commit', async () => {
+    vi.mocked(endpoints.getCommitCheckStatus).mockResolvedValue({
+      ci_status: 'pass',
+      committish: 'aaa1111',
+    })
+    renderPromoteTab()
+    await waitFor(() => {
+      expect(endpoints.getCommitCheckStatus).toHaveBeenCalled()
+    })
+    expect(screen.queryByText(/CI failed/)).not.toBeInTheDocument()
+  })
+
+  it('does not warn when the CI status is unknown', async () => {
+    // Never-ran, no-CI, and no-scope all land here. Treating it as a
+    // failure would put a confirmation in front of most promotes.
+    vi.mocked(endpoints.getCommitCheckStatus).mockResolvedValue({
+      ci_status: 'unknown',
+      committish: 'aaa1111',
+    })
+    renderPromoteTab()
+    await waitFor(() => {
+      expect(endpoints.getCommitCheckStatus).toHaveBeenCalled()
+    })
+    expect(screen.queryByText(/CI failed/)).not.toBeInTheDocument()
+  })
+
+  it('sends acknowledge_ci_failure=false when nothing was overridden', async () => {
+    const user = userEvent.setup()
+    vi.mocked(endpoints.getCommitCheckStatus).mockResolvedValue({
+      ci_status: 'pass',
+      committish: 'aaa1111',
+    })
+    renderPromoteTab()
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('v2.8.0')).toBeInTheDocument()
+    })
+    await user.click(promoteButton())
+    await waitFor(() => {
+      expect(endpoints.promoteDeployment).toHaveBeenCalledWith(
+        'acme',
+        'p1',
+        expect.objectContaining({ acknowledge_ci_failure: false }),
+      )
+    })
+  })
+
+  it('drops the acknowledgement when another commit is selected', async () => {
+    const user = userEvent.setup()
+    vi.mocked(endpoints.getCommitCheckStatus).mockResolvedValue({
+      ci_status: 'fail',
+      committish: 'aaa1111',
+    })
+    renderPromoteTab()
+    await waitFor(() => {
+      expect(screen.getByText(/CI failed for aaa1111/)).toBeInTheDocument()
+    })
+    await user.click(screen.getByRole('checkbox', { name: /Promote anyway/i }))
+    await user.click(screen.getByText('fix: broken thing'))
+    await waitFor(() => {
+      expect(
+        screen.getByRole('checkbox', { name: /Promote anyway/i }),
+      ).not.toBeChecked()
+    })
+    expect(promoteButton()).toBeDisabled()
+  })
+})

--- a/ui/src/components/deploy/PromoteTab.tsx
+++ b/ui/src/components/deploy/PromoteTab.tsx
@@ -162,7 +162,11 @@ export function PromoteTab({
   // Live CI status for the build being promoted. The commit list here comes
   // from `compare()`, which carries no check status at all, so this is the
   // only CI signal this form has.
-  const ciStatus = useCommitCheckStatus(orgSlug, projectId, selectedSha)
+  const { ciPending, ciStatus } = useCommitCheckStatus(
+    orgSlug,
+    projectId,
+    selectedSha,
+  )
   const ciFailed = ciNeedsAcknowledgement(ciStatus)
   const [ciAcknowledged, setCiAcknowledged] = useState(false)
   // A different commit is a different decision — never carry the
@@ -288,6 +292,10 @@ export function PromoteTab({
     tagValid &&
     !!selectedSha &&
     !promoteMutation.isPending &&
+    // Hold the button until CI has answered: an unresolved status cannot
+    // be told apart from a green one, and promoting on it skips the
+    // acknowledgement the server would then demand with a 409.
+    !ciPending &&
     !(ciFailed && !ciAcknowledged)
 
   return (

--- a/ui/src/components/deploy/PromoteTab.tsx
+++ b/ui/src/components/deploy/PromoteTab.tsx
@@ -21,6 +21,11 @@ import { extractApiErrorDetail } from '@/lib/apiError'
 import { cn } from '@/lib/utils'
 import type { DraftReleaseNotesResponse, Environment } from '@/types'
 
+import {
+  CiFailureNotice,
+  ciNeedsAcknowledgement,
+  useCommitCheckStatus,
+} from './CiFailureNotice'
 import { handleDispatchedBuild } from './releaseBuildHandoff'
 
 interface PromoteTabProps {
@@ -154,10 +159,23 @@ export function PromoteTab({
     if (!notesDirty) setNotes(draft.notes_markdown)
   }, [draft, tagDirty, notesDirty])
 
+  // Live CI status for the build being promoted. The commit list here comes
+  // from `compare()`, which carries no check status at all, so this is the
+  // only CI signal this form has.
+  const ciStatus = useCommitCheckStatus(orgSlug, projectId, selectedSha)
+  const ciFailed = ciNeedsAcknowledgement(ciStatus)
+  const [ciAcknowledged, setCiAcknowledged] = useState(false)
+  // A different commit is a different decision — never carry the
+  // acknowledgement across a selection change.
+  useEffect(() => {
+    setCiAcknowledged(false)
+  }, [selectedSha])
+
   const queryClient = useQueryClient()
   const promoteMutation = useMutation({
     mutationFn: () =>
       promoteDeployment(orgSlug, projectId, {
+        acknowledge_ci_failure: ciAcknowledged,
         action: 'promote',
         from_committish: selectedSha ?? '',
         from_environment: fromEnvironment,
@@ -266,7 +284,11 @@ export function PromoteTab({
   })
 
   const tagValid = SEMVER_RE.test(tag)
-  const canPromote = tagValid && !!selectedSha && !promoteMutation.isPending
+  const canPromote =
+    tagValid &&
+    !!selectedSha &&
+    !promoteMutation.isPending &&
+    !(ciFailed && !ciAcknowledged)
 
   return (
     <div className="flex flex-col gap-4">
@@ -350,6 +372,14 @@ export function PromoteTab({
           </ul>
         )}
       </section>
+
+      <CiFailureNotice
+        acknowledged={ciAcknowledged}
+        action="promote"
+        ciStatus={ciStatus}
+        onAcknowledgedChange={setCiAcknowledged}
+        sha={selectedSha}
+      />
 
       {/* Step 2 — version + notes */}
       <section>

--- a/ui/src/components/deployments/PendingPromoteCard.test.tsx
+++ b/ui/src/components/deployments/PendingPromoteCard.test.tsx
@@ -1,0 +1,195 @@
+import { screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import * as endpoints from '@/api/endpoints'
+import { render } from '@/test/utils'
+import type {
+  CurrentReleaseEnvironment,
+  Environment,
+  RecentCommit,
+} from '@/types'
+
+import { PendingPromoteCard } from './PendingPromoteCard'
+import type { PipelineStage } from './pipeline'
+import type { DeploymentActions } from './useDeploymentActions'
+
+// fallow-ignore-next-line unresolved-import
+vi.mock('@/api/endpoints', async () => {
+  const actual =
+    await vi.importActual<typeof import('@/api/endpoints')>('@/api/endpoints')
+  return {
+    ...actual,
+    draftReleaseNotes: vi.fn(),
+    getCommitCheckStatus: vi.fn(),
+  }
+})
+
+vi.mock('sonner', () => ({
+  toast: { error: vi.fn(), loading: vi.fn(), success: vi.fn() },
+}))
+
+const ENV = {
+  label_color: '#C86B5E',
+  name: 'Staging',
+  slug: 'staging',
+  sort_order: 2,
+} as unknown as Environment
+
+const UPSTREAM = {
+  name: 'Testing',
+  slug: 'testing',
+  sort_order: 1,
+} as unknown as Environment
+
+const TIP: RecentCommit = {
+  author: 'gavin',
+  authored_at: '2026-06-02T00:00:00Z',
+  ci_status: 'unknown',
+  message: 'fix: corrected test behavior',
+  sha: 'aab005fceed23f3a29acdf8ad89119b0b940c5c7',
+  short_sha: 'aab005f',
+  url: null,
+}
+
+const OLDER: RecentCommit = {
+  author: 'gavin',
+  authored_at: '2026-06-01T00:00:00Z',
+  ci_status: 'unknown',
+  message: 'feat: an earlier change',
+  sha: 'bbb222bbb222bbb222bbb222bbb222bbb222bbb2',
+  short_sha: 'bbb222b',
+  url: null,
+}
+
+const UPSTREAM_CURRENT: CurrentReleaseEnvironment = {
+  ci_status: null,
+  current_status: 'success',
+  environment: { name: 'testing', slug: 'testing' },
+  external_run_url: null,
+  last_event_at: '2026-06-02T00:00:00Z',
+  release: { committish: TIP.sha, tag: null },
+}
+
+const STAGE: PipelineStage = {
+  current: null,
+  currentHistoryEntry: null,
+  env: ENV,
+  kind: 'promote',
+  latestTag: '0.1.13',
+  pendingCommits: [TIP, OLDER],
+  pendingReleases: [],
+  promotableCommits: [TIP, OLDER],
+  recentReleases: [],
+  upstream: UPSTREAM,
+  upstreamCurrent: UPSTREAM_CURRENT,
+}
+
+const makeActions = (): DeploymentActions => ({
+  deploy: vi.fn(),
+  deployPending: false,
+  deployPendingSha: null,
+  promote: vi.fn(),
+  promotePending: false,
+})
+
+function renderCard(actions = makeActions()) {
+  render(
+    <PendingPromoteCard
+      accent={null}
+      actions={actions}
+      canTrigger
+      orgSlug="acme"
+      projectId="p1"
+      stage={STAGE}
+    />,
+  )
+  return actions
+}
+
+const promoteButton = () =>
+  screen.getByRole('button', { name: /& deploy to staging/i })
+
+describe('PendingPromoteCard — failing CI on the commit being tagged', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(endpoints.draftReleaseNotes).mockResolvedValue({
+      bump: 'patch',
+      commits_considered: 2,
+      degraded: false,
+      notes_markdown: '### Fixed\n- Corrected test behavior',
+      reasoning: 'a fix landed',
+      version: '0.1.14',
+    })
+    vi.mocked(endpoints.getCommitCheckStatus).mockResolvedValue({
+      ci_status: 'fail',
+      committish: TIP.short_sha,
+    })
+  })
+
+  it('warns and holds the promote until it is acknowledged', async () => {
+    renderCard()
+    await waitFor(() => {
+      expect(screen.getByText(/CI failed for aab005f/)).toBeInTheDocument()
+    })
+    expect(promoteButton()).toBeDisabled()
+  })
+
+  it('carries the acknowledgement into the promote request', async () => {
+    // Regression guard: this card dispatches through
+    // ``useDeploymentActions``, whose ``acknowledgeCiFailure`` defaults to
+    // false. Forgetting it here enables the button off local state while
+    // the request still says the failure was never acknowledged, and the
+    // API rightly answers 409.
+    const user = userEvent.setup()
+    const actions = renderCard()
+    await waitFor(() => {
+      expect(screen.getByText(/CI failed for aab005f/)).toBeInTheDocument()
+    })
+    await user.click(screen.getByRole('checkbox', { name: /Promote anyway/i }))
+    await waitFor(() => {
+      expect(promoteButton()).not.toBeDisabled()
+    })
+    await user.click(promoteButton())
+    expect(actions.promote).toHaveBeenCalledWith(
+      expect.objectContaining({
+        acknowledgeCiFailure: true,
+        sha: TIP.sha,
+        toEnvironment: 'staging',
+      }),
+    )
+  })
+
+  it('reports no acknowledgement when the commit is green', async () => {
+    const user = userEvent.setup()
+    vi.mocked(endpoints.getCommitCheckStatus).mockResolvedValue({
+      ci_status: 'pass',
+      committish: TIP.short_sha,
+    })
+    const actions = renderCard()
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('0.1.14')).toBeInTheDocument()
+    })
+    expect(screen.queryByText(/CI failed/)).not.toBeInTheDocument()
+    await user.click(promoteButton())
+    expect(actions.promote).toHaveBeenCalledWith(
+      expect.objectContaining({ acknowledgeCiFailure: false }),
+    )
+  })
+
+  it('drops the acknowledgement when another commit is selected', async () => {
+    const user = userEvent.setup()
+    renderCard()
+    await waitFor(() => {
+      expect(screen.getByText(/CI failed for aab005f/)).toBeInTheDocument()
+    })
+    await user.click(screen.getByRole('checkbox', { name: /Promote anyway/i }))
+    await user.click(screen.getByText('feat: an earlier change'))
+    await waitFor(() => {
+      expect(
+        screen.getByRole('checkbox', { name: /Promote anyway/i }),
+      ).not.toBeChecked()
+    })
+    expect(promoteButton()).toBeDisabled()
+  })
+})

--- a/ui/src/components/deployments/PendingPromoteCard.tsx
+++ b/ui/src/components/deployments/PendingPromoteCard.tsx
@@ -110,7 +110,11 @@ export function PendingPromoteCard({
   // imbi's synced history and can lag; this is the state the API's promote
   // gate will actually see. Read before the early returns below — it's a
   // hook.
-  const ciStatus = useCommitCheckStatus(orgSlug, projectId, selectedSha)
+  const { ciPending, ciStatus } = useCommitCheckStatus(
+    orgSlug,
+    projectId,
+    selectedSha,
+  )
   const ciFailed = ciNeedsAcknowledgement(ciStatus)
   const [ciAcknowledged, setCiAcknowledged] = useState(false)
   useEffect(() => {
@@ -138,6 +142,10 @@ export function PendingPromoteCard({
     canTrigger &&
     !actions.promotePending &&
     !isDrafting &&
+    // Hold the button until CI has answered: an unresolved status cannot
+    // be told apart from a green one, and promoting on it skips the
+    // acknowledgement the server would then demand with a 409.
+    !ciPending &&
     !(ciFailed && !ciAcknowledged)
   const selIdx = commits.findIndex((c) => c.sha === selectedSha)
   const heldCount = selIdx > 0 ? selIdx : 0

--- a/ui/src/components/deployments/PendingPromoteCard.tsx
+++ b/ui/src/components/deployments/PendingPromoteCard.tsx
@@ -11,6 +11,11 @@ import {
 } from 'lucide-react'
 
 import { draftReleaseNotes } from '@/api/endpoints'
+import {
+  CiFailureNotice,
+  ciNeedsAcknowledgement,
+  useCommitCheckStatus,
+} from '@/components/deploy/CiFailureNotice'
 import { ReleaseCommitPicker } from '@/components/releases/ReleaseCommitPicker'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -101,6 +106,17 @@ export function PendingPromoteCard({
     if (!notesDirty) setNotes(draft.notes_markdown)
   }, [draft, tagDirty, notesDirty])
 
+  // Live CI status for the commit being tagged. The picker's dots come from
+  // imbi's synced history and can lag; this is the state the API's promote
+  // gate will actually see. Read before the early returns below — it's a
+  // hook.
+  const ciStatus = useCommitCheckStatus(orgSlug, projectId, selectedSha)
+  const ciFailed = ciNeedsAcknowledgement(ciStatus)
+  const [ciAcknowledged, setCiAcknowledged] = useState(false)
+  useEffect(() => {
+    setCiAcknowledged(false)
+  }, [selectedSha])
+
   if (!fromTipSha) {
     return (
       <div className="border-tertiary text-tertiary rounded-lg border p-4 text-sm">
@@ -121,7 +137,8 @@ export function PendingPromoteCard({
     !!selectedSha &&
     canTrigger &&
     !actions.promotePending &&
-    !isDrafting
+    !isDrafting &&
+    !(ciFailed && !ciAcknowledged)
   const selIdx = commits.findIndex((c) => c.sha === selectedSha)
   const heldCount = selIdx > 0 ? selIdx : 0
   const reset = () => {
@@ -130,6 +147,7 @@ export function PendingPromoteCard({
     setNotes(draft?.notes_markdown ?? '')
     setTagDirty(false)
     setNotesDirty(false)
+    setCiAcknowledged(false)
   }
 
   return (
@@ -182,6 +200,14 @@ export function PendingPromoteCard({
             />
           )}
         </section>
+
+        <CiFailureNotice
+          acknowledged={ciAcknowledged}
+          action="promote"
+          ciStatus={ciStatus}
+          onAcknowledgedChange={setCiAcknowledged}
+          sha={selectedSha}
+        />
 
         <section className="border-tertiary flex flex-col gap-2 border-t pt-4">
           <div className="flex items-center gap-2.5">
@@ -298,6 +324,7 @@ export function PendingPromoteCard({
             onClick={() => {
               if (!selectedSha) return
               actions.promote({
+                acknowledgeCiFailure: ciAcknowledged,
                 fromEnvironment: stage.upstream?.slug ?? '',
                 notes,
                 sha: selectedSha,

--- a/ui/src/components/deployments/PendingReleasesCard.tsx
+++ b/ui/src/components/deployments/PendingReleasesCard.tsx
@@ -9,6 +9,7 @@ import {
   Info,
   Loader2,
   Rocket,
+  ShieldAlert,
 } from 'lucide-react'
 
 import { CiStatusDot } from '@/components/releases/CiStatusDot'
@@ -278,6 +279,17 @@ function ReleaseStack({
                 >
                   <Ban className="size-3" />
                   Blocked
+                </Badge>
+              ) : null}
+              {/* The dot above is the commit's CI state now; this is the
+                  record that someone shipped it while it was failing. */}
+              {rel.ci_override_by ? (
+                <Badge
+                  className="inline-flex shrink-0 items-center gap-1"
+                  variant="warning"
+                >
+                  <ShieldAlert className="size-3" />
+                  CI overridden
                 </Badge>
               ) : null}
               <span className="text-secondary min-w-0 flex-1 truncate text-xs">

--- a/ui/src/components/deployments/useDeploymentActions.tsx
+++ b/ui/src/components/deployments/useDeploymentActions.tsx
@@ -34,6 +34,17 @@ export interface DeployRequest {
 }
 
 export interface PromoteRequest {
+  /**
+   * Operator acknowledgement that `sha` has a failing CI run. Without it
+   * the API refuses the promote with a 409.
+   *
+   * Required, not optional-with-a-default: a caller that renders the
+   * warning and enables its submit button off local state, but forgets to
+   * forward the flag, produces a request the API rightly refuses — and the
+   * operator sees a 409 having just ticked the box. Making this mandatory
+   * turns that into a type error.
+   */
+  acknowledgeCiFailure: boolean
   fromEnvironment: string
   notes: string
   sha: string
@@ -142,6 +153,7 @@ export function useDeploymentActions({
   const promoteMutation = useMutation({
     mutationFn: (req: PromoteRequest) =>
       promoteDeployment(orgSlug, projectId, {
+        acknowledge_ci_failure: req.acknowledgeCiFailure,
         action: 'promote',
         from_committish: req.sha,
         from_environment: req.fromEnvironment,

--- a/ui/src/components/releases/ReleaseHistory.tsx
+++ b/ui/src/components/releases/ReleaseHistory.tsx
@@ -1,6 +1,12 @@
 import { useState } from 'react'
 
-import { Ban, ChevronDown, ChevronRight, ExternalLink } from 'lucide-react'
+import {
+  Ban,
+  ChevronDown,
+  ChevronRight,
+  ExternalLink,
+  ShieldAlert,
+} from 'lucide-react'
 import Markdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 
@@ -126,6 +132,33 @@ function BlockedNote({ isPending, onUnblock, rel }: BlockedNoteProps) {
   )
 }
 
+/**
+ * The record of an operator shipping over a failing CI run.
+ *
+ * Distinct from the row's `CiStatusDot`, which reports the commit's CI
+ * state *now* — a re-run can turn it green long after the fact, and the
+ * decision that was made still stands.
+ */
+function CiOverrideNote({ rel }: { rel: ReleaseHistoryEntry }) {
+  return (
+    <div className="border-warning bg-warning text-warning mt-1 mb-3 flex items-start gap-2 rounded-md border px-3 py-2.5">
+      <ShieldAlert className="mt-0.5 size-3.5 shrink-0" />
+      <div className="min-w-0 flex-1 text-xs leading-relaxed">
+        <p>Released over a failing CI run</p>
+        <p className="mt-1 opacity-80">
+          acknowledged by {rel.ci_override_by}
+          {rel.ci_override_at ? (
+            <>
+              {' · '}
+              <RelativeTime tooltip={false} value={rel.ci_override_at} />
+            </>
+          ) : null}
+        </p>
+      </div>
+    </div>
+  )
+}
+
 // fallow-ignore-next-line complexity
 function ReleaseRow({
   artifact,
@@ -172,6 +205,12 @@ function ReleaseRow({
               Blocked
             </Badge>
           ) : null}
+          {rel.ci_override_by ? (
+            <Badge className="inline-flex items-center gap-1" variant="warning">
+              <ShieldAlert className="size-3" />
+              CI overridden
+            </Badge>
+          ) : null}
           {isCurrent ? <Badge variant="accent">Latest</Badge> : null}
         </span>
       </button>
@@ -184,6 +223,7 @@ function ReleaseRow({
               rel={rel}
             />
           ) : null}
+          {rel.ci_override_by ? <CiOverrideNote rel={rel} /> : null}
           {rel.notes_markdown ? (
             <div className="document-markdown max-w-none text-sm [&>*:first-child]:mt-0 [&>*:last-child]:mb-0">
               <Markdown

--- a/ui/src/components/releases/ReleaseReadyCard.test.tsx
+++ b/ui/src/components/releases/ReleaseReadyCard.test.tsx
@@ -211,12 +211,40 @@ describe('ReleaseReadyCard', () => {
       committish: 'aaa1111',
     })
     renderCard(FIRST_RELEASE)
+    // Wait for the *resolved* status, not just the call: submission is
+    // held while the query is in flight, so asserting on dispatch alone
+    // would race the answer it is waiting for.
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', { name: /& release/i }),
+      ).not.toBeDisabled()
+    })
+    expect(endpoints.getCommitCheckStatus).toHaveBeenCalled()
+    expect(screen.queryByText(/CI failed/)).not.toBeInTheDocument()
+  })
+
+  it('holds submission until the CI status resolves', async () => {
+    // An unresolved query has no status, and "no status" reads the same
+    // as `unknown` — so without this the operator can submit a red
+    // commit before the answer lands and take a bare 409 instead of the
+    // acknowledgement flow.
+    let resolve: (value: { ci_status: string; committish: string }) => void
+    vi.mocked(endpoints.getCommitCheckStatus).mockReturnValue(
+      new Promise((r) => {
+        resolve = r as typeof resolve
+      }) as ReturnType<typeof endpoints.getCommitCheckStatus>,
+    )
+    renderCard(FIRST_RELEASE)
     await waitFor(() => {
       expect(endpoints.getCommitCheckStatus).toHaveBeenCalled()
     })
-    expect(screen.queryByText(/CI failed/)).not.toBeInTheDocument()
-    expect(
-      screen.getByRole('button', { name: /& release/i }),
-    ).not.toBeDisabled()
+    expect(screen.getByRole('button', { name: /& release/i })).toBeDisabled()
+
+    resolve!({ ci_status: 'pass', committish: 'aaa1111' })
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', { name: /& release/i }),
+      ).not.toBeDisabled()
+    })
   })
 })

--- a/ui/src/components/releases/ReleaseReadyCard.test.tsx
+++ b/ui/src/components/releases/ReleaseReadyCard.test.tsx
@@ -13,7 +13,11 @@ import { ReleaseReadyCard } from './ReleaseReadyCard'
 vi.mock('@/api/endpoints', async () => {
   const actual =
     await vi.importActual<typeof import('@/api/endpoints')>('@/api/endpoints')
-  return { ...actual, draftReleaseNotes: vi.fn() }
+  return {
+    ...actual,
+    draftReleaseNotes: vi.fn(),
+    getCommitCheckStatus: vi.fn(),
+  }
 })
 
 // fallow-ignore-next-line unresolved-import
@@ -85,6 +89,10 @@ describe('ReleaseReadyCard', () => {
       release_url: 'https://gh/releases/v0.1.0',
       tag: 'v0.1.0',
     })
+    vi.mocked(endpoints.getCommitCheckStatus).mockResolvedValue({
+      ci_status: 'pass',
+      committish: 'aaa1111',
+    })
   })
 
   it('renders the up-to-date card when there is no drift', () => {
@@ -98,6 +106,7 @@ describe('ReleaseReadyCard', () => {
     await user.click(screen.getByRole('button', { name: /& release/i }))
     await waitFor(() => {
       expect(releases.cutRelease).toHaveBeenCalledWith('acme', 'p1', {
+        acknowledge_ci_failure: false,
         committish: 'aaa1111',
         release_name: 'v0.1.0',
         release_notes_markdown: '',
@@ -137,5 +146,77 @@ describe('ReleaseReadyCard', () => {
     await waitFor(() => {
       expect(screen.getByDisplayValue('v2.0.0')).toBeInTheDocument()
     })
+  })
+
+  describe('failing CI on the selected commit', () => {
+    beforeEach(() => {
+      vi.mocked(endpoints.getCommitCheckStatus).mockResolvedValue({
+        ci_status: 'fail',
+        committish: 'aaa1111',
+      })
+    })
+
+    it('warns and holds the release until it is acknowledged', async () => {
+      renderCard(FIRST_RELEASE)
+      await waitFor(() => {
+        expect(screen.getByText(/CI failed for aaa1111/)).toBeInTheDocument()
+      })
+      expect(screen.getByRole('button', { name: /& release/i })).toBeDisabled()
+    })
+
+    it('releases anyway once acknowledged, and says so to the API', async () => {
+      const user = userEvent.setup()
+      renderCard(FIRST_RELEASE)
+      await waitFor(() => {
+        expect(screen.getByText(/CI failed for aaa1111/)).toBeInTheDocument()
+      })
+      await user.click(
+        screen.getByRole('checkbox', { name: /Release anyway/i }),
+      )
+      await user.click(screen.getByRole('button', { name: /& release/i }))
+      await waitFor(() => {
+        expect(releases.cutRelease).toHaveBeenCalledWith(
+          'acme',
+          'p1',
+          expect.objectContaining({ acknowledge_ci_failure: true }),
+        )
+      })
+    })
+
+    it('drops the acknowledgement when another commit is picked', async () => {
+      const user = userEvent.setup()
+      renderCard(FIRST_RELEASE)
+      await waitFor(() => {
+        expect(screen.getByText(/CI failed for aaa1111/)).toBeInTheDocument()
+      })
+      await user.click(
+        screen.getByRole('checkbox', { name: /Release anyway/i }),
+      )
+      // A different commit is a different decision.
+      await user.click(screen.getByText('fix: a bug'))
+      await waitFor(() => {
+        expect(
+          screen.getByRole('checkbox', { name: /Release anyway/i }),
+        ).not.toBeChecked()
+      })
+      expect(screen.getByRole('button', { name: /& release/i })).toBeDisabled()
+    })
+  })
+
+  it('stays silent when the CI status cannot be resolved', async () => {
+    // `unknown` covers a project with no CI and a token that cannot read
+    // check-runs; the API does not gate on it, so neither does the form.
+    vi.mocked(endpoints.getCommitCheckStatus).mockResolvedValue({
+      ci_status: 'unknown',
+      committish: 'aaa1111',
+    })
+    renderCard(FIRST_RELEASE)
+    await waitFor(() => {
+      expect(endpoints.getCommitCheckStatus).toHaveBeenCalled()
+    })
+    expect(screen.queryByText(/CI failed/)).not.toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: /& release/i }),
+    ).not.toBeDisabled()
   })
 })

--- a/ui/src/components/releases/ReleaseReadyCard.tsx
+++ b/ui/src/components/releases/ReleaseReadyCard.tsx
@@ -99,7 +99,11 @@ export function ReleaseReadyCard({
 
   // Live CI status for the commit being tagged; read before the early
   // return below because it's a hook.
-  const ciStatus = useCommitCheckStatus(orgSlug, projectId, selectedSha)
+  const { ciPending, ciStatus } = useCommitCheckStatus(
+    orgSlug,
+    projectId,
+    selectedSha,
+  )
   const ciFailed = ciNeedsAcknowledgement(ciStatus)
   const [ciAcknowledged, setCiAcknowledged] = useState(false)
   useEffect(() => {
@@ -130,6 +134,10 @@ export function ReleaseReadyCard({
     !!selectedSha &&
     !isPending &&
     !isDrafting &&
+    // Hold the button until CI has answered: an unresolved status cannot
+    // be told apart from a green one, and releasing on it skips the
+    // acknowledgement the server would then demand with a 409.
+    !ciPending &&
     !(ciFailed && !ciAcknowledged)
   const reset = () => {
     setSelectedSha(commits[0]?.sha ?? null)

--- a/ui/src/components/releases/ReleaseReadyCard.tsx
+++ b/ui/src/components/releases/ReleaseReadyCard.tsx
@@ -4,6 +4,11 @@ import { useMutation } from '@tanstack/react-query'
 import { Check, Loader2, RefreshCw, Rocket, Sparkles, Tag } from 'lucide-react'
 
 import { draftReleaseNotes } from '@/api/endpoints'
+import {
+  CiFailureNotice,
+  ciNeedsAcknowledgement,
+  useCommitCheckStatus,
+} from '@/components/deploy/CiFailureNotice'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
@@ -92,6 +97,15 @@ export function ReleaseReadyCard({
     projectId,
   })
 
+  // Live CI status for the commit being tagged; read before the early
+  // return below because it's a hook.
+  const ciStatus = useCommitCheckStatus(orgSlug, projectId, selectedSha)
+  const ciFailed = ciNeedsAcknowledgement(ciStatus)
+  const [ciAcknowledged, setCiAcknowledged] = useState(false)
+  useEffect(() => {
+    setCiAcknowledged(false)
+  }, [selectedSha])
+
   // Up to date — nothing new to cut.
   if (commits.length === 0) {
     return (
@@ -111,7 +125,12 @@ export function ReleaseReadyCard({
 
   const tagValid = SEMVER_RE.test(tag)
   const isDrafting = draftMutation.isPending
-  const canSubmit = tagValid && !!selectedSha && !isPending && !isDrafting
+  const canSubmit =
+    tagValid &&
+    !!selectedSha &&
+    !isPending &&
+    !isDrafting &&
+    !(ciFailed && !ciAcknowledged)
   const reset = () => {
     setSelectedSha(commits[0]?.sha ?? null)
     setTag(drift.suggested_tag)
@@ -119,10 +138,12 @@ export function ReleaseReadyCard({
     setTagDirty(false)
     setNotesDirty(false)
     setAiSuggestion(null)
+    setCiAcknowledged(false)
   }
   const submit = () => {
     if (!selectedSha) return
     cut({
+      acknowledge_ci_failure: ciAcknowledged,
       committish: selectedSha,
       release_name: tag,
       release_notes_markdown: notes,
@@ -163,6 +184,14 @@ export function ReleaseReadyCard({
             selectedSha={selectedSha}
           />
         </section>
+
+        <CiFailureNotice
+          acknowledged={ciAcknowledged}
+          action="release"
+          ciStatus={ciStatus}
+          onAcknowledgedChange={setCiAcknowledged}
+          sha={selectedSha}
+        />
 
         <section className="border-tertiary flex flex-col gap-2 border-t pt-4">
           <p className="text-tertiary text-xs tracking-wider uppercase">

--- a/ui/src/types/index.ts
+++ b/ui/src/types/index.ts
@@ -537,6 +537,18 @@ export type ClientCredentialCreate = Schemas['ClientCredentialCreate']
 
 export type ClientCredentialCreated = Schemas['ClientCredentialCreateResponse']
 
+/**
+ * Live rolled-up CI status for one commit, read straight from the
+ * deployment plugin. Deliberately not the synced `ci_status` carried on
+ * commit rows: this is the same call the promote gate makes, so a warning
+ * built on it cannot tell the operator a commit is green and then have the
+ * promote refused.
+ */
+export interface CommitCheckStatus {
+  ci_status: DeploymentCommitCiStatus
+  committish: string
+}
+
 export interface ConfigKeyResponse {
   data_type: string
   key: string
@@ -569,6 +581,12 @@ export interface CurrentReleaseEnvironment {
 }
 
 export interface CutReleaseRequest {
+  /**
+   * Operator acknowledgement that `committish` has a failing CI run.
+   * Without it the API refuses the cut with a 409; with it the release
+   * proceeds and the override is recorded.
+   */
+  acknowledge_ci_failure?: boolean
   committish: string
   prerelease?: boolean
   release_name?: null | string
@@ -628,6 +646,8 @@ export interface DeploymentCompareResult {
 }
 
 export interface DeploymentPromoteRequest {
+  /** See {@link CutReleaseRequest.acknowledge_ci_failure}. */
+  acknowledge_ci_failure?: boolean
   action: 'promote'
   from_committish: string
   from_environment: string
@@ -1262,6 +1282,14 @@ export interface ReleaseHistoryEntry {
   blocked_at?: null | string
   blocked_by?: null | string
   blocked_reason?: null | string
+  /**
+   * Set when an operator cut this release over a *failing* CI run and
+   * acknowledged it. `ci_status` below is the commit's state right now;
+   * these record what was known, and decided, at promote time — the two
+   * diverge once a re-run turns the commit green after the fact.
+   */
+  ci_override_at?: null | string
+  ci_override_by?: null | string
   ci_status: DeploymentCommitCiStatus
   notes_markdown?: null | string
   package_url?: null | string


### PR DESCRIPTION
## Summary
Surface a failing CI run in the promote and release forms and require an explicit acknowledgement before shipping, recording the override when an operator ships anyway.

## Problem
Operators could promote a commit whose CI had failed, or cut a library release from one, with no signal anywhere in the UI. The signal already existed — the deployment plugin's `get_check_status` aggregates `/commits/{sha}/check-runs` and degrades a scope-limited token to `unknown` rather than erroring — but neither the promote path nor `releases/cut` ever asked for it.

Two things make this narrower than it sounds:

- **The check has to be against the commit on the default branch, not the tag.** Tag-triggered workflow runs skip the test jobs, so "CI passed at the tag" is not a state that exists; gating on the tag would ask a question whose answer is always `unknown`.
- **`unknown` must not block.** It is what a project with no CI, a token without the check-runs scope, and a commit whose checks never ran all report. Treating it as a failure would refuse most promotes.

## Solution
Warn and confirm, not a hard block — shipping a red commit stays an operator decision, but a deliberate one that leaves a record.

- **New read endpoint** `GET /deployments/check-status?committish=…` — the live per-commit CI status behind the forms' warning. Answers `unknown` rather than erroring when check-runs cannot be read.
- **Server-side gate** on `promote` and `releases/cut`: `fail` is refused with a 409 unless the request carries `acknowledge_ci_failure`. The gate runs after the plugin is resolved but *before* the tag is cut and before the build is dispatched, so a refusal leaves nothing to clean up and a resubmit is a first attempt rather than a repair. There's a test pinning that ordering.
- **Only `fail` gates.** `warn` is a cancelled or stale run, not a failing build.
- **The override is recorded twice.** Stamped on the `Release` node at promote time, and folded into the `operations_log` row's description JSON as `ci_status` / `ci_override`. The node stamp is load-bearing on the dispatch path, where the audit row is only written by the watcher *after* a green build — an override whose release build then failed would otherwise leave no trace of the decision anywhere. `complete_promote_build` reads it back off the node rather than re-asking the plugin, whose answer can change in the intervening minutes.
- **Visible in release history** as a "CI overridden" badge plus a note naming who acknowledged it and when. Deliberately distinct from the row's existing `CiStatusDot`, which reports the commit's state *now* — a re-run can turn it green long after the fact, and the decision still stands.
- **Shared `CiFailureNotice`** (danger strip + acknowledgement checkbox) gates the submit button in all three forms: `PromoteTab`, `PendingPromoteCard`, and `ReleaseReadyCard`. It reads the *same* endpoint the gate uses, so the banner and the server cannot disagree — a warning sourced from the synced `ci_status` on commit rows could lag and tell the operator a commit is green over a promote the server then refuses.
- `PromoteRequest.acknowledgeCiFailure` is **required**, not optional-with-a-default. A form that renders the warning and enables its button off local state but forgets to forward the flag is now a type error instead of a 409 the operator sees having just ticked the box. That bug was found in dev testing and is what this guards.

## Impact
- **No behaviour change for green, warned, or unknown commits** — the same promotes and releases that worked before still work, with no extra confirmation. Only a `fail` status adds a step.
- **One extra plugin call per commit selection** in the three forms (`GET /check-status`, react-query cached per SHA). The promote/release request itself adds one `get_check_status` call. Both go through `call_with_timeout` and swallow errors to `unknown`, so a check-runs outage degrades to today's behaviour rather than blocking shipping.
- **New `Release` node properties** (`ci_status_at_promote`, `ci_override_by`, `ci_override_at`). Additive; releases written before this read as `('unknown', False)`, covered by a test.
- **`operations_log` description JSON gains two keys.** Additive — the ops-log UI reads that payload loosely (a targeted regex for `commit_sha`). Deploy and resync rows leave them at their defaults, since a deploy ships a commit an earlier promote already gated.
- **API-only enforcement is new**: a direct API caller that previously promoted a red commit now gets a 409 until it opts in. Intentional — that's the hole being closed — but worth knowing if anything scripts the promote endpoint.

## Testing
- `moon run api:test` — 2864 passed, coverage 85.12% (gate 85%). New `CiGateTestCase` / `DispatchCiGateTestCase` / `ReleaseCiOverrideTestCase` cover fail/warn/unknown/plugin-error, the acknowledged override, the side-effect-free refusal, both promote paths, `releases/cut`, the ops-log JSON, and the new endpoint.
- `npm run test` — 748 passed across 95 files. New `CiFailureNotice.test.tsx`, `PromoteTab.test.tsx`, `PendingPromoteCard.test.tsx`; `ReleaseReadyCard.test.tsx` extended.
- `moon run :lint :typecheck :format` and `moon run ui:build` clean.
- Manually exercised in an Okteto dev environment against a project with a deliberately broken build: confirmed the banner appears, the button is held until the box is checked, and an unacknowledged request is refused with a 409. That round is what surfaced the missing flag on `PendingPromoteCard`; the regression test added with the fix fails without it.

## Notes for the reviewer
- **`ui/src/types/api-generated.ts` is not regenerated.** `codegen:fetch` needs the API on :8000, and the served document goes through `create_custom_openapi` (`apps/api/src/imbi/api/openapi.py:259`), so an offline `app.openapi()` dump is not faithful — generating from one produced a 2460-line diff that deleted 1491 lines. Nothing here depends on that file: `CommitCheckStatus`, `ReleaseHistoryEntry`, `CutReleaseRequest`, and `DeploymentPromoteRequest` are all hand-written in `ui/src/types/index.ts`, and `tsc --noEmit` plus `ui:build` pass against the file unchanged. Worth a `npm run codegen:fetch` against a running API on top of this.
- The 409 detail is a plain string, matching `_assert_not_blocked`, so the existing `extractApiErrorDetail` toast reads well. That means a client cannot branch on it programmatically — fine here because the UI pre-checks, but a structured detail (like the `identity_required` 401) would be needed if we ever want a "retry with override" affordance driven off the error.
- The commit pickers' `CiStatusDot`s still come from the synced ClickHouse `ci_status` and can lag behind the live banner. Left alone deliberately; reconciling them is a separate change.

https://aweber.atlassian.net/browse/ENG-102
