### PR TITLE
Coerce attribute filter values to the attribute's declared type

### DIFF
--- a/apps/api/src/imbi/api/endpoints/projects.py
+++ b/apps/api/src/imbi/api/endpoints/projects.py
@@ -1520,6 +1520,51 @@ _FILTER_FIELD_RE = re.compile(r'^[A-Za-z_][A-Za-z0-9_]*$')
 _FILTER_OPS = frozenset({'eq', 'ne', 'in', 'not_in', 'exists', 'not_exists'})
 
 
+def _coerce_filter_value(
+    attribute: blueprint_attributes.FilterableAttribute,
+    raw_value: str,
+    raw_filter: str,
+) -> typing.Any:
+    """Coerce a filter value to the attribute's declared JSON type.
+
+    Filter values arrive as strings from the query parameter, but
+    boolean and numeric attributes are stored as their native agtype;
+    binding the raw string would compare ``'true'`` to ``true`` and
+    never match. Attributes without a boolean/integer/number type are
+    bound as strings, unchanged.
+
+    Raises:
+        fastapi.HTTPException: 400 when the value cannot represent the
+            attribute's type.
+    """
+    if attribute.type == 'boolean':
+        if raw_value in ('true', 'false'):
+            return raw_value == 'true'
+        raise fastapi.HTTPException(
+            status_code=400,
+            detail=(
+                f'Filter {raw_filter!r} requires a true/false value '
+                f'for boolean attribute {attribute.field!r}'
+            ),
+        )
+    if attribute.type in ('integer', 'number'):
+        try:
+            return int(raw_value)
+        except ValueError:
+            try:
+                return float(raw_value)
+            except ValueError:
+                raise fastapi.HTTPException(
+                    status_code=400,
+                    detail=(
+                        f'Filter {raw_filter!r} requires a numeric '
+                        f'value for {attribute.type} attribute '
+                        f'{attribute.field!r}'
+                    ),
+                ) from None
+    return raw_value
+
+
 def _build_attribute_filter(
     filters: list[str],
     whitelist: dict[str, blueprint_attributes.FilterableAttribute],
@@ -1533,9 +1578,11 @@ def _build_attribute_filter(
     set are excluded.
 
     Field names are validated against ``whitelist`` (and an identifier
-    pattern) before being interpolated; values are always bound as
-    query parameters. Raises ``HTTPException`` (400) on malformed
-    predicates, unknown operators, or non-filterable fields.
+    pattern) before being interpolated; values are coerced to the
+    attribute's declared type and always bound as query parameters.
+    Raises ``HTTPException`` (400) on malformed predicates, unknown
+    operators, non-filterable fields, or values that cannot represent
+    the attribute's type.
     """
     clauses: list[str] = []
     params: dict[str, typing.Any] = {}
@@ -1595,7 +1642,7 @@ def _build_attribute_filter(
         terms: list[str] = []
         for value_index, item in enumerate(values):
             key = f'f{index}_{value_index}'
-            params[key] = item
+            params[key] = _coerce_filter_value(whitelist[field], item, raw)
             terms.append(f'p.{field} {comparator} {{{key}}}')
         clauses.append(
             terms[0] if len(terms) == 1 else '(' + joiner.join(terms) + ')'

--- a/apps/api/src/imbi/api/endpoints/projects.py
+++ b/apps/api/src/imbi/api/endpoints/projects.py
@@ -5,9 +5,11 @@ belong to multiple project types.  See ADR-0006 for rationale.
 """
 
 import asyncio
+import contextlib
 import datetime
 import json
 import logging
+import math
 import re
 import typing
 
@@ -1548,20 +1550,33 @@ def _coerce_filter_value(
             ),
         )
     if attribute.type in ('integer', 'number'):
-        try:
+        # int() first so large integers don't round-trip through
+        # float and lose precision.
+        with contextlib.suppress(ValueError):
             return int(raw_value)
+        if attribute.type == 'integer':
+            raise fastapi.HTTPException(
+                status_code=400,
+                detail=(
+                    f'Filter {raw_filter!r} requires an integer '
+                    f'value for integer attribute {attribute.field!r}'
+                ),
+            )
+        try:
+            number = float(raw_value)
         except ValueError:
-            try:
-                return float(raw_value)
-            except ValueError:
-                raise fastapi.HTTPException(
-                    status_code=400,
-                    detail=(
-                        f'Filter {raw_filter!r} requires a numeric '
-                        f'value for {attribute.type} attribute '
-                        f'{attribute.field!r}'
-                    ),
-                ) from None
+            number = math.inf
+        # agtype has no NaN/Infinity literal, so non-finite values
+        # cannot be bound; reject them like unparseable input.
+        if not math.isfinite(number):
+            raise fastapi.HTTPException(
+                status_code=400,
+                detail=(
+                    f'Filter {raw_filter!r} requires a finite numeric '
+                    f'value for number attribute {attribute.field!r}'
+                ),
+            )
+        return number
     return raw_value
 
 

--- a/apps/api/tests/endpoints/test_projects.py
+++ b/apps/api/tests/endpoints/test_projects.py
@@ -1581,6 +1581,21 @@ class ProjectEndpointsTestCase(support.SharedAppTestCase):
         self.assertEqual(response.status_code, 400)
         self.assertIn('numeric', response.json()['detail'])
 
