### PR TITLE
Carry the deployment run URL through to the release train

### DIFF
--- a/apps/api/src/imbi/api/endpoints/releases.py
+++ b/apps/api/src/imbi/api/endpoints/releases.py
@@ -347,6 +347,68 @@ async def _gather_release_hydration(
     return list(run_results), ci_results
 
 
+async def _reconcile_in_flight_run(
+    db: graph.Graph,
+    *,
+    org_slug: str,
+    project_id: str,
+    release_id: str,
+    env_slug: str,
+    event: models.DeploymentEvent,
+    result: typing.Any,
+) -> models.DeploymentEvent | None:
+    """Fold one plugin run report into its stored ``DeploymentEvent``.
+
+    Returns the refreshed event when the report moves the status or
+    contributes a run URL the edge doesn't have, and ``None`` when it
+    tells us nothing new -- so a page load against an idle run costs no
+    writes.  The refreshed event is persisted too, so the edge
+    self-heals instead of being re-derived on every read; a persistence
+    failure is logged rather than raised, because the release train
+    must keep rendering.
+    """
+    new_status = _RUN_STATUS_TO_EVENT_STATUS.get(result.status)
+    # Prefer the run URL the plugin just resolved from the run id.
+    # The deploy/promote flow stores null there -- GitHub's
+    # ``Deployment`` has no human-facing URL until the workflow posts
+    # its first status -- so the stored value is the stale one, and
+    # reusing it is what left the field permanently null.
+    run_url = result.run_url or event.external_run_url
+    status_changed = new_status is not None and new_status != event.status
+    if not status_changed and run_url == event.external_run_url:
+        return None
+    update: dict[str, typing.Any] = {'external_run_url': run_url}
+    if status_changed:
+        update['status'] = new_status
+        update['timestamp'] = datetime.datetime.now(datetime.UTC)
+    new_event = event.model_copy(update=update)
+    if new_event.status in ('success', 'failed', 'in_progress'):
+        try:
+            await append_deployment_event(
+                db,
+                org_slug=org_slug,
+                project_id=project_id,
+                release_id=release_id,
+                env_slug=env_slug,
+                status=new_event.status,
+                # A URL-only refresh must not relabel an event the
+                # deploy flow wrote; only a status transition is this
+                # pass's own doing.
+                note='via release-train hydration'
+                if status_changed
+                else event.note,
+                external_run_id=event.external_run_id,
+                external_run_url=run_url,
+            )
+        except Exception:
+            LOGGER.exception(
+                'release-train hydration: failed to persist event for %s/%s',
+                project_id,
+                env_slug,
+            )
+    return new_event
+
+
 async def _hydrate_release_train(
     db: graph.Graph,
     org_slug: str,
@@ -363,12 +425,12 @@ async def _hydrate_release_train(
 ) -> dict[str, CheckStatus | None]:
     """Hydrate live deploy run + CI check-runs status per env.
 
-    Mutates ``by_env`` in place: when the plugin reports a terminal
-    status for an in-flight workflow run we update the in-memory event
-    so the response reflects the live state, and we append a fresh
-    ``DeploymentEvent`` to the edge so the system self-heals on
-    subsequent reads.  Returns a slug → ``CheckStatus`` map that the
-    caller folds into the response.
+    Mutates ``by_env`` in place: whatever
+    :func:`_reconcile_in_flight_run` learns about an in-flight run --
+    a newly terminal status, or the run URL that only exists once the
+    deploy workflow has posted a status -- replaces the in-memory event
+    so the response reflects the live state.  Returns a slug →
+    ``CheckStatus`` map that the caller folds into the response.
 
     Failures are tolerated silently — the release train must keep
     rendering even if the plugin can't be resolved or its calls hiccup.
@@ -423,37 +485,19 @@ async def _hydrate_release_train(
     ):
         if isinstance(result, BaseException):
             continue
-        new_status = _RUN_STATUS_TO_EVENT_STATUS.get(result.status)
-        if new_status is None or new_status == event.status:
-            continue
-        new_event = event.model_copy(
-            update={
-                'status': new_status,
-                'timestamp': datetime.datetime.now(datetime.UTC),
-            }
+        new_event = await _reconcile_in_flight_run(
+            db,
+            org_slug=org_slug,
+            project_id=project_id,
+            release_id=release_id,
+            env_slug=slug,
+            event=event,
+            result=result,
         )
+        if new_event is None:
+            continue
         env, release_raw, _ = by_env[slug]
         by_env[slug] = (env, release_raw, new_event)
-        if new_status in ('success', 'failed'):
-            try:
-                await append_deployment_event(
-                    db,
-                    org_slug=org_slug,
-                    project_id=project_id,
-                    release_id=release_id,
-                    env_slug=slug,
-                    status=new_status,
-                    note='via release-train hydration',
-                    external_run_id=event.external_run_id,
-                    external_run_url=event.external_run_url,
-                )
-            except Exception:
-                LOGGER.exception(
-                    'release-train hydration: failed to persist '
-                    'terminal event for %s/%s',
-                    project_id,
-                    slug,
-                )
 
     ci_status_by_slug: dict[str, CheckStatus | None] = {}
     for (slug, _committish), ci_result in zip(

--- a/apps/api/src/imbi/api/endpoints/releases.py
+++ b/apps/api/src/imbi/api/endpoints/releases.py
@@ -382,7 +382,7 @@ async def _reconcile_in_flight_run(
         update['status'] = new_status
         update['timestamp'] = datetime.datetime.now(datetime.UTC)
     new_event = event.model_copy(update=update)
-    if new_event.status in ('success', 'failed', 'in_progress'):
+    if new_event.status in ('success', 'failed', 'in_progress', 'pending'):
         try:
             await append_deployment_event(
                 db,
@@ -445,9 +445,17 @@ async def _hydrate_release_train(
         if not release_id or not committish:
             continue
         deployed.append((slug, committish))
+        # ``pending`` counts as in flight: the gateway maps GitHub's
+        # ``queued``/``pending`` deployment_status states to it, and
+        # that first delivery is exactly the one that arrives before
+        # the workflow knows its own run URL.  Polling only
+        # ``in_progress`` would strand those events with a null
+        # ``external_run_url`` forever -- the bug this pass exists to
+        # fix -- unless a later ``in_progress`` webhook happened to
+        # land.
         if (
             event is not None
-            and event.status == 'in_progress'
+            and event.status in ('in_progress', 'pending')
             and event.external_run_id
         ):
             in_flight.append((slug, release_id, committish, event))

--- a/apps/api/src/imbi/api/endpoints/releases.py
+++ b/apps/api/src/imbi/api/endpoints/releases.py
@@ -382,30 +382,36 @@ async def _reconcile_in_flight_run(
         update['status'] = new_status
         update['timestamp'] = datetime.datetime.now(datetime.UTC)
     new_event = event.model_copy(update=update)
-    if new_event.status in ('success', 'failed', 'in_progress', 'pending'):
-        try:
-            await append_deployment_event(
-                db,
-                org_slug=org_slug,
-                project_id=project_id,
-                release_id=release_id,
-                env_slug=env_slug,
-                status=new_event.status,
-                # A URL-only refresh must not relabel an event the
-                # deploy flow wrote; only a status transition is this
-                # pass's own doing.
-                note='via release-train hydration'
-                if status_changed
-                else event.note,
-                external_run_id=event.external_run_id,
-                external_run_url=run_url,
-            )
-        except Exception:
-            LOGGER.exception(
-                'release-train hydration: failed to persist event for %s/%s',
-                project_id,
-                env_slug,
-            )
+    # Every status reachable here is worth persisting, so there is no
+    # status filter: ``new_event.status`` is either a mapped
+    # ``_RUN_STATUS_TO_EVENT_STATUS`` value (pending/in_progress/
+    # success/failed) or -- when the plugin reported a status we don't
+    # map -- the event's own, which the in-flight selection has already
+    # narrowed to in_progress/pending.  ``rolled_back`` is the one
+    # ``DeploymentEvent`` status this pass can never produce.
+    try:
+        await append_deployment_event(
+            db,
+            org_slug=org_slug,
+            project_id=project_id,
+            release_id=release_id,
+            env_slug=env_slug,
+            status=new_event.status,
+            # A URL-only refresh must not relabel an event the
+            # deploy flow wrote; only a status transition is this
+            # pass's own doing.
+            note='via release-train hydration'
+            if status_changed
+            else event.note,
+            external_run_id=event.external_run_id,
+            external_run_url=run_url,
+        )
+    except Exception:
+        LOGGER.exception(
+            'release-train hydration: failed to persist event for %s/%s',
+            project_id,
+            env_slug,
+        )
     return new_event
 
 

--- a/apps/api/tests/endpoints/test_releases.py
+++ b/apps/api/tests/endpoints/test_releases.py
@@ -1795,6 +1795,156 @@ class CurrentReleasesHydrationTestCase(_ReleasesTestBase):
         run_mock.assert_awaited_once()
         ci_mock.assert_awaited_once()
 
+    def test_terminal_transition_adopts_plugin_run_url(self) -> None:
+        # The deploy flow stores a null external_run_url (GitHub has no
+        # human-facing URL for a Deployment at create time), so the
+        # hydration pass must adopt the URL the plugin just resolved
+        # rather than writing the stored null straight back.
+        run_mock = mock.AsyncMock(
+            return_value=mock.MagicMock(
+                status='success',
+                run_id='42',
+                run_url='https://gh/runs/42',
+            )
+        )
+        self._patch_plugin_resolution(
+            get_deployment_status=run_mock,
+            get_check_status=mock.AsyncMock(return_value='pass'),
+        )
+        self.mock_db.execute.side_effect = [
+            [{'id': PROJECT_ID}],
+            [
+                {
+                    'env': self._env('production', sort_order=30),
+                    'release': _release_row(tag='1.0.0', id='r1'),
+                    'deployments': self._events_with_run(
+                        '2026-04-20T10:00:00+00:00',
+                        'in_progress',
+                        run_id='42',
+                    ),
+                },
+            ],
+        ]
+        append_mock = mock.AsyncMock(return_value='no_release')
+        with (
+            mock.patch(
+                'imbi.common.graph.parse_agtype',
+                side_effect=lambda x: x,
+            ),
+            mock.patch(
+                'imbi.api.endpoints.releases.append_deployment_event',
+                new=append_mock,
+            ),
+        ):
+            response = self.client.get(self._url('/current'))
+        self.assertEqual(response.status_code, 200)
+        body = response.json()[0]
+        self.assertEqual(body['current_status'], 'success')
+        self.assertEqual(body['external_run_url'], 'https://gh/runs/42')
+        self.assertEqual(
+            append_mock.call_args.kwargs['external_run_url'],
+            'https://gh/runs/42',
+        )
+        self.assertEqual(
+            append_mock.call_args.kwargs['note'],
+            'via release-train hydration',
+        )
+
+    def test_run_url_backfilled_while_still_in_progress(self) -> None:
+        # A run URL can surface before the run finishes; persist it
+        # then instead of waiting for a terminal status, and leave the
+        # event's own note alone since nothing else about it changed.
+        run_mock = mock.AsyncMock(
+            return_value=mock.MagicMock(
+                status='in_progress',
+                run_id='42',
+                run_url='https://gh/runs/42',
+            )
+        )
+        self._patch_plugin_resolution(
+            get_deployment_status=run_mock,
+            get_check_status=mock.AsyncMock(return_value='pass'),
+        )
+        self.mock_db.execute.side_effect = [
+            [{'id': PROJECT_ID}],
+            [
+                {
+                    'env': self._env('production', sort_order=30),
+                    'release': _release_row(tag='1.0.0', id='r1'),
+                    'deployments': self._events_with_run(
+                        '2026-04-20T10:00:00+00:00',
+                        'in_progress',
+                        run_id='42',
+                    ),
+                },
+            ],
+        ]
+        append_mock = mock.AsyncMock(return_value='no_release')
+        with (
+            mock.patch(
+                'imbi.common.graph.parse_agtype',
+                side_effect=lambda x: x,
+            ),
+            mock.patch(
+                'imbi.api.endpoints.releases.append_deployment_event',
+                new=append_mock,
+            ),
+        ):
+            response = self.client.get(self._url('/current'))
+        self.assertEqual(response.status_code, 200)
+        body = response.json()[0]
+        self.assertEqual(body['current_status'], 'in_progress')
+        self.assertEqual(body['external_run_url'], 'https://gh/runs/42')
+        self.assertEqual(
+            append_mock.call_args.kwargs['external_run_url'],
+            'https://gh/runs/42',
+        )
+        self.assertEqual(append_mock.call_args.kwargs['status'], 'in_progress')
+        self.assertIsNone(append_mock.call_args.kwargs['note'])
+
+    def test_no_new_run_url_makes_no_write(self) -> None:
+        # Nothing changed: same status, and the plugin has no URL to
+        # add. The pass must not churn the edge on every page load.
+        run_mock = mock.AsyncMock(
+            return_value=mock.MagicMock(
+                status='in_progress',
+                run_id='42',
+                run_url=None,
+            )
+        )
+        self._patch_plugin_resolution(
+            get_deployment_status=run_mock,
+            get_check_status=mock.AsyncMock(return_value='pass'),
+        )
+        self.mock_db.execute.side_effect = [
+            [{'id': PROJECT_ID}],
+            [
+                {
+                    'env': self._env('production', sort_order=30),
+                    'release': _release_row(tag='1.0.0', id='r1'),
+                    'deployments': self._events_with_run(
+                        '2026-04-20T10:00:00+00:00',
+                        'in_progress',
+                        run_id='42',
+                    ),
+                },
+            ],
+        ]
+        append_mock = mock.AsyncMock(return_value='no_release')
+        with (
+            mock.patch(
+                'imbi.common.graph.parse_agtype',
+                side_effect=lambda x: x,
+            ),
+            mock.patch(
+                'imbi.api.endpoints.releases.append_deployment_event',
+                new=append_mock,
+            ),
+        ):
+            response = self.client.get(self._url('/current'))
+        self.assertEqual(response.status_code, 200)
+        append_mock.assert_not_awaited()
+
     def test_unknown_ci_status_returns_null(self) -> None:
         self._patch_plugin_resolution(
             get_check_status=mock.AsyncMock(return_value='unknown'),

--- a/apps/api/tests/endpoints/test_releases.py
+++ b/apps/api/tests/endpoints/test_releases.py
@@ -1902,6 +1902,113 @@ class CurrentReleasesHydrationTestCase(_ReleasesTestBase):
         self.assertEqual(append_mock.call_args.kwargs['status'], 'in_progress')
         self.assertIsNone(append_mock.call_args.kwargs['note'])
 
+    def test_queued_event_is_polled_and_run_url_persisted(self) -> None:
+        # The gateway maps GitHub's queued/pending deployment_status to
+        # a stored 'pending' event, and that first delivery is the one
+        # that carries no log_url.  Such an event must stay in the
+        # in-flight selection and persist the URL once the plugin
+        # resolves it, or external_run_url stays null forever.
+        run_mock = mock.AsyncMock(
+            return_value=mock.MagicMock(
+                status='queued',
+                run_id='42',
+                run_url='https://gh/runs/42',
+            )
+        )
+        self._patch_plugin_resolution(
+            get_deployment_status=run_mock,
+            get_check_status=mock.AsyncMock(return_value='pass'),
+        )
+        self.mock_db.execute.side_effect = [
+            [{'id': PROJECT_ID}],
+            [
+                {
+                    'env': self._env('production', sort_order=30),
+                    'release': _release_row(tag='1.0.0', id='r1'),
+                    'deployments': self._events_with_run(
+                        '2026-04-20T10:00:00+00:00',
+                        'pending',
+                        run_id='42',
+                    ),
+                },
+            ],
+        ]
+        append_mock = mock.AsyncMock(return_value='no_release')
+        with (
+            mock.patch(
+                'imbi.common.graph.parse_agtype',
+                side_effect=lambda x: x,
+            ),
+            mock.patch(
+                'imbi.api.endpoints.releases.append_deployment_event',
+                new=append_mock,
+            ),
+        ):
+            response = self.client.get(self._url('/current'))
+        self.assertEqual(response.status_code, 200)
+        run_mock.assert_awaited_once()
+        body = response.json()[0]
+        self.assertEqual(body['current_status'], 'pending')
+        self.assertEqual(body['external_run_url'], 'https://gh/runs/42')
+        self.assertEqual(append_mock.call_args.kwargs['status'], 'pending')
+        self.assertEqual(
+            append_mock.call_args.kwargs['external_run_url'],
+            'https://gh/runs/42',
+        )
+        # A URL-only refresh must not relabel the gateway's event.
+        self.assertIsNone(append_mock.call_args.kwargs['note'])
+
+    def test_queued_run_advancing_to_in_progress_persists(self) -> None:
+        # The follow-up poll of that same queued event: once the run
+        # actually starts, the status transition is persisted so the
+        # train stops showing "queued".
+        run_mock = mock.AsyncMock(
+            return_value=mock.MagicMock(
+                status='in_progress',
+                run_id='42',
+                run_url='https://gh/runs/42',
+            )
+        )
+        self._patch_plugin_resolution(
+            get_deployment_status=run_mock,
+            get_check_status=mock.AsyncMock(return_value='pass'),
+        )
+        self.mock_db.execute.side_effect = [
+            [{'id': PROJECT_ID}],
+            [
+                {
+                    'env': self._env('production', sort_order=30),
+                    'release': _release_row(tag='1.0.0', id='r1'),
+                    'deployments': self._events_with_run(
+                        '2026-04-20T10:00:00+00:00',
+                        'pending',
+                        run_id='42',
+                    ),
+                },
+            ],
+        ]
+        append_mock = mock.AsyncMock(return_value='no_release')
+        with (
+            mock.patch(
+                'imbi.common.graph.parse_agtype',
+                side_effect=lambda x: x,
+            ),
+            mock.patch(
+                'imbi.api.endpoints.releases.append_deployment_event',
+                new=append_mock,
+            ),
+        ):
+            response = self.client.get(self._url('/current'))
+        self.assertEqual(response.status_code, 200)
+        body = response.json()[0]
+        self.assertEqual(body['current_status'], 'in_progress')
+        self.assertEqual(body['external_run_url'], 'https://gh/runs/42')
+        self.assertEqual(append_mock.call_args.kwargs['status'], 'in_progress')
+        self.assertEqual(
+            append_mock.call_args.kwargs['note'],
+            'via release-train hydration',
+        )
+
     def test_no_new_run_url_makes_no_write(self) -> None:
         # Nothing changed: same status, and the plugin has no URL to
         # add. The pass must not churn the edge on every page load.

--- a/apps/gateway/src/imbi/gateway/actions.py
+++ b/apps/gateway/src/imbi/gateway/actions.py
@@ -288,6 +288,16 @@ class AddDeploymentEventConfig(pydantic.BaseModel):
     ``version_expression`` is optional; when present it narrows the
     lookup so that a single committish that ships under multiple tags
     is disambiguated.
+
+    ``external_run_id_selector`` is what makes a webhook status update
+    deduplicate onto the event the in-product deploy flow already
+    recorded (the API dedupes on that id) instead of appending an
+    anonymous second row. ``external_run_url_selector`` carries the
+    human-facing run URL, which only the webhook knows: GitHub's
+    ``Deployment`` object has no such URL at create time, so the
+    deploy flow stores ``None`` and the first ``deployment_status``
+    delivery -- whose ``log_url`` points at the Actions run -- is the
+    earliest moment it can be filled in.
     """
 
     environment_selector: json_pointer.JsonPointer
@@ -296,6 +306,7 @@ class AddDeploymentEventConfig(pydantic.BaseModel):
     version_expression: str | None = None
     note_selector: json_pointer.JsonPointer | None = None
     external_run_id_selector: json_pointer.JsonPointer | None = None
+    external_run_url_selector: json_pointer.JsonPointer | None = None
 
 
 class PublishReleaseConfig(pydantic.BaseModel):
@@ -595,6 +606,15 @@ async def add_deployment_event(
         event_body['external_run_id'] = str(
             action_config.external_run_id_selector.resolve(event)
         )
+    if action_config.external_run_url_selector is not None:
+        # Skipped when the pointer resolves to null/empty rather than
+        # sent as the literal ``"None"``: GitHub posts the first
+        # ``deployment_status`` of a rollout before the deploy workflow
+        # knows its own run URL, so ``log_url`` is legitimately absent
+        # on early deliveries and a later one fills it in.
+        run_url = action_config.external_run_url_selector.resolve(event, None)
+        if run_url:
+            event_body['external_run_url'] = str(run_url)
     async with ImbiClient() as client:
         releases = await client.list_releases(
             ctx.org_slug,

--- a/apps/gateway/tests/test_actions.py
+++ b/apps/gateway/tests/test_actions.py
@@ -262,6 +262,28 @@ def _deployment_event_config(
     return actions.AddDeploymentEventConfig.model_validate_json(raw)
 
 
+def _run_selector_config() -> actions.AddDeploymentEventConfig:
+    """A deployment-event config wired to both run selectors."""
+    return _deployment_event_config(
+        json.dumps(
+            {
+                'environment_selector': (
+                    '/payload/deployment_status/environment'
+                ),
+                'committish_expression': (
+                    'substring(payload.deployment.sha, 0, 7)'
+                ),
+                'version_expression': 'payload.deployment.ref',
+                'status_selector': '/payload/deployment_status/state',
+                'external_run_id_selector': '/payload/deployment/id',
+                'external_run_url_selector': (
+                    '/payload/deployment_status/log_url'
+                ),
+            }
+        )
+    )
+
+
 def _patch_list_releases(
     releases: list[dict[str, object]] | None = None,
 ) -> typing.Any:
@@ -1001,6 +1023,102 @@ class AddDeploymentEventTests(helpers.TestCase):
             'https://api.github.com/repos/o/r/deployments/42',
             event_body['note'],
         )
+
+    async def test_run_selectors_emit_run_id_and_url(self) -> None:
+        payload = {
+            **_STATUS_BODY,
+            'deployment': {**_STATUS_BODY['deployment'], 'id': 42},  # type: ignore[dict-item]
+            'deployment_status': {
+                'state': 'success',
+                'environment': 'production',
+                'log_url': 'https://gh/o/r/actions/runs/99',
+            },
+        }
+        with (
+            self.override_environment(ACTIONS_IMBI_TOKEN=_TOKEN),
+            _patch_list_releases(),
+            unittest.mock.patch.object(
+                actions.ImbiClient,
+                'record_deployment',
+                new_callable=unittest.mock.AsyncMock,
+                return_value=httpx.Response(200),
+            ) as mock_record,
+        ):
+            await actions.add_deployment_event(
+                ctx=_ctx(),
+                credentials={},
+                external_identifier='',
+                action_config=_run_selector_config(),
+                event=_event(payload),
+            )
+
+        event_body = mock_record.call_args.args[4]
+        self.assertEqual('42', event_body['external_run_id'])
+        self.assertEqual(
+            'https://gh/o/r/actions/runs/99', event_body['external_run_url']
+        )
+
+    async def test_absent_run_url_omits_the_key(self) -> None:
+        # GitHub posts the first deployment_status of a rollout before
+        # the workflow knows its own run URL; the key must be dropped
+        # rather than sent as the literal "None".
+        payload = {
+            **_STATUS_BODY,
+            'deployment': {**_STATUS_BODY['deployment'], 'id': 42},  # type: ignore[dict-item]
+            'deployment_status': {
+                'state': 'in_progress',
+                'environment': 'production',
+                'log_url': '',
+            },
+        }
+        with (
+            self.override_environment(ACTIONS_IMBI_TOKEN=_TOKEN),
+            _patch_list_releases(),
+            unittest.mock.patch.object(
+                actions.ImbiClient,
+                'record_deployment',
+                new_callable=unittest.mock.AsyncMock,
+                return_value=httpx.Response(200),
+            ) as mock_record,
+        ):
+            await actions.add_deployment_event(
+                ctx=_ctx(),
+                credentials={},
+                external_identifier='',
+                action_config=_run_selector_config(),
+                event=_event(payload),
+            )
+
+        event_body = mock_record.call_args.args[4]
+        self.assertNotIn('external_run_url', event_body)
+        self.assertEqual('42', event_body['external_run_id'])
+
+    async def test_missing_run_url_pointer_omits_the_key(self) -> None:
+        # The pointer resolving to nothing at all (no ``log_url`` key)
+        # must degrade the same way an empty one does, not raise.
+        payload = {
+            **_STATUS_BODY,
+            'deployment': {**_STATUS_BODY['deployment'], 'id': 42},  # type: ignore[dict-item]
+        }
+        with (
+            self.override_environment(ACTIONS_IMBI_TOKEN=_TOKEN),
+            _patch_list_releases(),
+            unittest.mock.patch.object(
+                actions.ImbiClient,
+                'record_deployment',
+                new_callable=unittest.mock.AsyncMock,
+                return_value=httpx.Response(200),
+            ) as mock_record,
+        ):
+            await actions.add_deployment_event(
+                ctx=_ctx(),
+                credentials={},
+                external_identifier='',
+                action_config=_run_selector_config(),
+                event=_event(payload),
+            )
+
+        self.assertNotIn('external_run_url', mock_record.call_args.args[4])
 
     async def test_failure_state_maps_to_failed(self) -> None:
         payload = {


### PR DESCRIPTION
## Summary
Fill in `external_run_url` on release deployment events so the release train can link to the CI/CD run that actually shipped a version. Adds an `external_run_url_selector` to the gateway's `add_deployment_event` action, and stops the release-train hydration pass from discarding the run URL the deployment plugin just resolved.

## Problem
For a project that deploys via the in-product promote flow and reports status back over GitHub webhooks, `external_run_url` is null on every deployment event, forever — `GET /releases/current` returns `"external_run_url": null` for every environment even after a clean, successful rollout.

Two independent gaps, neither of them in the GitHub plugin:

1. **The gateway has no way to send the field.** `AddDeploymentEventConfig` declared selectors for environment, committish, status, version, note and `external_run_id` — but not for the run URL — and `add_deployment_event` built its event body from only those. The API's `DeploymentEventInput` accepts `external_run_url`, so the value simply never left the gateway. `extra='forbid'` on that model means no rule config could work around it.

2. **The hydration pass threw the URL away.** `_hydrate_release_train` asks the plugin for live run status on in-flight events, then persisted `external_run_url=event.external_run_url` — the *stored* value — while discarding `result.run_url` from the `DeploymentRun` it had just fetched. Since the deploy/promote flow always stores null there (GitHub's `Deployment` object has no human-facing URL at create time; `trigger_deployment` documents this and returns `run_url=None`), that path could never populate the field. It also bailed out early whenever the status hadn't changed, which is exactly the window in which the run URL first appears.

The plugin side was never the problem: `get_deployment_status` already resolves the URL from a deployment id via `GET /deployments/{id}/statuses` → `log_url`, and the resync path already persists it.

## Solution
- Add `external_run_url_selector` to `AddDeploymentEventConfig` and thread it into the event body in `add_deployment_event`. Point it at `/payload/deployment_status/log_url`. The key is omitted rather than sent as the literal `"None"` when the pointer resolves to null, missing, or empty — GitHub posts the first `deployment_status` of a rollout before the deploy workflow knows its own run URL, so early deliveries legitimately carry no URL and a later one fills it in.
- Prefer `result.run_url` over the stored value in the hydration pass, and persist a URL-only refresh while the run is still in progress instead of waiting for a terminal status. A URL-only refresh keeps the event's existing note, since relabelling an event the deploy flow wrote isn't this pass's business.
- Extract the per-event reconciliation into `_reconcile_in_flight_run` to keep `_hydrate_release_train` under the complexity limit. It returns `None` when the plugin reports nothing new, so an idle in-flight run costs no writes on page load.

## Impact
- **Requires a config change to take effect on the gateway path.** The new selector is optional and defaults to `None`, so existing webhook rules are unaffected and keep behaving exactly as before. To get the URL flowing, a rule's `handler_config` needs `"external_run_url_selector": "/payload/deployment_status/log_url"`. Worth setting `"external_run_id_selector": "/payload/deployment/id"` at the same time — without it, webhook events append anonymous rows instead of deduplicating onto the event the promote flow already recorded.
- The hydration change stands on its own and needs no configuration: projects with no webhook rule now pick up the run URL from the plugin on the next read.
- Existing null URLs are not backfilled by this PR. `POST /projects/{id}/deployments/resync` already fills them in from the remote (dedup on `external_run_id` refreshes the stored event in place), so affected projects can be repaired without a migration.
- No API schema change — `DeploymentEventInput.external_run_url` already existed.

## Testing
- `pytest apps/api/tests/endpoints/test_releases.py apps/gateway/tests/test_actions.py` — 164 passed. Six new tests: gateway emits both run selectors / omits an empty `log_url` / omits a missing `log_url` pointer; hydration adopts the plugin's URL on a terminal transition, backfills it while still in progress without relabelling the note, and makes no write when the plugin reports nothing new.
- `moon run api:typecheck gateway:typecheck` — 0 errors.
- `uv run pre-commit run --files <changed>` — clean.
- Diagnosed against production: project `jkkYSVNznk9S1x8TGCqDE` release 4.3.1, whose staging/production events carry `external_run_id: "11109546"` with a null URL, while the corresponding GHE deployment's statuses both carry `log_url = https://aweber.ghe.com/apis/account-notifications/actions/runs/155800541`.
