### PR TITLE
Treat a duplicate GitHub Release 422 as already-published

### DIFF
--- a/apps/api/src/imbi/api/endpoints/project_deployments.py
+++ b/apps/api/src/imbi/api/endpoints/project_deployments.py
@@ -738,15 +738,19 @@ def _is_already_exists_error(exc: BaseException) -> bool:
         return False
     if not isinstance(payload, dict):
         return False
-    if 'already exists' in str(payload.get('message') or '').lower():
+    body = typing.cast(dict[str, typing.Any], payload)
+    if 'already exists' in str(body.get('message') or '').lower():
         return True
-    errors = payload.get('errors')
+    errors = body.get('errors')
     if not isinstance(errors, list):
         return False
     return any(
-        isinstance(error, dict)
-        and str(error.get('code') or '').lower() == 'already_exists'
-        for error in errors
+        str(
+            typing.cast(dict[str, typing.Any], error).get('code') or ''
+        ).lower()
+        == 'already_exists'
+        for error in typing.cast(list[object], errors)
+        if isinstance(error, dict)
     )
 
 

--- a/apps/api/src/imbi/api/endpoints/project_deployments.py
+++ b/apps/api/src/imbi/api/endpoints/project_deployments.py
@@ -716,16 +716,38 @@ async def _load_env_flags(
 
 
 def _is_already_exists_error(exc: BaseException) -> bool:
-    """Return True when exc is a GitHub 422 'Reference already exists'."""
+    """Return True when exc is a GitHub 422 "already exists" rejection.
+
+    The remote states this two different ways.  ``POST /git/refs`` for a
+    tag that is already there answers with a bare
+    ``{"message": "Reference already exists"}``, but ``POST /releases``
+    for a tag that already carries one answers with the generic
+    ``{"message": "Validation Failed", "errors": [{"resource":
+    "Release", "code": "already_exists", "field": "tag_name"}]}`` -- so
+    the per-error codes have to be inspected as well, or a re-publish of
+    an already-ratified release reads as a hard failure instead of the
+    idempotent no-op it is.
+    """
     if not isinstance(exc, httpx.HTTPStatusError):
         return False
     if exc.response.status_code != 422:
         return False
     try:
-        msg = (exc.response.json().get('message') or '').lower()
-        return 'already exists' in msg
+        payload = exc.response.json()
     except Exception:  # noqa: BLE001
         return False
+    if not isinstance(payload, dict):
+        return False
+    if 'already exists' in str(payload.get('message') or '').lower():
+        return True
+    errors = payload.get('errors')
+    if not isinstance(errors, list):
+        return False
+    return any(
+        isinstance(error, dict)
+        and str(error.get('code') or '').lower() == 'already_exists'
+        for error in errors
+    )
 
 
 def _promote_warning(step: str, exc: BaseException) -> str:

--- a/apps/api/tests/endpoints/test_project_deployments.py
+++ b/apps/api/tests/endpoints/test_project_deployments.py
@@ -3514,6 +3514,61 @@ class ReleasePublishTestCase(ProjectDeploymentsTestCase):
         self.assertIsNone(data['warning'])
         self.assertEqual(len(seen['upsert']), 1)
 
+    def test_publish_is_idempotent_for_a_validation_failed_conflict(
+        self,
+    ) -> None:
+        # ``POST /releases`` does not report a duplicate tag the way
+        # ``POST /git/refs`` does: the top-level message is the generic
+        # "Validation Failed" and ``already_exists`` shows up only as an
+        # error code.  Both shapes are the same idempotent no-op.
+        class _AlreadyThere(_FakeDeploymentPlugin):
+            async def create_release(  # type: ignore[override]
+                self,
+                ctx,
+                credentials,
+                tag,
+                name,
+                body_markdown,
+                prerelease=False,
+            ):
+                raise httpx.HTTPStatusError(
+                    "Client error '422 Unprocessable Entity'",
+                    request=httpx.Request('POST', 'https://api.gh/releases'),
+                    response=httpx.Response(
+                        422,
+                        json={
+                            'message': 'Validation Failed',
+                            'errors': [
+                                {
+                                    'resource': 'Release',
+                                    'code': 'already_exists',
+                                    'field': 'tag_name',
+                                }
+                            ],
+                        },
+                    ),
+                )
+
+            async def get_release(  # type: ignore[override]
+                self, ctx, credentials, tag
+            ):
+                return RemoteRelease(
+                    tag=tag, html_url=f'https://gh/releases/{tag}'
+                )
+
+        self.mocks['resolve_capability'].return_value = _make_resolved(
+            _AlreadyThere
+        )
+        seen = self._patch_execute()
+        with testclient.TestClient(self.test_app) as client:
+            response = client.post(self._PUBLISH)
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertTrue(data['published'])
+        self.assertEqual(data['release_url'], 'https://gh/releases/v6.4.0')
+        self.assertIsNone(data['warning'])
+        self.assertEqual(len(seen['upsert']), 1)
+
     def test_publish_writes_an_operations_log_audit(self) -> None:
         self._patch_execute()
         with testclient.TestClient(self.test_app) as client:


### PR DESCRIPTION
## Summary
Fix `POST /deployments/releases/{tag}/publish` treating GitHub's "this tag already has a release" 422 as a hard failure, so promoting a release to a second environment no longer logs a traceback and records the release as unpublished.

## Problem
Observed in 2.25.0 when promoting a release from staging to production. The staging rollout's `deployment_status` webhook already published the GitHub Release for the tag; the production promote fires the same publish path again, and GitHub correctly refuses to create a second release for that tag.

`publish_release` documents itself as idempotent — "a release the remote already has is not an error" — but `_is_already_exists_error` only inspected the 422's top-level `message`. GitHub phrases the conflict two different ways:

```
POST /git/refs   →  {"message": "Reference already exists"}                       matched
POST /releases   →  {"message": "Validation Failed",
                     "errors": [{"resource": "Release",
                                 "code": "already_exists",
                                 "field": "tag_name"}]}                           missed
```

For releases, `already_exists` appears only in `errors[].code`, so the exception fell through to the failure branch:

- a `LOGGER.exception` traceback plus a client-facing `create_release failed` warning
- `published=False` in the response and in the operations-log audit, so a successfully-ratified release reads as not ratified
- the `get_release` recovery path was skipped (it is gated on `warnings` being empty), so the `Release` node's `github_release` link was never written on the re-publish

The existing idempotency test passed only because it fed the endpoint a `{"message": "Reference already exists"}` payload that `POST /releases` never actually sends.

## Solution
Broaden `_is_already_exists_error` to check `errors[].code == 'already_exists'` alongside the message, keeping the git-refs shape working for `create_tag`. The malformed/non-JSON body guards are preserved, and the payload is type-narrowed before it is indexed.

This restores the documented behavior for a duplicate release: a debug log instead of a traceback, no warning, `published=True`, and the `get_release` fallback running so the node gets its `github_release` link.

## Impact
- Promotes past the first environment stop logging spurious `create_release failed` tracebacks and stop returning a warning to the caller.
- `published` in both the publish response and the operations-log audit is now accurate for re-publishes; previously-affected releases will pick up their `github_release` link the next time publish runs for that tag.
- No API surface, schema, or migration changes. Behavior for genuine `create_release` failures (non-422, or a 422 that is not an already-exists) is unchanged — still logged and degraded to a warning.

## Testing
- Added `test_publish_is_idempotent_for_a_validation_failed_conflict`, which uses GitHub's real release-conflict payload. Confirmed it fails against the unfixed code (`published=False`, warning present) and passes with the fix.
- `apps/api/tests/endpoints/test_project_deployments.py`: 508 passed.
- `uv run pre-commit run --files <changed>`: ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