+    def test_filter_integer_fractional_value_rejected(self) -> None:
+        response = self._list_with_filter('filter=replica_count:eq:1.5')
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('integer', response.json()['detail'])
+
+    def test_filter_number_non_finite_values_rejected(self) -> None:
+        """agtype has no NaN/Infinity literal, so reject them."""
+        for value in ('nan', 'inf', '-inf', 'Infinity'):
+            with self.subTest(value=value):
+                response = self._list_with_filter(
+                    f'filter=coverage:eq:{value}'
+                )
+                self.assertEqual(response.status_code, 400)
+                self.assertIn('finite', response.json()['detail'])
+
     def test_filter_string_value_unchanged(self) -> None:
         """String attributes still bind the raw string."""
         response = self._list_with_filter('filter=framework:eq:FastAPI')

--- a/apps/api/tests/endpoints/test_projects.py
+++ b/apps/api/tests/endpoints/test_projects.py
@@ -1454,6 +1454,9 @@ class ProjectEndpointsTestCase(support.SharedAppTestCase):
                             'type': 'string',
                             'enum': ['FastAPI', 'http-service-lib'],
                         },
+                        'deprecated': {'type': 'boolean'},
+                        'coverage': {'type': 'number'},
+                        'replica_count': {'type': 'integer'},
                     },
                 }
             ),
@@ -1532,6 +1535,58 @@ class ProjectEndpointsTestCase(support.SharedAppTestCase):
         response = self._list_with_filter('filter=framework:ne')
         self.assertEqual(response.status_code, 400)
         self.assertIn('requires a value', response.json()['detail'])
+
+    def test_filter_boolean_value_bound_as_boolean(self) -> None:
+        """Boolean attributes bind ``true``/``false``, not strings."""
+        response = self._list_with_filter('filter=deprecated:eq:true')
+        self.assertEqual(response.status_code, 200)
+        params = self.mock_db.execute.call_args.args[1]
+        self.assertIs(params['f0_0'], True)
+
+        response = self._list_with_filter('filter=deprecated:ne:false')
+        self.assertEqual(response.status_code, 200)
+        params = self.mock_db.execute.call_args.args[1]
+        self.assertIs(params['f0_0'], False)
+
+    def test_filter_boolean_invalid_value_rejected(self) -> None:
+        response = self._list_with_filter('filter=deprecated:eq:maybe')
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('true/false', response.json()['detail'])
+
+    def test_filter_number_value_bound_as_number(self) -> None:
+        """Number attributes bind ints/floats, not strings."""
+        response = self._list_with_filter('filter=coverage:eq:97.5')
+        self.assertEqual(response.status_code, 200)
+        params = self.mock_db.execute.call_args.args[1]
+        self.assertEqual(params['f0_0'], 97.5)
+        self.assertIsInstance(params['f0_0'], float)
+
+        response = self._list_with_filter('filter=coverage:eq:100')
+        self.assertEqual(response.status_code, 200)
+        params = self.mock_db.execute.call_args.args[1]
+        self.assertEqual(params['f0_0'], 100)
+        self.assertIsInstance(params['f0_0'], int)
+
+    def test_filter_integer_in_values_coerced(self) -> None:
+        """Each value in an ``in`` list is coerced independently."""
+        response = self._list_with_filter('filter=replica_count:in:1,2,3')
+        self.assertEqual(response.status_code, 200)
+        params = self.mock_db.execute.call_args.args[1]
+        self.assertEqual(
+            [params['f0_0'], params['f0_1'], params['f0_2']], [1, 2, 3]
+        )
+
+    def test_filter_number_invalid_value_rejected(self) -> None:
+        response = self._list_with_filter('filter=coverage:eq:lots')
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('numeric', response.json()['detail'])
+
+    def test_filter_string_value_unchanged(self) -> None:
+        """String attributes still bind the raw string."""
+        response = self._list_with_filter('filter=framework:eq:FastAPI')
+        self.assertEqual(response.status_code, 200)
+        params = self.mock_db.execute.call_args.args[1]
+        self.assertEqual(params['f0_0'], 'FastAPI')
 
     # -- Lifecycle dispatch wiring ------------------------------------
 


### PR DESCRIPTION
## Problem

The `filter=field:op[:value]` parameter on the project listing endpoint binds every value as a string (`params[key] = item` in `_build_attribute_filter`). Values arrive as strings from the query string, but boolean and numeric blueprint attributes are stored as their native agtype in the graph — so a predicate like `enabled:eq:true` compares the string `'true'` to the boolean `true` and silently returns zero rows. The same applies to `ne`, `in`, and `not_in` on any boolean, integer, or number attribute. `exists`/`not_exists` and string-attribute predicates are unaffected.

## Solution

- Add `_coerce_filter_value`, which converts each filter value to the whitelisted attribute's declared JSON type before binding: `true`/`false` for boolean attributes, numeric parsing for integer/number attributes, passthrough for everything else.
- Values that cannot represent the attribute's type are rejected with a 400 and a detail message naming the filter and attribute, consistent with the grammar's existing validation errors. Specifically:
  - integer attributes accept only integral values (`1.5` is a 400, not a never-matching bind);
  - number attributes parse `int` first (no float precision loss on large values), then `float`, and reject non-finite values (`nan`/`inf`) — agtype has no NaN/Infinity literal, and psycopg would otherwise render them as `'Infinity'::float8` inside the dollar-quoted Cypher string.
- `_cypher_param` already serializes Python `bool`/`int`/`float` into correct Cypher literals, so no changes are needed on the binding side.

## Tests

Extends the attribute-filtering test blueprint with boolean, number, and integer properties and adds cases covering: boolean values bound as booleans (`eq`/`ne`), int vs float coercion, per-value coercion in `in` lists, 400s for non-boolean values, non-numeric values, fractional integer input, and non-finite number input, and strings remaining unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)